### PR TITLE
fix(copilot-cli): remove conflicting gh alias before extension install

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -17,6 +17,24 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### 2026-04-12: Bug fix — gh 2.89.0+ idempotency check uses wrong command (PR #63 additional fix)
+
+`gh copilot --help` exits 0 unconditionally on gh 2.89.0+ because gh intercepts the flag
+and shows its own wrapper help — it never touches the Copilot CLI binary. This caused the
+idempotency check to always short-circuit on fresh systems, skipping the binary download.
+
+Fix: change to `gh copilot -- --help`. The `--` passes the flag through to the actual binary.
+On gh 2.89.0+ without the binary, this triggers a proactive download. On older gh without the
+extension, it exits non-zero and falls through to `gh extension install` as intended.
+
+Updated file-header comment in `scripts/linux/tools/copilot-cli.sh` to document the nuance.
+Decision dropped to `.squad/decisions/inbox/donald-idempotency-passthrough.md`.
+Branch: `squad/fix-copilot-cli-alias-conflict` — PR #63.
+
+**Rule:** Never probe a gh built-in wrapper with `--help` alone. Use `-- --help` to reach the binary.
+
+---
+
 ### 2026-04-08: gh 2.x+ built-in promotion breaks extension install (PR #63 revised)
 
 `gh 2.89.0` promotes `gh copilot` to a **built-in command**. This breaks two earlier patterns:

--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -17,6 +17,20 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### 2026-04-08: gh 2.x+ built-in promotion breaks extension install (PR #63 revised)
+
+`gh 2.89.0` promotes `gh copilot` to a **built-in command**. This breaks two earlier patterns:
+
+- `gh extension list | grep -q "gh-copilot"` — misses built-ins (only lists extensions)
+- `gh alias list | grep copilot` — misses built-ins (only lists aliases)
+- `gh extension install github/gh-copilot` — fails with `"copilot" matches the name of a built-in command` (stdout, not stderr)
+
+**Correct idempotency check:** `gh copilot --help &>/dev/null 2>&1` — succeeds whether copilot is a built-in, extension, or alias. Version-agnostic.
+
+**Correct install failure handling:** Use `set +e` to capture stdout+stderr from `gh extension install`, then grep for the "built-in" error string and exit 0 gracefully. Never let a version-gated "already built-in" failure propagate as a setup error.
+
+**Rule:** Never use `gh extension list` or `gh alias list` as the sole idempotency gate for gh subcommands — probe the actual command with `--help` instead.
+
 ### 2026-04-08: Bug fix — gh alias conflict blocks copilot-cli extension install
 
 `gh extension install` silently fails (stdout, not stderr) when an existing gh alias matches the extension's command name. For `gh-copilot`, this means any stale `copilot` alias from a prior partial install blocks reinstall entirely.

