### PR TITLE
fix(windows): Remove-CustomItem silent data loss — accept string[] param (#37)

### DIFF
--- a/examples/Microsoft.PowerShell_profile-example.ps1
+++ b/examples/Microsoft.PowerShell_profile-example.ps1
@@ -1,6 +1,6 @@
 ### Linux Commands ###
 
-function remove-custom { param([string]$path); Remove-Item -Path $path -Recurse -Force }
+function remove-custom { param([string[]]$path); Remove-Item -Path $path -Recurse -Force }
 Remove-Item -Force Alias:\rm
 Set-Alias -Name rm -Value remove-custom
 

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -99,7 +99,7 @@ function Write-PowerShellProfile {
 # -- Linux-compatible commands --------------------------------------------------
 
 function Remove-CustomItem {
-    param([string]$Path)
+    param([string[]]$Path)
     Remove-Item -Path $Path -Recurse -Force
 }
 Remove-Item -Force Alias:\rm -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

Fixes #37

Changes `[string]$Path` → `[string[]]$Path` in `Remove-CustomItem` so that calling `rm file1 file2` passes all arguments instead of silently dropping extras.

## Files changed
- `scripts/windows/setup.ps1` — param type in here-string
- `examples/Microsoft.PowerShell_profile-example.ps1` — kept in sync

## Testing
PSScriptAnalyzer lint passes. `Remove-Item -Path` already accepts `string[]`.

/cc @primetimetank21