### PR TITLE
feat: add psmux install to Windows setup

### DIFF
--- a/.squad/decisions/inbox/goofy-psmux-aliases.md
+++ b/.squad/decisions/inbox/goofy-psmux-aliases.md
@@ -1,0 +1,31 @@
+# Decision: psmux aliases in Windows PowerShell profile
+
+**Issue:** #140
+**Agent:** Goofy (Cross-Platform Developer)
+**Date:** 2025-07-17
+
+## Context
+
+The Linux/macOS setup defines tmux aliases (`tls`, `tks`, `tt`, `ta`) and a `create_tmux` function in `config/dotfiles/.aliases`. Windows had no equivalent.
+
+## Decisions
+
+### 1. Use psmux as the tmux equivalent
+**Choice:** Map all tmux aliases to `psmux` commands instead of tmux.
+**Why:** psmux is the Windows-native terminal multiplexer. The aliases mirror the Linux tmux workflow using the same short names (`tls`, `tks`, `tt`, `ta`).
+
+### 2. Follow existing Invoke-* / Set-Alias pattern
+**Choice:** Each alias gets a wrapper function (`Invoke-PsmuxList`, etc.) with a corresponding `Set-Alias`.
+**Why:** Matches the established convention in the `$profileContent` heredoc for all other aliases (git, gh, dev shortcuts).
+
+### 3. New-PsmuxSession as a named function (no alias)
+**Choice:** `New-PsmuxSession` is called by name, not aliased.
+**Why:** Mirrors `create_tmux` on Linux which is a function called directly. PowerShell verb-noun naming is idiomatic here.
+
+### 4. Test group placed as Group I
+**Choice:** Tests go in Group I (not Group F as originally specified in the issue).
+**Why:** Groups F, G, and H were already taken by existing tests. Used next available letter.
+
+## Outcome
+
+Windows PowerShell profile now has full psmux alias parity with Linux tmux aliases.

--- a/.squad/decisions/inbox/goofy-psmux-placement.md
+++ b/.squad/decisions/inbox/goofy-psmux-placement.md
@@ -1,0 +1,31 @@
+# Decision: psmux install placement and test group (Issue #139)
+
+**Date:** 2025-07-17
+**Author:** Goofy (Cross-Platform Developer)
+**Issue:** #139
+
+## Context
+
+Adding psmux (tmux equivalent for Windows PowerShell) to the Windows setup script.
+
+## Decisions
+
+### 1. Function placement -- after Install-Vim, before Install-CopilotCli
+
+Install-Psmux is a standalone terminal tool (like vim), so it belongs with other editor/terminal tools. Placed after vim and before Copilot CLI which is a developer service integration, not a terminal tool.
+
+### 2. Main call order -- mirrors function placement
+
+Install-Psmux is called between Install-Vim and Install-CopilotCli in Main, keeping the call order consistent with function definition order.
+
+### 3. No PATH patching (unlike vim)
+
+psmux does not need the manual PATH workaround that vim requires. winget handles PATH registration for psmux correctly. If this changes, a follow-up can add it.
+
+### 4. Test group letter -- Group H (not E)
+
+The task template suggested "Group E" but Groups A-G already exist in the test file. Used Group H to follow the sequential naming convention.
+
+### 5. AST-based tests instead of string matching
+
+Used `[System.Management.Automation.Language.Parser]::ParseFile()` for function existence checks rather than simple `Select-String` patterns. This is more robust (catches renamed/commented-out functions) and aligns with the CI PS 5.1 validation approach documented in decisions.md.

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -95,6 +95,17 @@ function Install-Vim {
     }
 }
 
