### PR TITLE
fix: Write-PowerShellProfile strips and re-injects profile block instead of skipping

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -241,3 +241,24 @@ Implemented squad-cli global install for Windows and Linux with skip+warn patter
 
 **PR #133 merged** by Mickey with --admin flag. Issue #132 closed.
 
+## [2026-04-18] Fix Write-PowerShellProfile sentinel skip logic (Issue #144, PR #145)
+**Branch:** `squad/fix-sentinel-update-logic`
+**Status:** ✅ Committed, PR opened
+
+**Problem:** Write-PowerShellProfile used "skip if sentinel present" logic. Users who ran setup.ps1 before PRs #141/#142 (psmux aliases) never got the new aliases — `ta`, `tks`, `tls`, `tt` were undefined because the function returned early.
+
+**Fix:** Changed to "strip + re-inject" pattern:
+- When BEGIN/END markers found, remove the old managed block entirely with regex
+- Fall through to inject the current fresh block (never skip)
+- Regex: `(?s)\r?\n$([regex]::Escape($beginMarker)).*?$([regex]::Escape($endMarker))\r?\n?`
+- Handles both CRLF (Windows) and LF line endings
+- Added `Write-Info "Updating PowerShell profile shortcuts..."` when updating existing profile
+
+**Tests added (Group J):**
+- J-1: BEGIN marker present in function body
+- J-2: END marker present in function body
+- J-3: No 'return' after sentinel check (verifies skip removed)
+- J-4: Get-Content/Set-Content present (verifies strip logic)
+
+**Key learning:** Sentinel-based idempotency that skips updates breaks incremental feature additions. Always use "strip managed content + re-inject fresh" for configuration blocks that evolve over time.
+

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -488,3 +488,26 @@ Test now correctly validates the actual implementation pattern. This resolves th
 
 **This closes the follow-up from the earlier PR #130/PR #133 regression work.**
 
+## [2026-04-19] PR #145 Review — Write-PowerShellProfile strip+re-inject fix
+
+**PR:** #145 (`squad/fix-sentinel-update-logic` → `develop`)
+**Author:** Goofy (via Copilot)
+**Issue:** #144 (child of #138)
+**Verdict:** ✅ APPROVED
+
+Reviewed strip+re-inject logic replacing the old "skip if sentinel present" pattern. All checklist items passed:
+- Regex `(?s)\r?\n<BEGIN>.*?<END>\r?\n?` handles both LF and CRLF
+- No `return` in sentinel path — strips old block, falls through to inject fresh
+- `Write-Info` message shown on update (not first install)
+- `Set-Content -NoNewline` preserves raw content correctly
+- Group J tests (J-1 to J-4) cover markers, no-return, and strip logic
+- Groups A-I unaffected
+- Conventional commit format correct
+
+**Non-blocking nit:** PR body says "Closes #138" instead of "Closes #144". #144 is the specific child issue; #138 is the broader parent.
+
+### Learnings
+
+- Sentinel-based idempotency that skips entirely breaks incremental feature additions. "Strip managed block + re-inject fresh" is the correct pattern for evolving config blocks.
+- When reviewing regex for profile management, always verify the leading/trailing newline anchors handle both LF and CRLF.
+

