### PR TITLE
feat: add tmux to system prerequisites (#83)

### DIFF
--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -63,10 +63,10 @@ install_prerequisites() {
       log_warn "Homebrew not found — install it from https://brew.sh and re-run setup"
       return 0
     fi
-    brew install curl git
+    brew install curl git tmux
   else
     sudo apt-get update -qq
-    sudo apt-get install -y curl git build-essential vim
+    sudo apt-get install -y curl git build-essential vim tmux
   fi
 
   log_ok "Prerequisites installed"


### PR DESCRIPTION
Closes #83

Adds tmux to install_prerequisites() for both macOS (brew) and Linux/WSL (apt-get). The .aliases file and start_up() both depend on tmux being present.

## Changes
- macOS: brew install curl git tmux
- Linux/WSL: apt-get install ... vim tmux

## Validation
- [x] bash -n scripts/linux/setup.sh passes