### PR TITLE
chore: sprint wrap — ban squash merges, close issue #97

### DIFF
--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -14,7 +14,9 @@ Sequence before any merge:
 1. Wait for CI green on the PR
 2. Call `gh pr review {n} --approve` as Mickey
 3. Verify approval recorded on GitHub
-4. Only then: `gh pr merge {n} --squash --delete-branch`
+4. Only then: `gh pr merge {n} --merge --delete-branch`
+
+**Important:** For sprint wrap PRs (develop → main), always use `--merge`. Regular merge commits keep develop and main histories in sync. **Never `--squash` — causes history divergence on protected branches.**
 
 Violation history: Sprint 2 (PRs #17-#27), Sprint 3 (PRs #33-#36). Branch protection on `develop` now enforces this at the GitHub level (Sprint 4).
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -874,6 +874,17 @@ Sprint wrap PRs from develop → main must use REGULAR merge commits (not squash
 
 develop is branch-protected (can't delete or force-push). Regular merges keep histories connected automatically. This eliminates the need for post-sprint develop reset operations.
 
+## [20260412T020010] User Directive — No-Squash for Sprint Wrap PRs
+
+**By:** Earl Tankard, Jr., Ph.D. (via Copilot)  
+**Date:** 2026-04-12T02:00:10Z
+
+**What:** Going forward, ALL sprint wrap PRs (develop → main) MUST use regular merge commits. NEVER squash.
+
+**Why:** Squash merges create permanent history divergence because develop is branch-protected. Regular merges keep both branches in sync.
+
+**Rationale:** This is a hard rule with no exceptions.
+
 ---
 
 ## Governance

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -254,8 +254,11 @@ gh pr merge {pr-number} --merge --delete-branch
 
 **GitHub (squash):**
 ```bash
+# ⚠️ NEVER use for sprint wrap PRs (develop → main)
 gh pr merge {pr-number} --squash --delete-branch
 ```
+
+**Sprint Wrap PRs (develop → main):** Always use `--merge` (regular merge commits). Squash merges cause permanent history divergence on protected branches. See `.squad/decisions.md` for rationale.
 
 **Azure DevOps:**
 ```bash


### PR DESCRIPTION
## Sprint Wrap

Regular merge (not squash) — per the new policy established this session.

### Changes
- \chore: update sprint wrap process — use regular merge commits\ (Closes #97)
- \docs(squad): final sync — no-squash directive, PR #98 regular merge\

### What's included
- Ralph's charter updated: sprint wrap PRs use \--merge\, never \--squash\
- \issue-lifecycle.md\ template updated with explicit sprint wrap guidance
- Final no-squash directive merged into \decisions.md\

Closes #97