### PR TITLE
feat: add psmux aliases and New-PsmuxSession to Windows PS profile

### DIFF
--- a/.squad/decisions/inbox/goofy-psmux-aliases.md
+++ b/.squad/decisions/inbox/goofy-psmux-aliases.md
@@ -1,0 +1,31 @@
+# Decision: psmux aliases in Windows PowerShell profile
+
+**Issue:** #140
+**Agent:** Goofy (Cross-Platform Developer)
+**Date:** 2025-07-17
+
+## Context
+
+The Linux/macOS setup defines tmux aliases (`tls`, `tks`, `tt`, `ta`) and a `create_tmux` function in `config/dotfiles/.aliases`. Windows had no equivalent.
+
+## Decisions
+
+### 1. Use psmux as the tmux equivalent
+**Choice:** Map all tmux aliases to `psmux` commands instead of tmux.
+**Why:** psmux is the Windows-native terminal multiplexer. The aliases mirror the Linux tmux workflow using the same short names (`tls`, `tks`, `tt`, `ta`).
+
+### 2. Follow existing Invoke-* / Set-Alias pattern
+**Choice:** Each alias gets a wrapper function (`Invoke-PsmuxList`, etc.) with a corresponding `Set-Alias`.
+**Why:** Matches the established convention in the `$profileContent` heredoc for all other aliases (git, gh, dev shortcuts).
+
+### 3. New-PsmuxSession as a named function (no alias)
+**Choice:** `New-PsmuxSession` is called by name, not aliased.
+**Why:** Mirrors `create_tmux` on Linux which is a function called directly. PowerShell verb-noun naming is idiomatic here.
+
+### 4. Test group placed as Group H
+**Choice:** Tests go in Group H, the next available letter after Group G (Install-SquadCli).
+**Why:** Groups A through G were already taken by existing test groups.
+
+## Outcome
+
+Windows PowerShell profile now has full psmux alias parity with Linux tmux aliases.

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -284,6 +284,30 @@ Set-Alias -Name pb -Value Invoke-PingBing
 Remove-Item -Force Alias:\h -ErrorAction SilentlyContinue
 Set-Alias -Name h -Value Get-History                        # command history
 
+# -- psmux (tmux for Windows) -----------------------------------------------
+
+function Invoke-PsmuxList { psmux ls $args }                    # list active psmux sessions
+Set-Alias -Name tls -Value Invoke-PsmuxList
+
+function Invoke-PsmuxKillServer { psmux kill-server $args }     # kill all psmux sessions
+Set-Alias -Name tks -Value Invoke-PsmuxKillServer
+
+function Invoke-PsmuxNewSession { psmux new-session -s tank_dev $args }  # create new named psmux session
+Set-Alias -Name tt -Value Invoke-PsmuxNewSession
+
+function Invoke-PsmuxAttach { psmux attach $args }              # attach to most recent psmux session
+Set-Alias -Name ta -Value Invoke-PsmuxAttach
+
+# Create or attach to the tank_dev psmux session (Windows equivalent of create_tmux)
+function New-PsmuxSession {
+    $session = 'tank_dev'
+    $exists = psmux ls 2>$null | Select-String -Pattern $session -Quiet
+    if (-not $exists) {
+        psmux new-session -d -s $session
+    }
+    psmux attach -t $session
+}
+
 # END dev-setup profile
 '@
 

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -505,6 +505,48 @@ Test-Scenario "G-4: No MyInvocation.MyCommand.Path in Install-SquadCli" {
 }
 
 # ---------------------------------------------------------------------------
+# Group H: psmux aliases in PowerShell profile (Issue #140)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group H: psmux aliases in PowerShell profile (Issue #140)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "H-1: psmux alias functions exist in profile content" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    $requiredFunctions = @('Invoke-PsmuxList', 'Invoke-PsmuxKillServer', 'Invoke-PsmuxNewSession', 'Invoke-PsmuxAttach')
+    foreach ($fn in $requiredFunctions) {
+        if ($setupContent -notmatch $fn) {
+            throw "Missing psmux alias function '$fn' in scripts/windows/setup.ps1"
+        }
+    }
+}
+
+Test-Scenario "H-2: psmux Set-Alias entries exist for tls, tks, tt, ta" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    $requiredAliases = @('tls', 'tks', 'tt', 'ta')
+    foreach ($alias in $requiredAliases) {
+        if ($setupContent -notmatch "Set-Alias\s+-Name\s+$alias\b") {
+            throw "Missing Set-Alias for '$alias' in scripts/windows/setup.ps1"
+        }
+    }
+}
+
+Test-Scenario "H-3: New-PsmuxSession function exists in profile content" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'function New-PsmuxSession') {
+        throw "New-PsmuxSession function not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "H-4: New-PsmuxSession checks for existing session before creating" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'psmux ls') {
+        throw "New-PsmuxSession does not contain 'psmux ls' session check"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Adds psmux (tmux for Windows) aliases and a `New-PsmuxSession` function to the PowerShell profile injected by `Write-PowerShellProfile`.

## Changes
- `scripts/windows/setup.ps1`: psmux section in `$profileContent` with `Invoke-Psmux*` wrappers, `Set-Alias` entries for `tls`/`tks`/`tt`/`ta`, and `New-PsmuxSession` function
- `tests/test_windows_setup.ps1`: Group H tests -- validates all alias functions and `New-PsmuxSession` exist in profile content

## Mapping (Linux -> Windows)
| Linux | Windows |
|-------|---------|
| `tls` = `tmux ls` | `tls` -> `Invoke-PsmuxList` -> `psmux ls` |
| `tks` = `tmux kill-server` | `tks` -> `Invoke-PsmuxKillServer` -> `psmux kill-server` |
| `tt` = `tmux new-session -s tank_dev` | `tt` -> `Invoke-PsmuxNewSession` -> `psmux new-session -s tank_dev` |
| `ta` = `tmux attach` | `ta` -> `Invoke-PsmuxAttach` -> `psmux attach` |
| `create_tmux` | `New-PsmuxSession` |

Closes #140