### PR TITLE
feat(process): document worktree isolation for parallel agent runs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,11 @@
     },
 
     "remoteEnv": {
-        "DEBIAN_FRONTEND": "noninteractive"
+        "DEBIAN_FRONTEND": "noninteractive",
+        // Set SQUAD_WORKTREES=1 when running parallel Squad agent sessions to enable
+        // worktree isolation. Each agent gets its own git worktree so branch checkouts
+        // never collide. See CONTRIBUTING.md § "Parallel Agent Work" for details.
+        "SQUAD_WORKTREES": "1"
     },
 
     "features": {

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 .squad/sessions/
 # Squad: SubSquad activation file (local to this machine)
 .squad-workstream
+
+# Binary artifacts — do not commit compiled binaries or archives
+*.tar.gz
+*.zip
+*.dll
+*.exe

--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -17,6 +17,15 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### Worktree isolation pattern (Issue #56, 2026-04-07)
+
+- `SQUAD_WORKTREES=1` is the recommended env var to enable per-issue git worktree isolation.
+- The coordinator creates worktrees at `{repo-parent}/{repo-name}-{issue-number}` so each agent gets a fully isolated working tree.
+- This prevents the Sprint 4 race condition where Chip-issue-43 checked out a branch while Chip-issue-41 was mid-commit on the same working tree.
+- `SQUAD_WORKTREES=1` is now set by default in `.devcontainer/devcontainer.json` `remoteEnv`.
+- Full pattern documented in `.squad/skills/worktree-isolation/SKILL.md` and `CONTRIBUTING.md § "Parallel Agent Work"`.
+- PR: https://github.com/primetimetank21/dev-setup/pull/58
+
 ## Work Log
 
 ### 2026-04-07 — Issue #10: Dev Container and Codespace post-create setup

--- a/.squad/skills/worktree-isolation/SKILL.md
+++ b/.squad/skills/worktree-isolation/SKILL.md
@@ -1,0 +1,87 @@
+# Skill: Worktree Isolation for Parallel Agent Runs
+
+**Confidence:** medium (confirmed by Sprint 4 incident)
+**Owner:** Pluto (Config Engineer)
+**Issue:** #56
+
+---
+
+## What
+
+Each issue being worked on by a Squad agent gets its own `git worktree`. Agents never share a working tree. Branch checkouts inside one worktree are fully isolated from every other agent running simultaneously.
+
+## Why
+
+When multiple agents share a single working tree, any agent can run `git checkout <branch>` at any moment — even while another agent has uncommitted changes or is mid-commit on a different branch. In Sprint 4, Chip-issue-43 checked out `squad/43` while Chip-issue-41 was committing to a different branch. Wrong content ended up on the wrong branch; PR #51 was closed.
+
+This is a race condition at the filesystem level. The only safe fix is full working tree isolation.
+
+## How
+
+### Enable via environment variable
+
+```bash
+export SQUAD_WORKTREES=1
+```
+
+Set this before starting any Squad session where multiple agents will run in parallel. The devcontainer sets `SQUAD_WORKTREES=1` by default in `remoteEnv`.
+
+### Enable via squad config
+
+```yaml
+worktrees: true
+```
+
+Add to your project's squad config file (`squad.yml` or equivalent).
+
+### What the coordinator does
+
+When `SQUAD_WORKTREES=1`, the Squad coordinator:
+
+1. Creates a worktree at `{repo-parent}/{repo-name}-{issue-number}` for each issue.
+2. Checks out the agent's branch inside that isolated worktree.
+3. Hands the agent its `WORKTREE_PATH`.
+4. After the agent finishes, the worktree can be removed with `git worktree remove <path>`.
+
+### Worktree path convention
+
+```
+{repo-parent}/{repo-name}-{issue-number}
+```
+
+**Example:**
+
+| Issue | Repo path                  | Worktree path                  |
+|-------|----------------------------|--------------------------------|
+| #41   | `/workspaces/dev-setup`    | `/workspaces/dev-setup-41`     |
+| #43   | `/workspaces/dev-setup`    | `/workspaces/dev-setup-43`     |
+| #56   | `/workspaces/dev-setup`    | `/workspaces/dev-setup-56`     |
+
+### Cleanup
+
+```bash
+# List all worktrees
+git worktree list
+
+# Remove a worktree after PR is merged
+git worktree remove /workspaces/dev-setup-56
+
+# Prune stale worktree refs
+git worktree prune
+```
+
+## When to use this
+
+- Any time two or more Squad agents are expected to run simultaneously on different issues.
+- Parallel sprints, parallel hotfix + feature work, or any CI-driven multi-agent pipeline.
+
+## When not needed
+
+- Single-agent runs (sequential, one issue at a time) — no race condition possible.
+- Read-only agents (explorers, reviewers) — no branch checkouts.
+
+## References
+
+- Sprint 4 incident: PR #51 closed due to branch checkout race between Chip-issue-41 and Chip-issue-43.
+- `git worktree` docs: `man git-worktree`
+- CONTRIBUTING.md § "Parallel Agent Work"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,4 +75,50 @@ Keep the summary under 72 characters. Add a body if the change needs more contex
 
 ---
 
+---
+
+## Parallel Agent Work
+
+### Why worktree isolation matters
+
+In Sprint 4, two Chip agents ran simultaneously on issues #41 and #43, both sharing the same git working tree. Chip-issue-43 checked out `squad/43` while Chip-issue-41 was mid-commit on a different branch. The result: wrong content landed on the wrong branch, and PR #51 had to be closed and recreated. This is a classic branch-checkout race condition.
+
+### How to enable it
+
+Set `SQUAD_WORKTREES=1` before starting any Squad session where parallel work is expected:
+
+```bash
+export SQUAD_WORKTREES=1
+```
+
+Or add it permanently to your `.env` / shell profile. The devcontainer sets it by default in `remoteEnv`.
+
+When enabled, the Squad coordinator creates an isolated `git worktree` for each issue before handing control to the agent. Branch checkouts inside one worktree never affect any other.
+
+### Worktree path convention
+
+```
+{repo-parent}/{repo-name}-{issue-number}
+```
+
+**Example:** for issue #56 inside `/workspaces/dev-setup`, the worktree is created at:
+
+```
+/workspaces/dev-setup-56/
+```
+
+Each worktree has its own index and working files but shares the same `.git` object store with the main repo — no extra disk space for history, just the working tree.
+
+### Cleaning up
+
+Worktrees are not automatically removed. After a PR is merged, clean up with:
+
+```bash
+git worktree remove /workspaces/dev-setup-56
+```
+
+Or list all active worktrees with `git worktree list`.
+
+---
+
 For the full technical overview, team ownership map, and architecture decisions, see [ARCHITECTURE.md](./ARCHITECTURE.md).


### PR DESCRIPTION
Documents and enables worktree isolation to prevent branch checkout races when multiple agents run in parallel on different issues.

- Updates CONTRIBUTING.md with parallel agent guidance (Sprint 4 race condition story, how to enable, path convention, cleanup)
- Adds worktree-isolation skill to .squad/skills/
- Documents SQUAD_WORKTREES=1 env var in devcontainer remoteEnv (enabled by default)

Closes #56