### PR TITLE
[Config] Dotfile templates

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -16,3 +16,38 @@
 ## Learnings
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
+
+## 2026-04-07 — Issue #11: Dotfile Templates
+
+**Branch:** `squad/11-dotfile-templates`  
+**PR:** targets `dev`
+
+### What I shipped
+
+Created `config/dotfiles/` with:
+
+- `.gitconfig.template` — git defaults with `YOUR_NAME`/`YOUR_EMAIL` placeholders,
+  sensible `core`, `pull`, `push`, `merge`, `fetch`, `diff` settings, and common
+  aliases (`co`, `br`, `st`, `lg`, `undo`, `unstage`).
+- `.editorconfig` — universal editor config: 2-space indent, LF, UTF-8, final
+  newline; exceptions for Markdown (trailing whitespace), Makefiles (tabs),
+  PowerShell (4 spaces), Python (4 spaces).
+- `.npmrc.template` — `save-exact`, `fund=false`, `audit=false`, `loglevel=warn`,
+  commented auth token stubs with instructions.
+- `install.sh` — idempotent Bash installer with `--dry-run` support. Copies
+  `.gitconfig` and `.npmrc` (user-editable), symlinks `.editorconfig`.
+  Backs up existing `.gitconfig` before overwriting. Substitutes
+  `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` / `GIT_AUTHOR_SIGNING_KEY` via `sed`.
+- `README.md` — full documentation of each file, env vars, idempotency, and
+  how to add new dotfiles.
+
+### Key decisions
+
+- Copy `.gitconfig`/`.npmrc`, symlink `.editorconfig` — machine-specific vs shared
+- Use `sed` not `envsubst` (not universally available)
+- Back up existing `.gitconfig` rather than skipping (Codespaces may have stale auto-generated config)
+- No `.zshrc` here — that belongs to issue #8
+
+### Decision record
+
+`.squad/decisions/inbox/pluto-dotfiles.md`

--- a/.squad/decisions/pluto-dotfiles.md
+++ b/.squad/decisions/pluto-dotfiles.md
@@ -1,0 +1,63 @@
+# Decision: Dotfile Install Strategy (issue #11)
+
+**By:** Pluto (Config Engineer)
+**Date:** 2026-04-07
+**Issue:** #11 — [Config] Dotfile templates
+
+---
+
+## Decisions Made
+
+### 1. Copy templates, don't symlink (for .gitconfig and .npmrc)
+
+**Decision:** `.gitconfig.template` and `.npmrc.template` are **copied** to
+`$HOME` rather than symlinked, so users can edit them freely without touching
+the repo.
+
+**Why:** These files routinely contain machine-specific values (name, email,
+tokens). If symlinked, editing `$HOME/.gitconfig` would corrupt the repo template.
+
+**Trade-off:** Changes to the repo template won't auto-propagate to existing
+installs. Acceptable — the install script's idempotency check handles
+re-installs safely with backups.
+
+---
+
+### 2. Symlink .editorconfig (not copy)
+
+**Decision:** `.editorconfig` is **symlinked** to `$HOME/.editorconfig`.
+
+**Why:** Editor config is project-agnostic and not machine-specific. Symlinking
+means updates to the canonical template in the repo propagate to all projects
+automatically.
+
+---
+
+### 3. Placeholder substitution via sed, not envsubst
+
+**Decision:** Use `sed -i` to substitute `YOUR_NAME` / `YOUR_EMAIL` placeholders
+rather than `envsubst` or a templating engine.
+
+**Why:** `envsubst` is not available on all platforms (notably macOS without
+Homebrew). `sed` is universally available. The substitution is simple enough
+that a regex approach is readable and safe.
+
+---
+
+### 4. .gitconfig backup on overwrite (not skip)
+
+**Decision:** When `$HOME/.gitconfig` already exists and differs from the
+template, **back it up** (`.bak`) and overwrite it — rather than skipping.
+
+**Why:** In Codespaces/Dev Containers, an existing `.gitconfig` may have been
+auto-generated with wrong defaults. The template is the source of truth; the
+backup preserves the user's previous state for recovery.
+
+---
+
+### 5. No .zshrc in this issue
+
+**Decision:** This issue creates no `.zshrc` template.
+
+**Why:** Issue #8 (shell aliases/shortcuts) owns `.zshrc`. Mixing concerns
+would create a merge conflict risk and blur ownership.

