### PR TITLE
feat(setup): add vim to system prerequisites

### DIFF
--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -66,7 +66,7 @@ install_prerequisites() {
     brew install curl git
   else
     sudo apt-get update -qq
-    sudo apt-get install -y curl git build-essential
+    sudo apt-get install -y curl git build-essential vim
   fi
 
   log_ok "Prerequisites installed"


### PR DESCRIPTION
Fixes #75. Adds vim to the apt-get prerequisites so aliases vb and vz (which call vim directly) work in the Devcontainer.