### PR TITLE
fix(copilot-cli): install standalone binary via official script (closes #81)

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -328,3 +328,26 @@ Both PRs reviewed by Mickey and squash-merged.
 - PR #77 (vim prerequisite): merged, branch squad/75-add-vim-prerequisite deleted.
 - PR #78 (script PTY): merged, branch squad/76-pty-copilot-download deleted.
 CI: 4/4 green on both. Issues #75 and #76 closed.
+
+### 2026-04-13: Issue #76 (revised) — Standalone copilot-cli install via official script (PR #82)
+
+Replaced the entire copilot-cli installation approach. Prior attempts using `CI=true gh copilot` failed because `gh copilot` is a shim wrapper that delegates to the standalone `github/copilot-cli` binary, but the binary never actually downloads in CI environments.
+
+**Root Cause:** `gh copilot` wrapper prompts for binary install when it's not present. Setting `CI=true` or using PTY tricks only partially worked — the binary download was unreliable and `copilot --version` still failed after container setup.
+
+**Fix:** Use the official standalone install script from `github/copilot-cli` repository:
+- Install command: `curl -fsSL https://gh.io/copilot-install | bash`
+- Non-root install: binary lands at `~/.local/bin/copilot` (already in PATH via dev-setup managed block)
+- Idempotency check: `[[ -x ~/.local/bin/copilot ]]` (checks for actual binary, not shim directory)
+- **Removes dependency on `gh auth` for the install step** — auth is only needed to use the tool, not install it
+
+**Changes:**
+- Replaced entire content of `scripts/linux/tools/copilot-cli.sh`
+- Removed `gh auth status` check before install
+- Removed `CI=true timeout` hack
+- Removed `script -q` PTY workaround
+- Simplified from 51 lines to 37 lines
+
+**Branch:** `fix/copilot-cli-standalone-install`
+**Issue:** #76  
+**PR:** #82 (open, targeting `develop`)

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
-# scripts/linux/tools/copilot-cli.sh — Install GitHub Copilot CLI binary
+# scripts/linux/tools/copilot-cli.sh — Install GitHub Copilot CLI
 #
 # Called by: scripts/linux/setup.sh
 # Owner:     Donald
-# Idempotent: yes — checks for the binary directory before attempting install.
+# Idempotent: yes — checks for ~/.local/bin/copilot before attempting install.
 #
-# Prerequisite: gh CLI must be installed and authenticated (see gh.sh, auth.sh)
-#
-# Note: On gh 2.89.0+, 'gh copilot' checks update.IsCI() (CI env var) before
-# showing the interactive install prompt (pkg/cmd/copilot/copilot.go). Setting
-# CI=true triggers a non-interactive binary download — no PTY or 'script' needed.
-# Binary is installed as ~/.local/share/gh/copilot/copilot (named "copilot").
+# Installs the standalone GitHub Copilot CLI (github/copilot-cli) via the
+# official install script (https://gh.io/copilot-install). Non-root install
+# lands at ~/.local/bin/copilot, which is already in PATH via the dev-setup
+# managed block.
 
 set -euo pipefail
 
@@ -18,33 +16,23 @@ log_info()  { printf '\033[0;34m[INFO]\033[0m  %s\n' "$*"; }
 log_ok()    { printf '\033[0;32m[OK]\033[0m    %s\n' "$*"; }
 log_warn()  { printf '\033[0;33m[WARN]\033[0m  %s\n' "$*"; }
 
-if ! command -v gh &>/dev/null; then
-  log_warn "gh CLI not found — skipping Copilot CLI install (run gh.sh first)"
-  exit 0
-fi
+COPILOT_BIN="${HOME}/.local/bin/copilot"
 
-if ! gh auth status &>/dev/null; then
-  log_warn "gh is not authenticated — skipping Copilot CLI install (run auth.sh first)"
-  exit 0
-fi
-
-COPILOT_INSTALL_DIR="${HOME}/.local/share/gh/copilot"
-
-if [[ -d "$COPILOT_INSTALL_DIR" ]] && [[ -n "$(ls -A "$COPILOT_INSTALL_DIR" 2>/dev/null)" ]]; then
+if [[ -x "$COPILOT_BIN" ]]; then
   log_ok "GitHub Copilot CLI already installed"
   exit 0
 fi
 
-log_info "Installing GitHub Copilot CLI binary..."
+log_info "Installing GitHub Copilot CLI..."
 
-# gh 2.89.0+ checks update.IsCI() before showing the install prompt (pkg/cmd/copilot/copilot.go).
-# When CI=true, IsCI() returns true and gh downloads the binary non-interactively.
-# The binary is installed as ~/.local/share/gh/copilot/copilot (named "copilot", not "gh-copilot").
-# timeout 60: the copilot binary may wait for input after download — kill it once install is done.
-CI=true timeout 60 gh copilot >/dev/null 2>&1 || true
-
-if [[ -d "$COPILOT_INSTALL_DIR" ]] && [[ -n "$(ls -A "$COPILOT_INSTALL_DIR" 2>/dev/null)" ]]; then
-  log_ok "GitHub Copilot CLI installed"
+# Official install script. Non-root: installs to ~/.local/bin/copilot (in PATH).
+# Root: installs to /usr/local/bin/copilot.
+if curl -fsSL https://gh.io/copilot-install | bash; then
+  if [[ -x "$COPILOT_BIN" ]]; then
+    log_ok "GitHub Copilot CLI installed"
+  else
+    log_warn "Install script ran but binary not found at ${COPILOT_BIN} — may need manual install"
+  fi
 else
-  log_warn "Could not auto-install Copilot CLI binary — run 'gh copilot' in your terminal to install manually"
+  log_warn "Could not install GitHub Copilot CLI — run 'curl -fsSL https://gh.io/copilot-install | bash' manually"
 fi


### PR DESCRIPTION
## Summary

Replaces the \CI=true gh copilot\ shim approach with the official standalone GitHub Copilot CLI install script.

## Root Cause

\gh copilot\ is a shim wrapper that delegates to the standalone \github/copilot-cli\ binary. When the binary isn't present, the shim prompts interactively — which fails in CI and means \copilot --version\ doesn't work after container setup.

## Changes

- **\scripts/linux/tools/copilot-cli.sh\**: Replaced entirely
  - Idempotency check: \~/.local/bin/copilot\ exists and is executable (not the shim dir)
  - Install: \curl -fsSL https://gh.io/copilot-install | bash\ (official \github/copilot-cli\ script)
  - Removes \gh auth\ requirement for the install step
  - Binary lands in \~/.local/bin\ — already in PATH via dev-setup managed block

## Testing

- \ash -n scripts/linux/tools/copilot-cli.sh\ — syntax clean ✅
- Idempotent: re-running when \~/.local/bin/copilot\ exists exits 0 immediately ✅

Closes #81