### PR TITLE
feat(process): document agent timeout policy to prevent stalled agent loops

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -835,7 +835,13 @@ prompt: |
 
 After each batch of agent work:
 
-1. **Collect results** via `read_agent` (wait: true, timeout: 300).
+1. **Collect results** via `read_agent` (wait: true, timeout: 300). This is the standard call pattern — always use `wait: true` so the coordinator blocks until the agent completes or the timeout fires rather than polling.
+
+   **Agent Timeout Handling:** Agents must complete within their tier's wall-clock limit (Quick: 5 min, Standard: 10 min, Complex: 20 min; default: Standard). Track elapsed time from spawn. If `read_agent` returns a timeout (agent still running after repeated calls exhausting the budget):
+   - **First timeout:** Cancel the agent. Log to orchestration log (agent name, elapsed time, last state). Retry once with a leaner or decomposed prompt.
+   - **Second timeout (same task):** Cancel. Do **not** retry. Escalate: `"⚠️ {AgentName} stalled twice on #{issue} — manual intervention needed."` Stop and wait for user direction.
+   - **Never retry silently** — every timeout is logged and surfaced to the user.
+   - See `.squad/team.md` → "Agent Timeout Policy" for the full tier table and rationale.
 
 2. **Silent success detection** — when `read_agent` returns empty/no response:
    - Check filesystem: history.md modified? New decision inbox files? Output files created?

--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -18,6 +18,30 @@ Sequence before any merge:
 
 Violation history: Sprint 2 (PRs #17-#27), Sprint 3 (PRs #33-#36). Branch protection on `develop` now enforces this at the GitHub level (Sprint 4).
 
+## Agent Stall Detection
+
+Ralph monitors running agents for signs of stalling. A stall is when an agent exceeds its wall-clock budget without producing useful output.
+
+**Timeout tiers** (from `.squad/team.md` → Agent Timeout Policy):
+
+| Task Type | Limit |
+|-----------|-------|
+| Quick | 5 min |
+| Standard | 10 min (default) |
+| Complex | 20 min |
+
+**When Ralph detects a stall:**
+1. Record the agent name, issue number, elapsed time, and last known state.
+2. Flag it to the coordinator immediately: `"⚠️ {AgentName} has been running {N} min — exceeds {tier} budget. Recommend cancel."`. Do NOT kill the agent directly — flag; coordinator acts.
+3. If the coordinator retries and the replacement agent also stalls, escalate to the user: `"⚠️ {AgentName} stalled twice on #{issue} — manual intervention needed."`.
+
+**Signs of a stall (in addition to elapsed time):**
+- Agent has made 30+ tool calls without writing any output files or git commits
+- Agent is looping on the same tool call repeatedly
+- `read_agent` returns no progress after 3 consecutive polls
+
+**Ralph never silently tolerates a stall.** Every stall is flagged in the same turn it is detected.
+
 ## Responsibilities
 
 - Collaborate with team members on assigned work

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -28,6 +28,34 @@
 - **Created:** 2026-04-07
 - **Goal:** Cross-platform setup scripts for Dev Containers / Codespaces — auto-detect OS and install preferred tools, configs, and shortcuts
 
+## Agent Timeout Policy
+
+Agents are spawned via the `task` tool with `mode: "background"`. There is no built-in timeout parameter — the coordinator enforces wall-clock limits by tracking elapsed time and acting when an agent exceeds its budget.
+
+### Timeout Tiers
+
+| Task Type | Examples | Wall-Clock Limit |
+|-----------|----------|-----------------|
+| **Quick** | Single-file lookup, read + report, simple Q&A | 5 min |
+| **Standard** | Implement one feature, write tests, update one config area | 10 min |
+| **Complex** | Multi-file refactor, cross-cutting feature, multi-agent fan-out | 20 min |
+
+When task type is unspecified, default to **Standard (10 min)**.
+
+### What the Coordinator Does When an Agent Times Out
+
+1. **First timeout:** Cancel the stalled agent. Log the failure in the orchestration log (agent name, elapsed time, last known state). Retry once with a decomposed or leaner prompt — break the task into smaller pieces, reduce scope, or change the approach.
+2. **Second timeout (same task):** Cancel. Do **not** retry again. Escalate to the user with: `"⚠️ {AgentName} stalled twice on #{issue} — manual intervention needed."` Log and stop.
+3. **No silent retries** — every timeout must be visible in the orchestration log and reported to the user.
+
+### Interaction with Ralph
+
+Ralph monitors running agents. When an agent's elapsed time exceeds its tier limit, Ralph flags it to the coordinator immediately. The coordinator then cancels and applies the retry/escalate logic above. Ralph does not kill agents directly — it flags; the coordinator acts.
+
+### Rationale
+
+Sprint 4 incident: Chip (issue #43) ran 45+ tool calls over 6+ minutes without useful output. Ralph had to take over manually. A documented timeout policy prevents this class of runaway agent and gives the coordinator clear recovery steps.
+
 ## Stack
 
 - **Languages:** Bash, Zsh, PowerShell


### PR DESCRIPTION
Adds a formal agent timeout policy to prevent the Sprint 4 Chip-issue-43 scenario where an agent ran 45+ tool calls without output.

Changes:
- Agent timeout policy in team.md
- Coordinator timeout handling in squad.agent.md
- Ralph stall detection guidance

Closes #55