### PR TITLE
fix(copilot-cli): trigger binary download non-interactively

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -350,3 +350,19 @@ This session completed the install script fixes that address Windows Devcontaine
 - Issues #68, #69 auto-close when PRs link them (may require manual close if not linked)
 - Windows users who pull latest + rebuild Devcontainer will get ordered, diagnostic-friendly logs
 - Users with old working trees (CRLF from before PR #66) will have files stripped on next Devcontainer create
+
+## 2026-04-11 23:01:46: Created Issue #72
+
+**Task:** Create GitHub issue for copilot-cli binary download bug
+
+**Issue:** ix(copilot-cli): binary never downloads — install prompt swallowed by output redirection
+
+**Details:** 
+- Root cause: Output suppression in installation check swallows interactive prompt, defaults to 'N'
+- Symptom: Binary never downloads; users see 'Cannot find GitHub Copilot CLI' on every invocation
+- Fix: Check directory existence, trigger download with \printf 'y\n'\, verify completion
+
+**Issue #:** 72
+
+---
+

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
-# scripts/linux/tools/copilot-cli.sh — Install GitHub Copilot CLI extension
+# scripts/linux/tools/copilot-cli.sh — Install GitHub Copilot CLI binary
 #
 # Called by: scripts/linux/setup.sh
 # Owner:     Donald
-# Idempotent: yes — uses 'gh copilot -- --help' to probe the actual Copilot binary,
-#             not gh's wrapper. On gh 2.89.0+, 'gh copilot --help' exits 0 even
-#             before the binary is downloaded (shows gh's own help). The '--' pass-through
-#             hits the real binary, triggering a proactive download if needed.
+# Idempotent: yes — checks for the binary directory before attempting install.
 #
-# Prerequisite: gh CLI must be installed and authenticated (see gh.sh)
+# Prerequisite: gh CLI must be installed and authenticated (see gh.sh, auth.sh)
 #
-# Note: In gh 2.x+, 'gh copilot' may be a built-in command rather than an
-# extension. This script handles both cases gracefully.
+# Note: On gh 2.89.0+, 'gh copilot' is a built-in that prompts interactively
+# on first use. Output suppression swallows that prompt, stdin gets EOF, and
+# the binary is never downloaded. This script pipes 'y' to trigger a
+# non-interactive download and verifies via directory existence check.
 
 set -euo pipefail
 
@@ -24,45 +23,29 @@ if ! command -v gh &>/dev/null; then
   exit 0
 fi
 
-# Check if gh copilot is fully operational — passes through to the actual binary.
-# On gh 2.89.0+, this also triggers a proactive binary download if not yet present.
-# 'gh copilot --help' is NOT sufficient: it exits 0 even before the binary is downloaded
-# because it shows gh's own wrapper help, not the CLI binary's help.
-if gh copilot -- --help &>/dev/null 2>&1; then
+if ! gh auth status &>/dev/null; then
+  log_warn "gh is not authenticated — skipping Copilot CLI install (run auth.sh first)"
+  exit 0
+fi
+
+COPILOT_INSTALL_DIR="${HOME}/.local/share/gh/copilot"
+
+if [[ -d "$COPILOT_INSTALL_DIR" ]] && [[ -n "$(ls -A "$COPILOT_INSTALL_DIR" 2>/dev/null)" ]]; then
   log_ok "GitHub Copilot CLI already installed"
   exit 0
 fi
 
-# gh extension install requires authentication
-if ! gh auth status &>/dev/null; then
-  log_warn "gh is not authenticated — skipping Copilot CLI install"
-  log_warn "Run 'gh auth login' then re-run setup to install the Copilot CLI extension"
-  exit 0
-fi
+log_info "Installing GitHub Copilot CLI binary..."
 
-# Remove any conflicting gh alias that would block extension install
-if gh alias list 2>/dev/null | grep -q "^copilot"; then
-  log_warn "Removing conflicting gh alias 'copilot' (leftover from prior install)..."
-  gh alias delete copilot
-fi
-
-log_info "Installing GitHub Copilot CLI..."
-
-# Temporarily disable set -e to capture install output and handle gracefully.
-# In newer gh versions, 'copilot' may be promoted to a built-in, causing
-# extension install to fail with a specific error we can detect and accept.
+# Pipe 'y' to answer the install prompt non-interactively.
+# timeout 60 prevents hanging if the binary launches interactively after download.
+# set +e / set -e because timeout exits non-zero when it kills the process.
 set +e
-install_out="$(gh extension install github/gh-copilot 2>&1)"
-install_rc=$?
+printf 'y\n' | timeout 60 gh copilot >/dev/null 2>&1
 set -e
 
-if [[ $install_rc -ne 0 ]]; then
-  if printf '%s' "$install_out" | grep -q "matches the name of a built-in"; then
-    log_ok "GitHub Copilot CLI is available as a built-in gh command"
-    exit 0
-  fi
-  printf '%s\n' "$install_out"
-  exit 1
+if [[ -d "$COPILOT_INSTALL_DIR" ]] && [[ -n "$(ls -A "$COPILOT_INSTALL_DIR" 2>/dev/null)" ]]; then
+  log_ok "GitHub Copilot CLI installed"
+else
+  log_warn "Could not auto-install Copilot CLI binary — run 'gh copilot' in your terminal to install manually"
 fi
-
-log_ok "GitHub Copilot CLI installed — run 'gh copilot --help' to get started"


### PR DESCRIPTION
## Problem

The Copilot CLI binary never actually downloads. The install prompt ('Install GitHub Copilot CLI? [y/N]') is swallowed by output redirection, defaults to N, and the binary is never fetched. The script incorrectly claims success after detecting the 'matches the name of a built-in' message from a failed extension install.

## Fix

- Replace exit-code-based check with directory existence check (\~/.local/share/gh/copilot\)
- Trigger binary download non-interactively: \printf 'y\n' | timeout 60 gh copilot\
- Verify download by re-checking directory
- Remove unused \gh extension install\ and \gh alias delete\ paths

Fixes #72