### PR TITLE
fix: hotfix PR #130 regressions — PS5.1 crash + PSScriptAnalyzer warnings

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -387,3 +387,8 @@ Branch protection write via `gh api` is blocked by the Codespace token scope. Th
 - Reviewed and approved PR #126
 - Merged via `--merge --delete-branch --admin` (regular merge commit, branch deleted)
 - Closed #124 and #125 with closing comments
+
+## [2026-04-18] Sprint 7 wrap
+- PR #131: develop → main, regular merge, --admin
+- Sprint 7 complete: hooks (#121), branch isolation docs (#122), CI guards (#123)
+- Stale squad/* branches cleaned up

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -392,3 +392,32 @@ Branch protection write via `gh api` is blocked by the Codespace token scope. Th
 - PR #131: develop → main, regular merge, --admin
 - Sprint 7 complete: hooks (#121), branch isolation docs (#122), CI guards (#123)
 - Stale squad/* branches cleaned up
+
+---
+
+## [2026-04-18] Created bug issue for PR #130 regressions (Issue #132)
+
+**Task:** File combined bug issue covering two regressions from PR #130 merge.
+
+**Bugs identified:**
+1. **PSScriptAnalyzer CI warnings in `scripts/windows/setup.ps1`:**
+   - Line 320: `Install-GitHooks` plural noun → `PSUseSingularNouns` warning (should be `Install-GitHook`)
+   - Line 322: `$gitDir` assigned but never used → `PSUseDeclaredVarsMoreThanAssignments` warning
+   - Affects both lint jobs on CI
+
+2. **Windows PS 5.1 runtime crash in `setup.ps1` (root, line ~32):**
+   - Error: `The variable '$IsWindows' cannot be retrieved because it has not been set.`
+   - Root cause: Chip's PR #130 replaced PSVersion-based guards with `Test-Path Variable:*` guards
+   - Under `Set-StrictMode -Version Latest` on PS 5.1, `$IsWindows` is undefined and throws even with short-circuit `-and`
+   - Fix: Revert to approved PSVersion-based guard pattern (already in decisions.md)
+
+**Issue created:** [#132](https://github.com/primetimetank21/dev-setup/issues/132)
+**Assigned to:** Goofy (via `squad:goofy` label)
+**Acceptance criteria:** Includes all fixes, CI passes, PS 5.1 compat verified
+
+**Key learning:** PR #130 merged with both a linting regression (unused var + function name convention) and a runtime regression (guard pattern incompatible with PS 5.1 strict mode). Demonstrates need for stricter pre-merge validation of PowerShell changes under strict mode before landing on develop/main.
+
+## [2026-04-18] #132 PS 5.1 guard regression review
+- Test-Path Variable:* is WRONG under strict mode — always use PSVersion-based short-circuit
+- Merged PR #133: Goofy's fix restoring correct guards
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1850,3 +1850,9 @@ Both are scoped, small, and ready. Include in next sprint planning pass.
 
 Issue #108 was created because `.aliases` shortcuts are currently only applied on Linux/macOS (via `.zshrc`). Windows users running PowerShell get no shell shortcuts at all. This is a feature parity gap. Ensure Sprint 6 planning accounts for the full scope: discovering which aliases are useful in PS context, and adapting them to PS syntax (not just copying bash aliases).
 
+
+## [2026-04-18]: Sprint 7 wrap — develop → main
+
+**By:** Mickey
+**What:** Merged develop → main via PR #131 (regular merge commit). Sprint 7 complete: git hooks (#121), branch isolation docs (#122), CI PS guards (#123).
+**Why:** Sprint 7 all issues closed, develop ahead of main.

--- a/.squad/decisions/inbox/mickey-review-133.md
+++ b/.squad/decisions/inbox/mickey-review-133.md
@@ -1,0 +1,5 @@
+### [2026-04-18]: Test-Path Variable:* DOES NOT work under PS 5.1 strict mode (#132)
+**By:** Mickey
+**What:** Confirmed that (Test-Path Variable:IsWindows -and $IsWindows) throws VariableIsUndefined under Set-StrictMode -Version Latest on PS 5.1, even with short-circuit -and.
+**Correct pattern:** ($PSVersionTable.PSVersion.Major -ge 6 -and $IsWindows) — PSVersion check short-circuits first, $IsWindows is never evaluated on PS 5.x.
+**Why:** Regression from Chip's PR #130 CI "fix". PSVersion-based guards are the only safe approach.

--- a/.squad/decisions/inbox/mickey-sprint7-wrap.md
+++ b/.squad/decisions/inbox/mickey-sprint7-wrap.md
@@ -1,4 +1,0 @@
-### [2026-04-18]: Sprint 7 wrap — develop → main
-**By:** Mickey
-**What:** Merged develop → main via PR #131 (regular merge commit). Sprint 7 complete: git hooks (#121), branch isolation docs (#122), CI PS guards (#123).
-**Why:** Sprint 7 all issues closed, develop ahead of main.

--- a/.squad/decisions/inbox/mickey-sprint7-wrap.md
+++ b/.squad/decisions/inbox/mickey-sprint7-wrap.md
@@ -1,0 +1,4 @@
+### [2026-04-18]: Sprint 7 wrap — develop → main
+**By:** Mickey
+**What:** Merged develop → main via PR #131 (regular merge commit). Sprint 7 complete: git hooks (#121), branch isolation docs (#122), CI PS guards (#123).
+**Why:** Sprint 7 all issues closed, develop ahead of main.

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -317,9 +317,9 @@ function Install-SquadCli {
     Write-Ok "squad-cli installed"
 }
 
-function Install-GitHooks {
+function Install-GitHook {
     Write-Info "Configuring git hooks..."
-    $gitDir = & git rev-parse --git-dir 2>$null
+    & git rev-parse --git-dir 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
         & git config core.hooksPath hooks
         Write-Ok "Git hooks configured (core.hooksPath=hooks)"
@@ -345,7 +345,7 @@ function Main {
     Install-CopilotCli
     Install-SquadCli
     Write-PowerShellProfile
-    Install-GitHooks
+    Install-GitHook
 
     Write-Ok ""
     Write-Ok "Setup complete!"

--- a/setup.ps1
+++ b/setup.ps1
@@ -26,13 +26,13 @@ function Write-Err   { param([string]$Msg) Write-Output "[ERROR] $Msg" }
 function Get-Platform {
   # $IsLinux, $IsMacOS, and $IsWindows are automatic variables introduced in PowerShell 6 (Core).
   # On Windows PowerShell 5.x they do NOT exist, so referencing them directly under Set-StrictMode
-  # causes a hard "variable not set" error. To stay PS 5.1-compatible we guard every reference
-  # behind Test-Path Variable:* checks. $PSVersionTable.PSVersion.Major has been available since PS 2.
+  # causes a hard "variable not set" error. To stay PS 5.1-compatible we use PSVersion-based guards.
+  # $PSVersionTable.PSVersion.Major has been available since PS 2.
   # On PS 5.x Windows, $env:OS is always 'Windows_NT', giving us a reliable fallback.
-  $isWin = (Test-Path Variable:IsWindows -and $IsWindows) -or
-            (-not (Test-Path Variable:IsWindows) -and $env:OS -eq 'Windows_NT')
-  $isLin = Test-Path Variable:IsLinux -and $IsLinux
-  $isMac = Test-Path Variable:IsMacOS -and $IsMacOS
+  $isWin = ($PSVersionTable.PSVersion.Major -ge 6 -and $IsWindows) -or `
+            ($PSVersionTable.PSVersion.Major -lt 6 -and $env:OS -eq 'Windows_NT')
+  $isLin = $PSVersionTable.PSVersion.Major -ge 6 -and $IsLinux
+  $isMac = $PSVersionTable.PSVersion.Major -ge 6 -and $IsMacOS
 
   if ($isLin -or $isMac) {
     # Unlikely to be reached via PowerShell on Linux/macOS in most setups,


### PR DESCRIPTION
## Summary
Fixes two regressions introduced by PR #130 (git hooks implementation).

### Fixes
- **#132** — `Install-GitHook` (singular noun) + `$gitDir` unused removed — PSScriptAnalyzer CI clean
- **#132** — Root `setup.ps1` PSVersion-based short-circuit guards restored — PS 5.1 strict mode crash fixed

### Root cause
Chip's PR #130 introduced `Test-Path Variable:*` guards that fail under `Set-StrictMode -Version Latest` on PS 5.1. PSVersion-based short-circuit (`Major -ge 6 -and $IsWindows`) is the correct approved pattern.

Regular merge commit. No squash.