### PR TITLE
fix(ci): resolve PSScriptAnalyzer violations (#28)

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -1,10 +1,10 @@
-# scripts/windows/setup.ps1 — Core Windows installer
+# scripts/windows/setup.ps1 - Core Windows installer
 #
 # Called by: setup.ps1 (root entry point)
 # Owner:     Goofy (#2)
 #
 # Installs developer tools on Windows using winget as the primary package manager.
-# Each install function is idempotent — safe to run multiple times.
+# Each install function is idempotent - safe to run multiple times.
 # Requires: Windows 10 1709+ with App Installer (winget) available.
 #
 # Usage (direct):
@@ -13,10 +13,10 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Write-Info  { param([string]$Msg) Write-Host "[INFO]  $Msg" -ForegroundColor Cyan }
-function Write-Ok    { param([string]$Msg) Write-Host "[OK]    $Msg" -ForegroundColor Green }
-function Write-Warn  { param([string]$Msg) Write-Host "[WARN]  $Msg" -ForegroundColor Yellow }
-function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red }
+function Write-Info  { param([string]$Msg) Write-Output "[INFO]  $Msg" }
+function Write-Ok    { param([string]$Msg) Write-Output "[OK]    $Msg" }
+function Write-Warn  { param([string]$Msg) Write-Output "[WARN]  $Msg" }
+function Write-Err   { param([string]$Msg) Write-Output "[ERROR] $Msg" }
 
 function Test-WingetAvailable {
     return $null -ne (Get-Command winget -ErrorAction SilentlyContinue)
@@ -76,7 +76,7 @@ function Install-CopilotCli {
             return
         }
     } catch {
-        Write-Warn "gh CLI not authenticated or not found — skipping Copilot CLI install"
+        Write-Warn "gh CLI not authenticated or not found - skipping Copilot CLI install"
         Write-Warn "Run 'gh auth login' then re-run this script to install Copilot CLI"
         return
     }

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,4 +1,4 @@
-# setup.ps1 — Entry point for dev-setup on Windows (PowerShell)
+# setup.ps1 - Entry point for dev-setup on Windows (PowerShell)
 #
 # This script detects the Windows environment and routes to the correct
 # platform-specific installer. It does NOT install any tools itself.
@@ -14,16 +14,16 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# ── Logging helpers ───────────────────────────────────────────────────────────
+# -- Logging helpers -----------------------------------------------------------
 
-function Write-Info  { param([string]$Msg) Write-Host "[INFO]  $Msg" -ForegroundColor Cyan }
-function Write-Ok    { param([string]$Msg) Write-Host "[OK]    $Msg" -ForegroundColor Green }
-function Write-Warn  { param([string]$Msg) Write-Host "[WARN]  $Msg" -ForegroundColor Yellow }
-function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red }
+function Write-Info  { param([string]$Msg) Write-Output "[INFO]  $Msg" }
+function Write-Ok    { param([string]$Msg) Write-Output "[OK]    $Msg" }
+function Write-Warn  { param([string]$Msg) Write-Output "[WARN]  $Msg" }
+function Write-Err   { param([string]$Msg) Write-Output "[ERROR] $Msg" }
 
-# ── OS Detection ─────────────────────────────────────────────────────────────
+# -- OS Detection -------------------------------------------------------------
 
-function Detect-Platform {
+function Get-Platform {
   if ($IsLinux -or $IsMacOS) {
     # Unlikely to be reached via PowerShell on Linux/macOS in most setups,
     # but handle gracefully if pwsh is installed there.
@@ -45,13 +45,13 @@ function Detect-Platform {
   return 'unknown'
 }
 
-# ── Routing ───────────────────────────────────────────────────────────────────
+# -- Routing -------------------------------------------------------------------
 
 function Main {
   $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-  $platform  = Detect-Platform
+  $platform  = Get-Platform
 
-  Write-Info "dev-setup — entry point (PowerShell)"
+  Write-Info "dev-setup - entry point (PowerShell)"
   Write-Info "Detected platform: $platform"
 
   switch ($platform) {


### PR DESCRIPTION
## Summary

Fixes all PSScriptAnalyzer violations flagged in issue #28 for `setup.ps1` and `scripts/windows/setup.ps1`.

## Violations Fixed

### PSAvoidUsingWriteHost (both files)
- Replaced all `Write-Host "..." -ForegroundColor Color` calls with `Write-Output "..."` in the four logging helper functions (`Write-Info`, `Write-Ok`, `Write-Warn`, `Write-Err`)

### PSUseApprovedVerbs (setup.ps1)
- Renamed `Detect-Platform` → `Get-Platform` (`Detect` is not an approved PowerShell verb)
- Updated the call site in `Main` accordingly

### PSUseBOMForUnicodeEncodedFile (both files)
- Replaced Unicode box-drawing characters (`──`, `─`) with ASCII hyphens (`-`)
- Replaced Unicode em-dash (`—`) with ASCII hyphen (`-`)
- Files are now pure ASCII, so no BOM is required

## Verification
Both files now pass `Invoke-ScriptAnalyzer -Path ... -EnableExit` with exit code 0.

Closes #28