### PR TITLE
chore(devcontainer): replace pip with uv for Python tooling (#44)

### DIFF
--- a/.copilot/skills/git-workflow/SKILL.md
+++ b/.copilot/skills/git-workflow/SKILL.md
@@ -176,7 +176,7 @@ cd ../squad-pr && npm link squad-sdk
 # replace github.com/org/squad-sdk => ../squad-sdk
 
 # Python
-cd ../squad-sdk && pip install -e .
+cd ../squad-sdk && uv pip install -e .
 ```
 
 **Important:** Remove local links before committing. `npm link` and `go replace` are dev-only — CI must use published packages or PR-specific refs.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -124,3 +124,12 @@ Set these in GitHub → Settings → Codespaces → Secrets:
 | `GIT_AUTHOR_EMAIL` | Your email for git commits | `45021016+primetimetank21@users.noreply.github.com` |
 
 These are applied automatically on `postCreateCommand` when the devcontainer starts.
+
+---
+
+## Python Package Management
+
+Use `uv` instead of `pip` for all Python tooling:
+- CLI tools: `uv tool install <package>`
+- Libraries: `uv pip install <package>`
+- Never use `pip install` directly.


### PR DESCRIPTION
Closes #44

Replaces pip with uv for Python tooling. uv is the required package manager per team convention.

- Fixes pip install -e . in SKILL.md → uv pip install -e .
- Documents Python Package Management policy in .devcontainer/README.md