### PR TITLE
fix(devcontainer): strip CRLF from .sh files on container create (#69)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,8 @@
     "name": "dev-setup Dev Container",
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 
+    "onCreateCommand": "find . -name '*.sh' | xargs sed -i 's/\\r//'",
+
     "postCreateCommand": ["bash", "-c", "bash setup.sh && git config --global user.name \"${GIT_AUTHOR_NAME:-Earl Tankard, Jr., Ph.D.}\" && git config --global user.email \"${GIT_AUTHOR_EMAIL:-45021016+primetimetank21@users.noreply.github.com}\""],
 
     "customizations": {


### PR DESCRIPTION
Adds onCreateCommand to strip CRLF from .sh files before postCreateCommand. Fixes Windows bind-mount CRLF issue not resolved by index-only gitattributes renormalize (PR #66). Safe no-op on LF systems and Codespaces. Fixes #69