### PR TITLE
fix(dotfiles): correct create_tmux() — named session check, remove dead var (#38)

### DIFF
--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -107,12 +107,11 @@ alias nrt='npm run test'
 
 # Create or attach to the tank_dev tmux session
 create_tmux() {
-  pidof tmux 1>/dev/null
-  tmux_exists=$?
-  session_name="tankSession"
-  if [[ $tmux_exists -ne 0 ]]; then
-    tt && ta
+  local session="tank_dev"
+  if ! tmux has-session -t "$session" 2>/dev/null; then
+    tmux new-session -d -s "$session"
   fi
+  tmux attach -t "$session"
 }
 
 # Run on shell startup — launch tmux session


### PR DESCRIPTION
## Summary

Fixes #38

Three bugs fixed in `create_tmux()`:
1. **Dead variable** `session_name="tankSession"` removed — session name now a `local` variable
2. **Coarse detection** `pidof tmux` → `tmux has-session -t tank_dev` (checks the named session, not just any tmux process)
3. **Redundant commands** `tt && ta` → `tmux new-session -d` (detached) then `tmux attach -t`

## Files changed
- `config/dotfiles/.aliases`

/cc @primetimetank21