### PR TITLE
feat(aliases): add va alias to edit ~/.aliases in vim

### DIFF
--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -91,6 +91,7 @@ alias sb="source ~/.bashrc"                   # reload bash config
 alias vz="vim ~/.zshrc"                       # edit zsh config in vim
 alias sz="source ~/.zshrc"                    # reload zsh config
 alias vv="vim ~/.vimrc"                       # edit vim config in vim
+alias va="vim ~/.aliases"                     # edit aliases file in vim
 
 # ── Dev shortcuts ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds `alias va="vim ~/.aliases"` to the Utility section of `config/dotfiles/.aliases`, grouped with the existing `vb`, `vz`, and `vv` vim-editor aliases. Includes required inline comment.

Closes #85

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>