### PR TITLE
fix(dotfiles): append managed block to existing .zshrc/.bashrc (#64)

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -102,6 +102,29 @@ Created `config/dotfiles/` with:
 
 ---
 
+## 2026-04-12 — Issue #64: Append Managed Block to Existing .zshrc/.bashrc
+
+**Branch:** `squad/64-dotfiles-append-managed-block`
+**PR:** #65 (open, targeting `develop`)
+**Status:** Ready for review
+
+**What I did:**
+- Replaced the "skip .zshrc if it exists" behavior with an append-managed-block strategy
+- Added `append_managed_block()` helper to `config/dotfiles/install.sh` — uses a marker comment for idempotency
+- `.zshrc` block: sets PATH for `$HOME/.local/bin`, inits nvm, sources `.aliases`
+- `.bashrc` block: sets PATH for `$HOME/.local/bin`, sources `.aliases` (nvm init omitted — nvm installer handles it)
+- Fresh-install (no `.zshrc`) path unchanged — still copies the template
+- `--dry-run` support wired into the new helper
+
+**Key decisions:**
+- Marker: `# --- dev-setup managed block` — simple `grep -qF` check before every append
+- `.bashrc` block is intentionally shorter than `.zshrc` — nvm appends its own init to `.bashrc` during install
+- Only append to `.bashrc` if it already exists — no template for `.bashrc`
+
+**Decision record:** `.squad/decisions/inbox/pluto-dotfiles-managed-block.md`
+
+---
+
 ## 2026-04-08 — Issue #56: Worktree Isolation for Parallel Agent Work
 
 **Branch:** `squad/56-worktree-isolation`  

--- a/config/dotfiles/install.sh
+++ b/config/dotfiles/install.sh
@@ -6,7 +6,9 @@
 # - Copies .npmrc.template      → $HOME/.npmrc
 # - Symlinks .editorconfig      → $HOME/.editorconfig
 # - Symlinks .aliases           → $HOME/.aliases
-# - Copies .zshrc.template      → $HOME/.zshrc  (skipped if $HOME/.zshrc exists)
+# - Copies .zshrc.template      → $HOME/.zshrc  (fresh install only)
+#   OR appends dev-setup managed block to existing $HOME/.zshrc
+# - Appends dev-setup managed block to existing $HOME/.bashrc
 #
 # Usage:
 #   ./config/dotfiles/install.sh            # install for real
@@ -72,6 +74,32 @@ install_copy() {
     cp "$src" "$dest"
     ok "Installed $label"
   fi
+}
+
+# ── Helper: append managed block to a shell rc file if not already present ───
+# Usage: append_managed_block <dest> <block> [<label>]
+append_managed_block() {
+  local dest="$1"
+  local block="$2"
+  local label="${3:-$(basename "$dest")}"
+  local marker="# --- dev-setup managed block"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    if grep -qF "$marker" "$dest" 2>/dev/null; then
+      dry "$label (dev-setup block already present — would skip)"
+    else
+      dry "Would append dev-setup block to $label"
+    fi
+    return
+  fi
+
+  if grep -qF "$marker" "$dest" 2>/dev/null; then
+    skip "$label (dev-setup block already present)"
+    return
+  fi
+
+  printf '\n%s\n' "$block" >> "$dest"
+  ok "Appended dev-setup block to $label"
 }
 
 # ── Helper: create a symlink, skipping if it already points to the right file
@@ -177,14 +205,17 @@ install_symlink \
   "$HOME/.vimrc" \
   ".vimrc"
 
-# .zshrc.template — copy only if no .zshrc exists (never overwrite the user's own)
+# .zshrc — copy template on fresh install; append managed block to existing file
+ZSHRC_MANAGED_BLOCK='# --- dev-setup managed block (do not edit) ---
+export PATH="$HOME/.local/bin:$PATH"
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+[ -f "$HOME/.aliases" ] && source "$HOME/.aliases"
+# --- end dev-setup managed block ---'
+
 if [[ -f "$HOME/.zshrc" ]]; then
-  if [[ "$DRY_RUN" == true ]]; then
-    dry "Skipping .zshrc — $HOME/.zshrc already exists (won't overwrite)"
-  else
-    info "Skipping .zshrc — $HOME/.zshrc already exists. To apply the template manually:"
-    info "  cp $DOTFILES_DIR/.zshrc.template $HOME/.zshrc"
-  fi
+  append_managed_block "$HOME/.zshrc" "$ZSHRC_MANAGED_BLOCK" ".zshrc"
 else
   if [[ "$DRY_RUN" == true ]]; then
     dry "Would copy .zshrc.template → $HOME/.zshrc"
@@ -192,6 +223,16 @@ else
     cp "$DOTFILES_DIR/.zshrc.template" "$HOME/.zshrc"
     ok "Installed .zshrc from template"
   fi
+fi
+
+# .bashrc — append managed block if file exists (nvm PATH already appended by nvm installer)
+BASHRC_MANAGED_BLOCK='# --- dev-setup managed block (do not edit) ---
+export PATH="$HOME/.local/bin:$PATH"
+[ -f "$HOME/.aliases" ] && source "$HOME/.aliases"
+# --- end dev-setup managed block ---'
+
+if [[ -f "$HOME/.bashrc" ]]; then
+  append_managed_block "$HOME/.bashrc" "$BASHRC_MANAGED_BLOCK" ".bashrc"
 fi
 
 printf "\n${GREEN}Done.${RESET}\n\n"


### PR DESCRIPTION
## Problem

\install.sh\ skipped \.zshrc\ when \\C:\Users\Earl Tankard/.zshrc\ already existed (always true in Devcontainer base images). Result: nvm, PATH, and aliases were never available in the shell after setup. \.bashrc\ was never touched at all.

## Fix

Append a dev-setup managed block to existing \.zshrc\ and \.bashrc\ if not already present. Uses a marker comment for idempotency — safe to run multiple times.

**Before (skip):**
\\\
→ Already installed: Skipping .zshrc — \C:\Users\Earl Tankard/.zshrc already exists (won't overwrite)
# .bashrc: not touched at all
\\\

**After (append):**
\\\
✓ Appended dev-setup block to .zshrc
✓ Appended dev-setup block to .bashrc
\\\
On subsequent runs (idempotent):
\\\
→ Already installed: .zshrc (dev-setup block already present)
→ Already installed: .bashrc (dev-setup block already present)
\\\

## Changes

- Added \ppend_managed_block()\ helper that guards with marker \# --- dev-setup managed block\
- \.zshrc\: appends PATH + nvm init + aliases block to existing file; copies template on fresh install (unchanged path)
- \.bashrc\: appends PATH + aliases block when file exists (nvm init omitted — nvm installer already appends it)
- \--dry-run\ support included in the new helper

Closes #64