--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -17,6 +17,14 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### 2026-04-08: Bug fix — gh alias conflict blocks copilot-cli extension install
+
+`gh extension install` silently fails (stdout, not stderr) when an existing gh alias matches the extension's command name. For `gh-copilot`, this means any stale `copilot` alias from a prior partial install blocks reinstall entirely.
+
+Fix pattern: guard with `gh alias list | grep -q "^copilot"` and delete before installing. Applied to `scripts/linux/tools/copilot-cli.sh` on branch `squad/fix-copilot-cli-alias-conflict`, PR #63.
+
+Also: never use `$(gh copilot --version)` in a post-install check — if the alias conflict exists, that subshell triggers the same error and leaks it into log output. Use `gh extension list | grep -q "gh-copilot"` or a plain success string instead.
+
 ### 2026-04-07: Issues #1, #4, #5, #6, #7, #9 — Core Linux/macOS setup scripts implemented
 
 Implemented the full installer suite on branch `squad/1-linux-core-setup` (based on Mickey's `squad/3-os-detection-entry-point`):

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -311,6 +311,48 @@ Squad merge pattern is: `gh pr merge --admin` after Mickey approval. This is NOT
 
 ---
 
+## [2026-04-08] Guard Against gh Alias Conflicts Before Extension Install
+
+**Date:** 2026-04-08  
+**Owner:** Donald (Shell Dev)  
+**Issue:** Bug — `scripts/linux/tools/copilot-cli.sh` fails with alias conflict  
+**PR:** #63  
+**Branch:** `squad/fix-copilot-cli-alias-conflict`  
+**Status:** PR Open
+
+### Problem
+
+`gh extension install github/gh-copilot` fails with:
+```
+"copilot" matches the name of a built-in command or alias
+```
+
+The `gh` CLI refuses to install an extension whose command name matches an existing alias. The error goes to stdout, not stderr — so `2>/dev/null` redirection does not suppress it. A prior partial install can leave a stale `copilot` alias that permanently blocks future installs.
+
+A secondary bug: the post-install check `$(gh copilot --version 2>/dev/null)` would trigger the same alias collision if one existed, leaking the error string into the output.
+
+### Decision
+
+Any shell script that installs a `gh` extension must:
+
+1. Check for a conflicting alias before calling `gh extension install`:
+   ```bash
+   if gh alias list 2>/dev/null | grep -q "^copilot"; then
+     log_warn "Removing conflicting gh alias 'copilot'..."
+     gh alias delete copilot
+   fi
+   ```
+
+2. Never use `$(gh <extension-cmd> --version)` as a post-install verification — it triggers the same alias lookup. Prefer `gh extension list | grep -q "<extension-name>"`.
+
+### Rationale
+
+- The `gh` alias conflict is silent from a script perspective (stdout, not stderr) and idempotency guards won't catch it if the extension was partially registered.
+- The alias delete is safe: it only fires if the alias exists, and after install the extension's native command supersedes any alias anyway.
+- Removing the `--version` subshell eliminates stdout-leaking post-install checks that could corrupt log output.
+
+---
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -3,7 +3,10 @@
 #
 # Called by: scripts/linux/setup.sh
 # Owner:     Donald
-# Idempotent: yes — checks if gh copilot is already available (built-in or extension)
+# Idempotent: yes — uses 'gh copilot -- --help' to probe the actual Copilot binary,
+#             not gh's wrapper. On gh 2.89.0+, 'gh copilot --help' exits 0 even
+#             before the binary is downloaded (shows gh's own help). The '--' pass-through
+#             hits the real binary, triggering a proactive download if needed.
 #
 # Prerequisite: gh CLI must be installed and authenticated (see gh.sh)
 #
@@ -21,9 +24,12 @@ if ! command -v gh &>/dev/null; then
   exit 0
 fi
 
-# Check if gh copilot is already available (built-in in gh 2.x+ or installed extension)
-if gh copilot --help &>/dev/null 2>&1; then
-  log_ok "GitHub Copilot CLI already available"
+# Check if gh copilot is fully operational — passes through to the actual binary.
+# On gh 2.89.0+, this also triggers a proactive binary download if not yet present.
+# 'gh copilot --help' is NOT sufficient: it exits 0 even before the binary is downloaded
+# because it shows gh's own wrapper help, not the CLI binary's help.
+if gh copilot -- --help &>/dev/null 2>&1; then
+  log_ok "GitHub Copilot CLI already installed"
   exit 0
 fi
 

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -30,7 +30,13 @@ if ! gh auth status &>/dev/null; then
   exit 0
 fi
 
+# Remove any conflicting gh alias that would block extension install
+if gh alias list 2>/dev/null | grep -q "^copilot"; then
+  log_warn "Removing conflicting gh alias 'copilot' (leftover from prior install)..."
+  gh alias delete copilot
+fi
+
 log_info "Installing GitHub Copilot CLI..."
 gh extension install github/gh-copilot
 
-log_ok "Copilot CLI installed: $(gh copilot --version 2>/dev/null || echo 'installed')"
+log_ok "GitHub Copilot CLI installed — run 'gh copilot --help' to get started"

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -2,10 +2,13 @@
 # scripts/linux/tools/copilot-cli.sh — Install GitHub Copilot CLI extension
 #
 # Called by: scripts/linux/setup.sh
-# Owner:     Donald (#9)
-# Idempotent: yes — checks if gh-copilot extension is already installed
+# Owner:     Donald
+# Idempotent: yes — checks if gh copilot is already available (built-in or extension)
 #
 # Prerequisite: gh CLI must be installed and authenticated (see gh.sh)
+#
+# Note: In gh 2.x+, 'gh copilot' may be a built-in command rather than an
+# extension. This script handles both cases gracefully.
 
 set -euo pipefail
 
@@ -18,8 +21,9 @@ if ! command -v gh &>/dev/null; then
   exit 0
 fi
 
-if gh extension list 2>/dev/null | grep -q "gh-copilot"; then
-  log_ok "GitHub Copilot CLI already installed"
+# Check if gh copilot is already available (built-in in gh 2.x+ or installed extension)
+if gh copilot --help &>/dev/null 2>&1; then
+  log_ok "GitHub Copilot CLI already available"
   exit 0
 fi
 
@@ -37,6 +41,22 @@ if gh alias list 2>/dev/null | grep -q "^copilot"; then
 fi
 
 log_info "Installing GitHub Copilot CLI..."
-gh extension install github/gh-copilot
+
+# Temporarily disable set -e to capture install output and handle gracefully.
+# In newer gh versions, 'copilot' may be promoted to a built-in, causing
+# extension install to fail with a specific error we can detect and accept.
+set +e
+install_out="$(gh extension install github/gh-copilot 2>&1)"
+install_rc=$?
+set -e
+
+if [[ $install_rc -ne 0 ]]; then
+  if printf '%s' "$install_out" | grep -q "matches the name of a built-in"; then
+    log_ok "GitHub Copilot CLI is available as a built-in gh command"
+    exit 0
+  fi
+  printf '%s\n' "$install_out"
+  exit 1
+fi
 
 log_ok "GitHub Copilot CLI installed — run 'gh copilot --help' to get started"


### PR DESCRIPTION
## Root Cause (Revised Diagnosis)

`gh 2.89.0` promotes `gh copilot` to a **built-in command** — not an alias, not an extension. This means:

- `gh extension list | grep -q "gh-copilot"` → misses the built-in (original idempotency check)
- `gh alias list | grep copilot` → misses the built-in (PR #63 first-pass guard)
- `gh extension install github/gh-copilot` → still fails with `"copilot" matches the name of a built-in command`

The alias-guard fix in the first commit was correct in spirit but wrong in mechanism — the conflict is a built-in, not an alias.

## Two-Part Fix

### 1. Idempotency check upgraded (first pass)

**Before:**
```bash
if gh extension list 2>/dev/null | grep -q "gh-copilot"; then
```

**After (first pass):**
```bash
if gh copilot --help &>/dev/null 2>&1; then
```

`gh copilot --help` succeeds whether `copilot` is a built-in, an extension, or an alias — making the idempotency check version-agnostic.

### 2. Install failure handled gracefully

Wrap `gh extension install` with `set +e` / `set -e` to capture stdout+stderr. If the install fails with the "matches the name of a built-in" message, exit 0 instead of propagating the failure:

```bash
set +e
install_out="$(gh extension install github/gh-copilot 2>&1)"
install_rc=$?
set -e

if [[ $install_rc -ne 0 ]]; then
  if printf '%s' "$install_out" | grep -q "matches the name of a built-in"; then
    log_ok "GitHub Copilot CLI is available as a built-in gh command"
    exit 0
  fi
  printf '%s\n' "$install_out"
  exit 1
fi
```

### Alias guard retained

`gh alias list | grep "^copilot"` guard is kept as defensive code — handles environments with stale aliases from prior partial installs.

### 3. Idempotency check: use `--` pass-through

**Problem:** On gh 2.89.0+, `gh copilot --help` exits 0 **regardless** of whether the Copilot CLI binary has been downloaded. `gh` intercepts the flag and shows its own wrapper help — it never touches the actual binary. So the idempotency check from fix #1 always short-circuits to "already available" on a fresh system before the binary has ever been fetched.

**Fix:**
```bash
# Before (insufficient on gh 2.89.0+):
if gh copilot --help &>/dev/null 2>&1; then

# After:
if gh copilot -- --help &>/dev/null 2>&1; then
```

The `--` separator passes the `--help` flag through to the actual Copilot CLI binary. Behaviour across all versions:

| Scenario | Exit code | Result |
|---|---|---|
| gh 2.89.0+ — binary already downloaded | 0 | Short-circuits ✓ |
| gh 2.89.0+ — binary not yet present | 0 (after download) | Proactive download, then exits ✓ |
| Older gh — extension installed | 0 | Short-circuits ✓ |
| Older gh — extension not installed | non-zero | Falls through to install ✓ |

If the download fails (no network etc.), `gh copilot -- --help` exits non-zero, the script falls through to `gh extension install`, which fails with "matches the name of a built-in" on gh 2.89.0+, and the existing graceful handler catches that and exits 0.

## Testing

On **gh >= 2.89.0** (built-in):
- Fresh run (binary not yet downloaded): `gh copilot -- --help` triggers download → exits 0 immediately (no install step reached)
- Re-run (binary present): exits 0 immediately
- Install step reached only if download fails → graceful built-in handler fires

On **gh < 2.89.0** (extension):
- Fresh run: installs extension → exits 0
- Re-run: `gh copilot -- --help` succeeds → exits 0 immediately
- Stale alias present: alias deleted → installs cleanly
