### PR TITLE
fix: guard sb and sz aliases to their respective shells

### DIFF
--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -87,9 +87,9 @@ alias myip='curl -s ifconfig.me'
 alias pb='ping bing.com'              # quick connectivity check
 alias ports='ss -tulnp'
 alias vb="vim ~/.bashrc"                      # edit bash config in vim
-alias sb="source ~/.bashrc"                   # reload bash config
+alias sb='[[ -n "$BASH_VERSION" ]] && source ~/.bashrc || echo "[sb] Not in bash — use sz"'   # reload bash config (bash only)
 alias vz="vim ~/.zshrc"                       # edit zsh config in vim
-alias sz="source ~/.zshrc"                    # reload zsh config
+alias sz='[[ -n "$ZSH_VERSION"  ]] && source ~/.zshrc  || echo "[sz] Not in zsh — use sb"'    # reload zsh config (zsh only)
 alias vv="vim ~/.vimrc"                       # edit vim config in vim
 alias va="vim ~/.aliases"                     # edit aliases file in vim
 


### PR DESCRIPTION
Fixes #92

## Problem
Running \sb\ in zsh sources \~/.bashrc\ which contains bash-specific syntax (\shopt\, PS1 escape sequences), causing errors and prompt corruption. Symmetric issue exists for \sz\ in bash.

## Fix
- \sb\: checks \\\ before sourcing; prints \[sb] Not in bash — use sz\ otherwise
- \sz\: checks \\\ before sourcing; prints \[sz] Not in zsh — use sb\ otherwise

## Testing
- Run \sb\ in zsh → should print redirect message, no errors
- Run \sz\ in bash → should print redirect message, no errors
- Run \sb\ in bash → should reload ~/.bashrc normally
- Run \sz\ in zsh → should reload ~/.zshrc normally