+# psmux - tmux equivalent for Windows PowerShell terminal multiplexer.
+function Install-Psmux {
+    if (Get-Command psmux -ErrorAction SilentlyContinue) {
+        Write-Ok "psmux already installed: $(psmux --version 2>&1)"
+        return
+    }
+    Write-Info "Installing psmux..."
+    winget install psmux --silent --accept-source-agreements --accept-package-agreements
+    Write-Ok "psmux installed"
+}
+
 function Install-CopilotCli {
     # Accept either the standalone binary (winget) or the legacy gh extension
     if (Get-Command copilot -ErrorAction SilentlyContinue) {
@@ -284,6 +295,30 @@ Set-Alias -Name pb -Value Invoke-PingBing
 Remove-Item -Force Alias:\h -ErrorAction SilentlyContinue
 Set-Alias -Name h -Value Get-History                        # command history
 
+# -- psmux (tmux for Windows) -----------------------------------------------
+
+function Invoke-PsmuxList { psmux ls $args }                    # list active psmux sessions
+Set-Alias -Name tls -Value Invoke-PsmuxList
+
+function Invoke-PsmuxKillServer { psmux kill-server $args }     # kill all psmux sessions
+Set-Alias -Name tks -Value Invoke-PsmuxKillServer
+
+function Invoke-PsmuxNewSession { psmux new-session -s tank_dev $args }  # create new named psmux session
+Set-Alias -Name tt -Value Invoke-PsmuxNewSession
+
+function Invoke-PsmuxAttach { psmux attach $args }              # attach to most recent psmux session
+Set-Alias -Name ta -Value Invoke-PsmuxAttach
+
+# Create or attach to the tank_dev psmux session (Windows equivalent of create_tmux)
+function New-PsmuxSession {
+    $session = 'tank_dev'
+    $exists = psmux ls 2>$null | Select-String -Pattern $session -Quiet
+    if (-not $exists) {
+        psmux new-session -d -s $session
+    }
+    psmux attach -t $session
+}
+
 # END dev-setup profile
 '@
 
@@ -342,6 +377,7 @@ function Main {
     Install-Nvm
     Install-GhCli
     Install-Vim
+    Install-Psmux
     Install-CopilotCli
     Install-SquadCli
     Write-PowerShellProfile

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -505,6 +505,90 @@ Test-Scenario "G-4: No MyInvocation.MyCommand.Path in Install-SquadCli" {
 }
 
 # ---------------------------------------------------------------------------
+# Group H: Install-Psmux (Issue #139)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group H: psmux install (Issue #139)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "H-1: Install-Psmux function exists in setup.ps1" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $fn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Install-Psmux' }, $true)
+    if ($fn.Count -eq 0) {
+        throw "Install-Psmux function not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "H-2: Install-Psmux is called in Main" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $mainFn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Main' }, $true)
+    if ($mainFn.Count -eq 0) { throw "Main function not found" }
+    $mainBody = $mainFn[0].Body.Extent.Text
+    if ($mainBody -notmatch 'Install-Psmux') {
+        throw "Install-Psmux is not called in Main"
+    }
+}
+
+Test-Scenario "H-3: Install-Psmux is idempotent (checks before installing)" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $fn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Install-Psmux' }, $true)
+    if ($fn.Count -eq 0) { throw "Install-Psmux function not found" }
+    $fnBody = $fn[0].Body.Extent.Text
+    if ($fnBody -notmatch 'Get-Command psmux') {
+        throw "Install-Psmux does not check for psmux before installing (missing Get-Command psmux)"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Group I: psmux aliases in PowerShell profile (Issue #140)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group I: psmux aliases in PowerShell profile (Issue #140)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "I-1: psmux alias functions exist in profile content" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    $requiredFunctions = @('Invoke-PsmuxList', 'Invoke-PsmuxKillServer', 'Invoke-PsmuxNewSession', 'Invoke-PsmuxAttach')
+    foreach ($fn in $requiredFunctions) {
+        if ($setupContent -notmatch $fn) {
+            throw "Missing psmux alias function '$fn' in scripts/windows/setup.ps1"
+        }
+    }
+}
+
+Test-Scenario "I-2: psmux Set-Alias entries exist for tls, tks, tt, ta" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    $requiredAliases = @('tls', 'tks', 'tt', 'ta')
+    foreach ($alias in $requiredAliases) {
+        if ($setupContent -notmatch "Set-Alias\s+-Name\s+$alias\b") {
+            throw "Missing Set-Alias for '$alias' in scripts/windows/setup.ps1"
+        }
+    }
+}
+
+Test-Scenario "I-3: New-PsmuxSession function exists in profile content" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'function New-PsmuxSession') {
+        throw "New-PsmuxSession function not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "I-4: New-PsmuxSession checks for existing session before creating" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'psmux ls') {
+        throw "New-PsmuxSession does not contain 'psmux ls' session check"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Adds `Install-Psmux` to the Windows setup script. psmux is the tmux equivalent for Windows PowerShell.

## Changes
- `scripts/windows/setup.ps1`: new `Install-Psmux` function using `winget install psmux`; idempotent (checks if already installed); called from `Main` after `Install-Vim` and before `Install-CopilotCli`
- `tests/test_windows_setup.ps1`: Group H tests -- validates function existence (AST), Main call, idempotency pattern
- `.squad/decisions/inbox/goofy-psmux-placement.md`: decision note on placement and test group naming

## Testing
Static AST analysis tests in Group H. CI validates PS syntax and script analysis.

Closes #139