--- a/config/dotfiles/.editorconfig
+++ b/config/dotfiles/.editorconfig
@@ -1,0 +1,43 @@
+# .editorconfig
+# https://editorconfig.org
+#
+# Applies across the whole dev-setup repo and to any project that symlinks
+# this file to $HOME/.editorconfig (done by install.sh).
+#
+# Rules are ordered from most-general to most-specific; later blocks
+# override earlier ones for matching file types.
+
+root = true
+
+# ── Sensible defaults for every file ────────────────────────────────────────
+[*]
+indent_style              = space
+indent_size               = 2
+end_of_line               = lf
+charset                   = utf-8
+trim_trailing_whitespace  = true
+insert_final_newline      = true
+
+# ── Markdown — trailing spaces are intentional (hard line-break) ─────────────
+[*.md]
+trim_trailing_whitespace  = false
+
+# ── Makefiles require real tabs ──────────────────────────────────────────────
+[Makefile]
+indent_style              = tab
+
+# ── Shell scripts — 2-space indent (same as default, explicit for clarity) ──
+[*.sh]
+indent_size               = 2
+
+# ── PowerShell — Microsoft convention is 4 spaces ───────────────────────────
+[*.ps1]
+indent_size               = 4
+
+# ── JSON / YAML — 2 spaces is the community norm ────────────────────────────
+[*.{json,yml,yaml}]
+indent_size               = 2
+
+# ── Python — PEP 8 mandates 4 spaces ────────────────────────────────────────
+[*.py]
+indent_size               = 4

--- a/config/dotfiles/.gitconfig.template
+++ b/config/dotfiles/.gitconfig.template
@@ -1,0 +1,71 @@
+# .gitconfig.template
+#
+# Copy to $HOME/.gitconfig (done by install.sh).
+# Placeholders like YOUR_NAME are substituted by install.sh when the
+# corresponding env vars (GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
+# GIT_AUTHOR_SIGNING_KEY) are set; otherwise leave them as-is and edit
+# $HOME/.gitconfig manually afterwards.
+#
+# See: config/dotfiles/README.md for details.
+
+[user]
+	name  = YOUR_NAME
+	email = YOUR_EMAIL
+	# Uncomment and set to your GPG/SSH signing key fingerprint when ready:
+	# signingkey = YOUR_SIGNING_KEY
+
+[core]
+	# Normalise line endings to LF on commit; don't touch on checkout.
+	# Safe for both Linux/macOS and Windows (WSL) development.
+	autocrlf = input
+
+	# Honour $EDITOR if the user has set one; fall back to vim.
+	editor = ${EDITOR:-vim}
+
+	# Faster status in large repos.
+	untrackedCache = true
+
+	# Improve performance of git status across filesystem boundaries.
+	fsmonitor = false
+
+[init]
+	defaultBranch = main
+
+[pull]
+	# Use merge (not rebase) on pull — explicit rebase should be a
+	# deliberate choice, not a surprise default.
+	rebase = false
+
+[push]
+	# Automatically set the remote tracking branch on first push
+	# (requires Git >= 2.37).
+	autoSetupRemote = true
+
+[merge]
+	# Always create a merge commit (no fast-forward) so history is explicit.
+	ff = false
+
+[fetch]
+	# Remove local references to deleted remote branches automatically.
+	prune = true
+
+[diff]
+	# Better word-level diffing for prose and code.
+	algorithm = histogram
+	colorMoved = default
+
+[color]
+	ui = auto
+
+[alias]
+	# Short-hands used by the whole squad
+	co  = checkout
+	br  = branch
+	st  = status -sb
+	lg  = log --oneline --graph --decorate --abbrev-commit \
+	          --format='%C(bold blue)%h%C(reset) %C(green)(%ar)%C(reset) %s %C(dim white)— %an%C(reset)%C(auto)%d%C(reset)'
+
+	# Convenience
+	undo   = reset --soft HEAD~1
+	unstage = restore --staged
+	aliases = config --get-regexp alias

