### PR TITLE
fix(setup): rename Install-GitHook, remove unused gitDir, restore PSVersion guards

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -317,9 +317,9 @@ function Install-SquadCli {
     Write-Ok "squad-cli installed"
 }
 
-function Install-GitHooks {
+function Install-GitHook {
     Write-Info "Configuring git hooks..."
-    $gitDir = & git rev-parse --git-dir 2>$null
+    & git rev-parse --git-dir 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
         & git config core.hooksPath hooks
         Write-Ok "Git hooks configured (core.hooksPath=hooks)"
@@ -345,7 +345,7 @@ function Main {
     Install-CopilotCli
     Install-SquadCli
     Write-PowerShellProfile
-    Install-GitHooks
+    Install-GitHook
 
     Write-Ok ""
     Write-Ok "Setup complete!"

--- a/setup.ps1
+++ b/setup.ps1
@@ -26,13 +26,13 @@ function Write-Err   { param([string]$Msg) Write-Output "[ERROR] $Msg" }
 function Get-Platform {
   # $IsLinux, $IsMacOS, and $IsWindows are automatic variables introduced in PowerShell 6 (Core).
   # On Windows PowerShell 5.x they do NOT exist, so referencing them directly under Set-StrictMode
-  # causes a hard "variable not set" error. To stay PS 5.1-compatible we guard every reference
-  # behind Test-Path Variable:* checks. $PSVersionTable.PSVersion.Major has been available since PS 2.
+  # causes a hard "variable not set" error. To stay PS 5.1-compatible we use PSVersion-based guards.
+  # $PSVersionTable.PSVersion.Major has been available since PS 2.
   # On PS 5.x Windows, $env:OS is always 'Windows_NT', giving us a reliable fallback.
-  $isWin = (Test-Path Variable:IsWindows -and $IsWindows) -or
-            (-not (Test-Path Variable:IsWindows) -and $env:OS -eq 'Windows_NT')
-  $isLin = Test-Path Variable:IsLinux -and $IsLinux
-  $isMac = Test-Path Variable:IsMacOS -and $IsMacOS
+  $isWin = ($PSVersionTable.PSVersion.Major -ge 6 -and $IsWindows) -or `
+            ($PSVersionTable.PSVersion.Major -lt 6 -and $env:OS -eq 'Windows_NT')
+  $isLin = $PSVersionTable.PSVersion.Major -ge 6 -and $IsLinux
+  $isMac = $PSVersionTable.PSVersion.Major -ge 6 -and $IsMacOS
 
   if ($isLin -or $isMac) {
     # Unlikely to be reached via PowerShell on Linux/macOS in most setups,


### PR DESCRIPTION
## Summary
Fixes two regressions introduced by PR #130.

## Fix 1 — PSScriptAnalyzer warnings (CI unblocked)
- Renamed `Install-GitHooks` → `Install-GitHook` (singular noun, PSUseSingularNouns)
- Removed unused `$gitDir` variable (PSUseDeclaredVarsMoreThanAssignments)
- Updated all call sites

## Fix 2 — PS 5.1 runtime crash (Windows unblocked)
- Reverted `Test-Path Variable:IsWindows` guard back to approved PSVersion-based short-circuit
- Pattern: `($PSVersionTable.PSVersion.Major -ge 6 -and $IsWindows)` — PS 5.x short-circuits before evaluating `$IsWindows`
- `Test-Path Variable:*` fails under `Set-StrictMode -Version Latest` on PS 5.1 even with short-circuit

## Root cause
Chip's PR #130 introduced `Test-Path Variable:*` guards that don't work under PS 5.1 strict mode. The PSVersion-based approach (already in decisions.md) is the correct pattern.

Closes #132