### PR TITLE
fix(ci): add Test-Path Variable guards for PS 6+ auto-vars in setup.ps1 (#123)

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -27,12 +27,12 @@ function Get-Platform {
   # $IsLinux, $IsMacOS, and $IsWindows are automatic variables introduced in PowerShell 6 (Core).
   # On Windows PowerShell 5.x they do NOT exist, so referencing them directly under Set-StrictMode
   # causes a hard "variable not set" error. To stay PS 5.1-compatible we guard every reference
-  # behind a version check. $PSVersionTable.PSVersion.Major has been available since PS 2.
+  # behind Test-Path Variable:* checks. $PSVersionTable.PSVersion.Major has been available since PS 2.
   # On PS 5.x Windows, $env:OS is always 'Windows_NT', giving us a reliable fallback.
-  $isWin = ($PSVersionTable.PSVersion.Major -ge 6 -and $IsWindows) -or
-            ($PSVersionTable.PSVersion.Major -lt 6 -and $env:OS -eq 'Windows_NT')
-  $isLin = $PSVersionTable.PSVersion.Major -ge 6 -and $IsLinux
-  $isMac = $PSVersionTable.PSVersion.Major -ge 6 -and $IsMacOS
+  $isWin = (Test-Path Variable:IsWindows -and $IsWindows) -or
+            (-not (Test-Path Variable:IsWindows) -and $env:OS -eq 'Windows_NT')
+  $isLin = Test-Path Variable:IsLinux -and $IsLinux
+  $isMac = Test-Path Variable:IsMacOS -and $IsMacOS
 
   if ($isLin -or $isMac) {
     # Unlikely to be reached via PowerShell on Linux/macOS in most setups,


### PR DESCRIPTION
Replaces PSVersionTable version checks with Test-Path Variable:* guards for
IsLinux, IsWindows, and IsMacOS. This syntax is required for PS 5.1 compat
validation and matches the pattern established in scripts/windows/setup.ps1.

The previous version check approach works at runtime but fails PSScriptAnalyzer
validation on both PS 7+ and PS 5.1, and doesn't match the test requirement.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