--- a/config/dotfiles/.npmrc.template
+++ b/config/dotfiles/.npmrc.template
@@ -1,0 +1,36 @@
+# .npmrc.template
+#
+# Copy to $HOME/.npmrc (done by install.sh).
+# Edit $HOME/.npmrc directly for machine-specific overrides.
+#
+# See: config/dotfiles/README.md for details.
+
+# ── Version pinning ──────────────────────────────────────────────────────────
+# Pin exact versions in package.json on every `npm install --save`.
+# Prevents unintended upgrades across machines and keeps lock-files stable.
+save-exact=true
+
+# ── Noise reduction ─────────────────────────────────────────────────────────
+# Suppress "funding" messages that appear after installs.
+fund=false
+
+# Suppress automatic security audit on every install.
+# Run `npm audit` deliberately instead of on every install.
+audit=false
+
+# Reduce log verbosity to warnings and errors only.
+loglevel=warn
+
+# ── Registry auth (optional) ─────────────────────────────────────────────────
+# Uncomment and set NPM_TOKEN in your shell profile (e.g. ~/.zshrc.local)
+# to authenticate with the public npm registry.
+# Never commit a real token — use an environment variable.
+#
+# //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+
+# ── Private registry (optional) ──────────────────────────────────────────────
+# If you use a private registry (e.g. GitHub Packages, Artifactory), add it
+# here. Use an env var for the token.
+#
+# @my-org:registry=https://npm.pkg.github.com
+# //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/config/dotfiles/README.md
+++ b/config/dotfiles/README.md
@@ -1,0 +1,171 @@
+# Dotfile Templates
+
+Managed by **Pluto** (Config Engineer). These templates give every Dev Container
+and Codespace a sensible, consistent environment right out of the box — no
+manual config required on day one.
+
+---
+
+## Files
+
+| File | Destination | Method | Notes |
+|------|-------------|--------|-------|
+| `.gitconfig.template` | `$HOME/.gitconfig` | Copy | Editable per-machine |
+| `.editorconfig` | `$HOME/.editorconfig` | Symlink | Shared, not machine-specific |
+| `.npmrc.template` | `$HOME/.npmrc` | Copy | Editable per-machine |
+| `install.sh` | — | Script | Idempotent installer |
+
+---
+
+## Quick Start
+
+```bash
+# From the repo root:
+bash config/dotfiles/install.sh
+
+# Preview what would happen without changing anything:
+bash config/dotfiles/install.sh --dry-run
+```
+
+---
+
+## Customisation
+
+### `.gitconfig`
+
+After running `install.sh`, a copy lives at `$HOME/.gitconfig`.  
+Edit it directly for machine-specific values.
+
+**Env-var substitution at install time:**
+
+Set these before running `install.sh` and the script will fill them in
+automatically:
+
+| Env var | Replaces | Example |
+|---------|----------|---------|
+| `GIT_AUTHOR_NAME` | `YOUR_NAME` | `Earl Tankard` |
+| `GIT_AUTHOR_EMAIL` | `YOUR_EMAIL` | `earl@example.com` |
+| `GIT_AUTHOR_SIGNING_KEY` | `YOUR_SIGNING_KEY` | `ABC123DEF456` |
+
+```bash
+export GIT_AUTHOR_NAME="Your Name"
+export GIT_AUTHOR_EMAIL="you@example.com"
+bash config/dotfiles/install.sh
+```
+
+If the env vars are not set, the placeholders (`YOUR_NAME`, `YOUR_EMAIL`)
+remain in `$HOME/.gitconfig` — just edit the file manually.
+
+**Included defaults (and why):**
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `core.autocrlf` | `input` | Normalise line endings to LF on commit; safe cross-platform |
+| `core.editor` | `${EDITOR:-vim}` | Honour user preference; fall back to vim |
+| `pull.rebase` | `false` | Merge on pull is a safe, explicit default |
+| `init.defaultBranch` | `main` | Modern default; avoids `master` |
+| `push.autoSetupRemote` | `true` | Skip manual `-u origin <branch>` on first push (Git ≥ 2.37) |
+| `merge.ff` | `false` | Always create a merge commit for clear history |
+| `fetch.prune` | `true` | Keep local refs clean when remote branches are deleted |
+| `diff.algorithm` | `histogram` | Better diff quality for code and prose |
+
+**Aliases:**
+
+| Alias | Expands to |
+|-------|-----------|
+| `git co` | `git checkout` |
+| `git br` | `git branch` |
+| `git st` | `git status -sb` |
+| `git lg` | Pretty one-line graph log |
+| `git undo` | `git reset --soft HEAD~1` |
+| `git unstage` | `git restore --staged` |
+
+---
+
+### `.editorconfig`
+
+This file is **symlinked** to `$HOME/.editorconfig`, so updates to the repo
+template propagate automatically (unlike the copied dotfiles).
+
+Most editors pick up `$HOME/.editorconfig` as a global fallback when no
+project-level `.editorconfig` is found. The file is also checked into the
+repo root, so it applies to this project directly.
+
+**Key rules:**
+
+| Pattern | indent_style | indent_size | Notes |
+|---------|-------------|-------------|-------|
+| `[*]` | space | 2 | Baseline for everything |
+| `[*.md]` | space | 2 | `trim_trailing_whitespace = false` (Markdown hard breaks) |
+| `[Makefile]` | **tab** | — | `make` requires real tabs |
+| `[*.sh]` | space | 2 | Explicit (matches baseline) |
+| `[*.ps1]` | space | **4** | Microsoft PowerShell convention |
+| `[*.py]` | space | **4** | PEP 8 |
+
+---
+
+### `.npmrc`
+
+After running `install.sh`, a copy lives at `$HOME/.npmrc`.  
+Edit it directly for machine-specific settings.
+
+**Included defaults (and why):**
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `save-exact` | `true` | Pin exact versions; prevents silent upgrades across machines |
+| `fund` | `false` | Suppress funding nags on install |
+| `audit` | `false` | Run `npm audit` deliberately rather than on every install |
+| `loglevel` | `warn` | Keep install output readable |
+
+**Optional: registry auth**
+
+Uncomment and set env vars in your shell profile (e.g. `~/.zshrc.local`):
+
+```bash
+# Public npm registry (personal token)
+export NPM_TOKEN="npm_..."
+
+# GitHub Packages (private org packages)
+export GITHUB_TOKEN="ghp_..."
+```
+
+Then uncomment the relevant lines in `$HOME/.npmrc`.  
+**Never hardcode tokens in any file.**
+
+---
+
+## How Idempotency Works
+
+`install.sh` is safe to run multiple times:
+
+- **Symlinks:** If `$HOME/.editorconfig` already points to the correct target,
+  the script prints `→ Already installed: .editorconfig` and skips it.
+  If the symlink points somewhere else, it is replaced.
+
+- **Copied files:** If `$HOME/.gitconfig` already exists and matches the
+  template exactly, the script skips it. If the file exists but differs
+  (e.g. you've edited it), the existing file is backed up to
+  `$HOME/.gitconfig.bak` before the template is copied.
+
+- **Backups:** A `.bak` file is only created once per run — subsequent runs
+  see the template file in place and skip.
+
+---
+
+## Dry Run
+
+Pass `--dry-run` to preview all actions without making any changes:
+
+```bash
+bash config/dotfiles/install.sh --dry-run
+```
+
+---
+
+## Adding New Dotfiles
+
+1. Add the template file to `config/dotfiles/` (use `.template` suffix for
+   files that users typically customise per-machine).
+2. Add an `install_copy` or `install_symlink` call in `install.sh`.
+3. Document it in this README.

--- a/config/dotfiles/install.sh
+++ b/config/dotfiles/install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# config/dotfiles/install.sh
+#
+# Idempotent dotfile installer.
+# - Copies .gitconfig.template  → $HOME/.gitconfig  (with backup if needed)
+# - Copies .npmrc.template      → $HOME/.npmrc
+# - Symlinks .editorconfig      → $HOME/.editorconfig
+#
+# Usage:
+#   ./config/dotfiles/install.sh            # install for real
+#   ./config/dotfiles/install.sh --dry-run  # show what would happen
+#
+# Env vars honoured at install time (substituted into .gitconfig):
+#   GIT_AUTHOR_NAME        → replaces YOUR_NAME
+#   GIT_AUTHOR_EMAIL       → replaces YOUR_EMAIL
+#   GIT_AUTHOR_SIGNING_KEY → replaces YOUR_SIGNING_KEY (and uncomments the line)
+
+set -euo pipefail
+
+# ── Resolve the directory containing this script ────────────────────────────
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Colour helpers ───────────────────────────────────────────────────────────
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+ok()   { printf "${GREEN}✓ %s${RESET}\n" "$*"; }
+skip() { printf "${CYAN}→ Already installed: %s${RESET}\n" "$*"; }
+info() { printf "${YELLOW}  %s${RESET}\n" "$*"; }
+dry()  { printf "${YELLOW}[dry-run] %s${RESET}\n" "$*"; }
+
+# ── Parse flags ──────────────────────────────────────────────────────────────
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *) printf "Unknown argument: %s\n" "$arg" >&2; exit 1 ;;
+  esac
+done
+
+# ── Helper: copy a template file, skipping if destination already matches ───
+# Usage: install_copy <src> <dest> [<label>]
+install_copy() {
+  local src="$1"
+  local dest="$2"
+  local label="${3:-$(basename "$dest")}"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    if [[ -f "$dest" ]]; then
+      dry "Would back up existing $dest → ${dest}.bak and overwrite with $src"
+    else
+      dry "Would copy $src → $dest"
+    fi
+    return
+  fi
+
+  if [[ -f "$dest" ]]; then
+    # Only back up if the destination is not already this template
+    if ! diff -q "$src" "$dest" > /dev/null 2>&1; then
+      cp "$dest" "${dest}.bak"
+      info "Backed up existing $dest → ${dest}.bak"
+      cp "$src" "$dest"
+      ok "Installed $label"
+    else
+      skip "$label"
+    fi
+  else
+    cp "$src" "$dest"
+    ok "Installed $label"
+  fi
+}
+
+# ── Helper: create a symlink, skipping if it already points to the right file
+# Usage: install_symlink <target> <link_path> [<label>]
+install_symlink() {
+  local target="$1"
+  local link="$2"
+  local label="${3:-$(basename "$link")}"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    if [[ -L "$link" ]] && [[ "$(readlink "$link")" == "$target" ]]; then
+      dry "Symlink already correct: $link → $target"
+    else
+      dry "Would create symlink: $link → $target"
+    fi
+    return
+  fi
+
+  if [[ -L "$link" ]]; then
+    if [[ "$(readlink "$link")" == "$target" ]]; then
+      skip "$label"
+      return
+    fi
+    # Symlink exists but points somewhere else — replace it
+    rm "$link"
+  elif [[ -e "$link" ]]; then
+    # Regular file in the way — back it up
+    cp "$link" "${link}.bak"
+    info "Backed up existing $link → ${link}.bak"
+    rm "$link"
+  fi
+
+  ln -s "$target" "$link"
+  ok "Linked $label"
+}
+
+# ── Substitute placeholders in $HOME/.gitconfig ─────────────────────────────
+substitute_gitconfig() {
+  local gitconfig="$HOME/.gitconfig"
+  [[ -f "$gitconfig" ]] || return
+
+  local changed=false
+
+  if [[ -n "${GIT_AUTHOR_NAME:-}" ]]; then
+    sed -i "s/YOUR_NAME/${GIT_AUTHOR_NAME}/g" "$gitconfig"
+    changed=true
+  fi
+
+  if [[ -n "${GIT_AUTHOR_EMAIL:-}" ]]; then
+    sed -i "s/YOUR_EMAIL/${GIT_AUTHOR_EMAIL}/g" "$gitconfig"
+    changed=true
+  fi
+
+  if [[ -n "${GIT_AUTHOR_SIGNING_KEY:-}" ]]; then
+    # Replace placeholder and uncomment the signingkey line in one pass
+    sed -i \
+      -e "s/YOUR_SIGNING_KEY/${GIT_AUTHOR_SIGNING_KEY}/g" \
+      -e "s/^[[:space:]]*#[[:space:]]*\(signingkey = \)/\t\1/" \
+      "$gitconfig"
+    changed=true
+  fi
+
+  if [[ "$changed" == true ]]; then
+    info "Substituted env vars into $gitconfig"
+  fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+printf "\n${CYAN}Installing dotfiles from %s${RESET}\n\n" "$DOTFILES_DIR"
+
+# .gitconfig — copy so users can edit without touching the repo template
+install_copy \
+  "$DOTFILES_DIR/.gitconfig.template" \
+  "$HOME/.gitconfig" \
+  ".gitconfig"
+
+# Substitute env var placeholders after copying (no-op if vars unset)
+if [[ "$DRY_RUN" == false ]]; then
+  substitute_gitconfig
+fi
+
+# .npmrc — copy for the same reason
+install_copy \
+  "$DOTFILES_DIR/.npmrc.template" \
+  "$HOME/.npmrc" \
+  ".npmrc"
+
+# .editorconfig — symlink because users rarely need machine-specific overrides
+install_symlink \
+  "$DOTFILES_DIR/.editorconfig" \
+  "$HOME/.editorconfig" \
+  ".editorconfig"
+
+printf "\n${GREEN}Done.${RESET}\n\n"


### PR DESCRIPTION
## Summary

Closes #11

Adds idempotent dotfile templates and an install script for `.gitconfig`, `.editorconfig`, and `.npmrc`.

## Files added

```
config/dotfiles/
├── .gitconfig.template   # Git defaults + aliases; placeholders for name/email
├── .editorconfig         # Universal editor config (symlinked to $HOME)
├── .npmrc.template       # npm defaults (save-exact, no fund/audit noise)
├── install.sh            # Idempotent installer with --dry-run support
└── README.md             # Full documentation
```

## Acceptance criteria

- [x] Template files exist for .gitconfig, .editorconfig, .npmrc
- [x] No hardcoded user-specific values — uses `YOUR_NAME`/`YOUR_EMAIL` placeholders, substituted from `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` env vars at install time
- [x] Symlink script links templates to $HOME (copy for .gitconfig/.npmrc, symlink for .editorconfig)
- [x] Documentation explains how to customise (README.md)

## Key design choices

- **Copy vs symlink:** `.gitconfig` and `.npmrc` are copied (users edit per-machine); `.editorconfig` is symlinked (no machine-specific values, auto-propagates)
- **Idempotency:** second run prints Already installed and skips; existing `.gitconfig` backed up to `.bak` before overwrite
- **sed not envsubst:** envsubst not available on all platforms; sed is universal
- Decision record: `.squad/decisions/pluto-dotfiles.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
