### PR TITLE
fix(setup): replace em-dash in root setup.ps1; refresh PATH after vim install

### DIFF
--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -156,3 +156,18 @@
 
 Designed and implemented PS 5.1 validation job using `windows-latest` runner with Windows PowerShell 5.1. Used `shell: powershell` to invoke native PS 5.1, Parser::ParseFile for syntax validation, and PSScriptAnalyzer for linting. Dual-runtime coverage now active (PS 7+ and PS 5.1). Issue closed.
 
+---
+
+### 2026-04-18 — Hotfix: CI em-dash + vim PATH (Issues #123, #107)
+
+**Branch:** `squad/fix-ci-vim-path`
+**PR:** [#126](https://github.com/primetimetank21/dev-setup/pull/126)
+
+**What I fixed:**
+1. **CI failure (PSUseBOMForUnicodeEncodedFile):** Replaced UTF-8 em-dash (U+2014) on line 63 of root `setup.ps1` with ASCII `--`. This non-ASCII byte triggered PSScriptAnalyzer's `PSUseBOMForUnicodeEncodedFile` rule, breaking both `Lint PowerShell Scripts` and `Validate PowerShell 5.1 Compatibility` CI jobs. Verified zero non-ASCII bytes remain.
+2. **Vim not on PATH after install:** Added `$env:PATH` refresh in `Install-Vim` (`scripts/windows/setup.ps1`) after `winget install`. Reads Machine + User PATH from the registry so vim is available immediately without restarting the terminal. Added fallback warning if vim still not found on PATH.
+
+**Key decisions:**
+- Used `[System.Environment]::GetEnvironmentVariable('PATH', 'Machine')` — works on PS 5.1+ (no PS6+ auto-vars)
+- Fallback `Write-Warn` keeps user informed without failing the setup
+

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -198,3 +198,19 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Implemented squad-cli global install for Windows and Linux with skip+warn pattern when npm is absent. Established reusable precedent for optional npm-dependent tools. Work shipped as planned. Issue closed.
 
+## Issue #125: Permanently add vim to User PATH after winget install (PR #126)
+
+**Branch:** `squad/fix-ci-vim-path`  
+**Date:** 2026-04-18  
+
+**Problem:** winget's `vim.vim` package does not add vim's directory to the system or user PATH. A simple `$env:PATH` session refresh is not enough — vim is unavailable even after opening a new terminal.
+
+**Fix:** After `winget install`, search `C:\Program Files*\Vim\*\vim.exe` (covers both Program Files and Program Files (x86), plus versioned subfolders like `vim91/`). If found, permanently write the directory to the User PATH registry entry via `[System.Environment]::SetEnvironmentVariable('PATH', ..., 'User')`, then refresh the current session PATH.
+
+**Key details:**
+- `Get-ChildItem` with wildcard glob finds the versioned install directory
+- `Sort-Object -Descending` picks the latest version if multiple exist
+- `SetEnvironmentVariable(..., 'User')` persists across new terminal sessions (registry write)
+- Session PATH also refreshed immediately so vim works without restart
+- PS 5.x compatible: no `$IsWindows`, no `$MyInvocation.MyCommand.Path`, ASCII-only
+

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -76,14 +76,22 @@ function Install-Vim {
     }
     Write-Info "Installing vim..."
     winget install --id vim.vim --silent --accept-source-agreements --accept-package-agreements
-    # Refresh PATH so vim is available in the current session without restarting
-    $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
-                [System.Environment]::GetEnvironmentVariable('PATH', 'User')
-    if (Get-Command vim -ErrorAction SilentlyContinue) {
+    # winget does not reliably add vim to PATH -- find and register it manually
+    $vimExe = Get-ChildItem 'C:\Program Files*\Vim\*\vim.exe' -ErrorAction SilentlyContinue |
+              Sort-Object -Property FullName -Descending |
+              Select-Object -First 1
+    if ($vimExe) {
+        $vimDir = $vimExe.DirectoryName
+        $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+        if ($userPath -notlike "*$vimDir*") {
+            [System.Environment]::SetEnvironmentVariable('PATH', "$userPath;$vimDir", 'User')
+        }
+        $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+                    [System.Environment]::GetEnvironmentVariable('PATH', 'User')
         Write-Ok "vim installed"
     } else {
         Write-Ok "vim installed"
-        Write-Warn "vim not yet on PATH -- restart your terminal to use it"
+        Write-Warn "vim not found on PATH -- restart your terminal or verify C:\Program Files\Vim"
     }
 }
 

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -76,7 +76,15 @@ function Install-Vim {
     }
     Write-Info "Installing vim..."
     winget install --id vim.vim --silent --accept-source-agreements --accept-package-agreements
-    Write-Ok "vim installed"
+    # Refresh PATH so vim is available in the current session without restarting
+    $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+                [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+    if (Get-Command vim -ErrorAction SilentlyContinue) {
+        Write-Ok "vim installed"
+    } else {
+        Write-Ok "vim installed"
+        Write-Warn "vim not yet on PATH -- restart your terminal to use it"
+    }
 }
 
 function Install-CopilotCli {

--- a/setup.ps1
+++ b/setup.ps1
@@ -60,7 +60,7 @@ function Get-Platform {
 function Main {
   # $PSScriptRoot is the reliable automatic variable for the script's directory (PS 3.0+).
   # Fallback to $MyInvocation.MyCommand.Definition for dot-sourced or hosted execution contexts
-  # where $PSScriptRoot may be empty. Avoid .Path — it is null in several common host environments.
+  # where $PSScriptRoot may be empty. Avoid .Path -- it is null in several common host environments.
   $ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Definition }
   $platform  = Get-Platform
 


### PR DESCRIPTION
## Fixes
- Closes #124 — replace non-ASCII em-dash in root `setup.ps1` comment (line 63) with ASCII `--`
- Closes #125 — find vim.exe after winget install, permanently write its directory to User PATH registry, refresh session PATH

## Changes
- `setup.ps1` (root) line 63: em-dash `—` → `--` (fixes `PSUseBOMForUnicodeEncodedFile` CI failure)
- `scripts/windows/setup.ps1` `Install-Vim`: search `C:\Program Files*\Vim\*\vim.exe` post-install, permanently add to User PATH via `SetEnvironmentVariable`

## Why permanent PATH write
Earl confirmed vim is not available even after opening a new terminal. winget's `vim.vim` package does not add vim to PATH. The fix discovers the install location and writes it to the User PATH registry entry so it persists across sessions.

## Testing
- `python3 -c "data=open('setup.ps1','rb').read(); print('non-ascii:', [i for i,b in enumerate(data) if b>127])"` → `[]`
- After `Install-Vim` runs: `vim` works in same session AND new terminal