### PR TITLE
fix(dotfiles): enforce LF line endings for shell dotfiles

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "dev-setup Dev Container",
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 
-    "onCreateCommand": "find . -name '*.sh' | xargs sed -i 's/\\r//'",
+    "onCreateCommand": "find . -name '*.sh' -o -name '.aliases' -o -name '.vimrc' -o -name '*.template' | xargs sed -i 's/\\r//'",
 
     "postCreateCommand": ["bash", "-c", "bash setup.sh && git config --global user.name \"${GIT_AUTHOR_NAME:-Earl Tankard, Jr., Ph.D.}\" && git config --global user.email \"${GIT_AUTHOR_EMAIL:-45021016+primetimetank21@users.noreply.github.com}\""],
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,15 @@
 # Shell scripts must always use LF — CRLF breaks bash on Linux/Devcontainers
 *.sh   text eol=lf
 *.bash text eol=lf
+config/dotfiles/.aliases         text eol=lf
+config/dotfiles/.vimrc           text eol=lf
+config/dotfiles/.zshrc.template  text eol=lf
+config/dotfiles/.npmrc.template  text eol=lf
+config/dotfiles/.gitconfig.template text eol=lf
+config/dotfiles/.editorconfig    text eol=lf
+config/dotfiles/install.sh       text eol=lf
+setup.sh                         text eol=lf
+setup.ps1                        -text
 
 # Squad: union merge for append-only team state files
 .squad/decisions.md merge=union


### PR DESCRIPTION
## Summary

Fixes #87

Dotfiles like `.aliases` weren't covered by the existing CRLF-strip in `onCreateCommand` because they're not `.sh` files. On Windows checkouts, these files get `\r` characters that appear as `^M` errors when sourced in the Linux devcontainer.

## Changes

- **`.gitattributes`**: Added `text eol=lf` rules for `.aliases`, `.vimrc`, `.zshrc.template`, `.npmrc.template`, `.gitconfig.template`, `.editorconfig`, `config/dotfiles/install.sh`, and `setup.sh`. Marked `setup.ps1` as `-text`. Preserved all existing `merge=union` entries.
- **`devcontainer.json`**: Expanded `onCreateCommand` to strip `\r` from `.aliases`, `.vimrc`, and `*.template` files (belt-and-suspenders alongside `.gitattributes`).
- **Renormalized**: Ran `git add --renormalize .` to fix any already-checked-out files with CRLF.

## Testing

- Verify `.aliases` sources cleanly in devcontainer (no `^M` errors)
- Verify `git checkout` on Windows writes LF for all covered dotfiles
