### PR TITLE
fix(shell): merge stderr into stdout for ordered output in piped environments (#68)

### DIFF
--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -11,6 +11,7 @@
 #   bash scripts/linux/setup.sh
 
 set -euo pipefail
+exec 2>&1  # Merge stderr into stdout for ordered output in piped/Devcontainer environments
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="${SCRIPT_DIR}/tools"

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,7 @@
 #   windows-compat    — Cygwin/MSYS2/Git Bash (limited support, use setup.ps1)
 
 set -euo pipefail
+exec 2>&1  # Merge stderr into stdout for ordered output in piped/Devcontainer environments
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
## Summary

Adds \xec 2>&1\ immediately after \set -euo pipefail\ in both root entry points so \log_error()\ output appears in-sequence with all other log helpers in piped/Devcontainer environments.

## Changes

- \setup.sh\ — added \xec 2>&1\ after \set -euo pipefail\
- \scripts/linux/setup.sh\ — same

## Child scripts (scripts/linux/tools/*.sh)

Audited all 6 tool scripts: **none use \>&2\**. They inherit the merged file descriptor from their parent process (\xec 2>&1\ propagates to child processes via \ash \\). No changes required.

Fixes #68