### PR TITLE
feat(devcontainer): set git identity from env vars on postCreate (#46)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -111,3 +111,16 @@ mcr.microsoft.com/devcontainers/base:ubuntu
 ```
 
 Microsoft's official Ubuntu-based devcontainer base image. Includes common developer tools (curl, wget, git, etc.) and the devcontainer toolchain. See the [image definition](https://github.com/devcontainers/images/tree/main/src/base-ubuntu) for full details.
+
+---
+
+## Required Codespace Secrets
+
+Set these in GitHub → Settings → Codespaces → Secrets:
+
+| Secret | Description | Default |
+|--------|-------------|---------|
+| `GIT_AUTHOR_NAME` | Your full name for git commits | `Earl Tankard, Jr., Ph.D.` |
+| `GIT_AUTHOR_EMAIL` | Your email for git commits | `45021016+primetimetank21@users.noreply.github.com` |
+
+These are applied automatically on `postCreateCommand` when the devcontainer starts.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "dev-setup Dev Container",
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 
-    "postCreateCommand": "bash setup.sh",
+    "postCreateCommand": ["bash", "-c", "bash setup.sh && git config --global user.name \"${GIT_AUTHOR_NAME:-Earl Tankard, Jr., Ph.D.}\" && git config --global user.email \"${GIT_AUTHOR_EMAIL:-45021016+primetimetank21@users.noreply.github.com}\""],
 
     "customizations": {
         "vscode": {


### PR DESCRIPTION
Closes #46

Sets git identity on devcontainer creation using environment variables:
- Falls back to owner defaults if secrets not set
- Documents required Codespace secrets in .devcontainer/README.md