--- a/.squad/decisions/inbox/mickey-pr145-review.md
+++ b/.squad/decisions/inbox/mickey-pr145-review.md
@@ -1,0 +1,18 @@
+# Decision: Adopt strip+re-inject pattern for managed config blocks
+
+**Date:** 2026-04-19
+**Author:** Mickey (Lead)
+**Context:** PR #145 review (Issue #144)
+
+## Decision
+
+All managed config blocks (e.g., `# BEGIN dev-setup profile` / `# END dev-setup profile`) must use the **strip + re-inject** pattern instead of **skip if sentinel present**. This ensures re-running setup always converges to the latest managed content.
+
+## Rationale
+
+The old skip pattern silently dropped new aliases/functions for users who ran setup before those features were added. The strip+re-inject pattern preserves user content outside the markers while always injecting the current block.
+
+## Applies To
+
+- `Write-PowerShellProfile` in `scripts/windows/setup.ps1`
+- Any future managed block injection (Linux shell configs, etc.)

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -130,12 +130,16 @@ function Install-CopilotCli {
 }
 
 function Write-PowerShellProfile {
-    $sentinel = '# BEGIN dev-setup profile'
+    $beginMarker = '# BEGIN dev-setup profile'
+    $endMarker   = '# END dev-setup profile'
 
-    # Idempotency check - skip if already written
-    if ((Test-Path $PROFILE) -and (Select-String -Path $PROFILE -Pattern ([regex]::Escape($sentinel)) -Quiet)) {
-        Write-Ok "PowerShell profile shortcuts already installed"
-        return
+    # If the managed block already exists, strip it out so we can re-inject fresh
+    if ((Test-Path $PROFILE) -and (Select-String -Path $PROFILE -Pattern ([regex]::Escape($beginMarker)) -Quiet)) {
+        Write-Info "Updating PowerShell profile shortcuts..."
+        $raw = Get-Content $PROFILE -Raw
+        # Strip the managed block (handles both LF and CRLF)
+        $raw = $raw -replace "(?s)\r?\n$([regex]::Escape($beginMarker)).*?$([regex]::Escape($endMarker))\r?\n?", ''
+        Set-Content $PROFILE $raw -NoNewline
     }
 
     $profileContent = @'

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -589,6 +589,67 @@ Test-Scenario "I-3: Install-Psmux is idempotent (checks before installing)" {
 }
 
 # ---------------------------------------------------------------------------
+# Group J: Write-PowerShellProfile strip+re-inject logic (Issue #138)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group J: Write-PowerShellProfile strip+re-inject logic (Issue #138)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "J-1: Write-PowerShellProfile body contains the begin marker string" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $fn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Write-PowerShellProfile' }, $true)
+    if ($fn.Count -eq 0) { throw "Write-PowerShellProfile function not found" }
+    $fnBody = $fn[0].Body.Extent.Text
+    if ($fnBody -notmatch 'BEGIN dev-setup profile') {
+        throw "Write-PowerShellProfile body does not contain 'BEGIN dev-setup profile' marker"
+    }
+}
+
+Test-Scenario "J-2: Write-PowerShellProfile body contains the end marker string" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $fn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Write-PowerShellProfile' }, $true)
+    if ($fn.Count -eq 0) { throw "Write-PowerShellProfile function not found" }
+    $fnBody = $fn[0].Body.Extent.Text
+    if ($fnBody -notmatch 'END dev-setup profile') {
+        throw "Write-PowerShellProfile body does not contain 'END dev-setup profile' marker"
+    }
+}
+
+Test-Scenario "J-3: Write-PowerShellProfile body does NOT contain return after sentinel check" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $fn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Write-PowerShellProfile' }, $true)
+    if ($fn.Count -eq 0) { throw "Write-PowerShellProfile function not found" }
+    $fnBody = $fn[0].Body.Extent.Text
+    # The old skip logic had "return" right after the sentinel check
+    # The new strip logic should NOT have "return" — it strips and falls through
+    if ($fnBody -match 'Select-String.*BEGIN dev-setup profile.*\)\s*\{\s*[^}]*?\breturn\b') {
+        throw "Write-PowerShellProfile still has 'return' after sentinel check - should strip+re-inject instead"
+    }
+}
+
+Test-Scenario "J-4: Write-PowerShellProfile body contains Get-Content and Set-Content (strip logic)" {
+    $setupPath = Join-Path $RepoRoot 'scripts\windows\setup.ps1'
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($setupPath, [ref]$tokens, [ref]$errors)
+    $fn = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'Write-PowerShellProfile' }, $true)
+    if ($fn.Count -eq 0) { throw "Write-PowerShellProfile function not found" }
+    $fnBody = $fn[0].Body.Extent.Text
+    if ($fnBody -notmatch 'Get-Content') {
+        throw "Write-PowerShellProfile does not contain 'Get-Content' - strip logic missing"
+    }
+    if ($fnBody -notmatch 'Set-Content') {
+        throw "Write-PowerShellProfile does not contain 'Set-Content' - strip logic missing"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Users who ran setup.ps1 before PRs #141/#142 never received the new psmux aliases (ta, tks, tls, tt) because Write-PowerShellProfile would skip updates when the sentinel marker was present.

## Solution

Changed the sentinel logic from "skip if present" to "strip + re-inject":
- When the BEGIN/END markers are found, remove the old managed block entirely
- Then fall through to inject the current fresh block
- Handles both CRLF (Windows) and LF line endings safely
- Added Write-Info message when updating (vs first install)

## Tests

Added test group J with 4 tests:
- J-1: Verify BEGIN marker present in function body
- J-2: Verify END marker present in function body  
- J-3: Verify no 'return' after sentinel check (confirms skip removed)
- J-4: Verify Get-Content/Set-Content present (confirms strip logic)

## Related

Closes #138

## Review Notes

- Preserves existing "create directory if missing" and "prepend blank line" logic
- Regex is safe: only removes content between BEGIN/END markers
- Always updates when content has changed (no more skipping)