### PR TITLE
docs: codify direct-push-to-main override policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,29 @@ Keep the summary under 72 characters. Add a body if the change needs more contex
 
 ---
 
+## Direct-Push Override Policy
+
+Normally, all changes flow through PRs into `develop`. Direct pushes to `main` are **never** allowed as routine workflow.
+
+**Exception: Hotfix Override**
+
+A direct push to `main` is permitted ONLY when ALL of the following conditions are met:
+
+1. A critical regression or broken state is on `main` that blocks users
+2. The fix is small, surgical, and fully understood (not exploratory)
+3. `develop` itself is broken or the PR pipeline cannot be expedited
+4. The repo owner (Earl Tankard) explicitly authorizes the override in session
+
+**Required audit trail:**
+
+- Commit message must include `[hotfix-override]` annotation
+- A squad decision record must be written to `.squad/decisions/inbox/` documenting: what was pushed, why, and who authorized
+- The override must be referenced in the next sprint retro
+
+**Reference:** The 2026-04-18 hotfix session (PS 5.x `$MyInvocation.MyCommand.Path` regression) is the canonical example of an authorized override.
+
+---
+
 ---
 
 ## Parallel Agent Work


### PR DESCRIPTION
## Summary

Adds a **Direct-Push Override Policy** section to `CONTRIBUTING.md`, codifying the conditions under which a direct push to `main` is permitted as a hotfix escape hatch.

## What changed

- New section in `CONTRIBUTING.md` between **Code Review** and **Parallel Agent Work**
- Documents the four required conditions for a hotfix override
- Specifies the audit trail: `[hotfix-override]` commit annotation, decision record, retro reference
- References the 2026-04-18 PS 5.x hotfix session as the canonical precedent

## Why

The 2026-04-18 sprint retro identified that the override process was ad-hoc. This formalizes the policy so future overrides have a clear checklist and audit trail.

Closes #110