### PR TITLE
feat(hooks): add PSScriptAnalyzer advisory check to pre-push hook (#147)

### DIFF
--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -421,3 +421,41 @@ Goofy's branch `squad/147-prepush-psscriptanalyzer` already existed with the hoo
 ✅ Tests ready for CI validation once branch is merged
 
 **Testing Philosophy:** Static validation tests like these catch structural issues (missing guards, wrong shebang, accidental hard-fail) without requiring a full git environment or execution context. They complement integration tests and catch regressions early.
+
+---
+
+## 2025-01-XX: PS 5.1 Compatibility Fix - Group L Tests (#147)
+
+### Problem
+
+All 5 Group L tests (L-1 through L-5) were failing in CI with:
+```
+Error: A positional parameter cannot be found that accepts argument 'pre-push'.
+```
+
+Root cause: PS 5.1's `Join-Path` only accepts 2 positional arguments. Multi-segment calls like:
+```powershell
+Join-Path $RepoRoot 'hooks' 'pre-push'
+```
+fail on PS 5.1 (the third argument `'pre-push'` has no positional parameter). PS 7+ allows multiple child segments, but PS 5.1 does not.
+
+### Fix
+
+Replaced all 5 occurrences of multi-segment `Join-Path` in Group L (lines 734, 745, 756, 769, 783) with nested two-argument calls:
+```powershell
+# PS 5.1 + PS 7+ compatible:
+$hookPath = Join-Path (Join-Path $RepoRoot 'hooks') 'pre-push'
+```
+
+### Key Lesson
+
+**ALWAYS use nested `Join-Path` calls with exactly 2 arguments for PS 5.1 compatibility.**
+
+This applies to ALL test code and any PowerShell scripts that must run on both PS 5.1 and PS 7+. Never assume multi-segment positional syntax is available.
+
+### Outcome
+
+✅ Fixed all 5 Group L tests in `tests/test_windows_setup.ps1`
+✅ Commit 4dfacfe pushed to `squad/147-prepush-psscriptanalyzer`
+✅ Tests should now pass on both PS 5.1 and PS 7+ in CI
+

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -376,3 +376,48 @@ Anticipatory test design for Group K (Issue #138 profile fixes) before implement
 **Outcome:** Test design contributed to comprehensive validation of dual-path profile fix. All Group K tests now passing as part of PR #146 merged to main.
 
 **Key Reflection:** Anticipatory testing per charter ("work from specs, not implementations") sometimes requires test adaptation when implementation details differ from predicted patterns. This is expected and healthy — the alternative of writing tests after implementation introduces "testing to the code" bias.
+
+---
+
+## [2026-04-19] Issue #147 — Group L Tests for pre-push PSScriptAnalyzer Block
+
+**Branch:** `squad/147-prepush-psscriptanalyzer` (Goofy's branch)
+**Commit:** 467aeae
+**Status:** ✅ Committed and pushed
+
+### What I Built
+
+Added Group L tests (L-1 through L-5) to `tests/test_windows_setup.ps1` to verify the new PSScriptAnalyzer block in `hooks/pre-push`. All tests are **static validation** — they read and verify hook file structure without executing the hook.
+
+**Test Coverage:**
+- **L-1:** Verifies `command -v pwsh` guard exists (graceful skip path for systems without PowerShell Core)
+- **L-2:** Verifies `Invoke-ScriptAnalyzer` invocation exists (the actual PS lint check)
+- **L-3:** Verifies PSScriptAnalyzer module check or skip message (handles module-not-installed case)
+- **L-4:** Verifies NO `exit 1` on PSScriptAnalyzer lines — check is advisory only (distinguishes from main-branch guard which rightfully has exit 1)
+- **L-5:** Verifies hook shebang is `#!/bin/sh` for POSIX compatibility (not `#!/bin/bash`)
+
+### Technical Approach
+
+All tests use static file analysis:
+- Read `hooks/pre-push` file content with `Get-Content`
+- Use regex matching to verify expected patterns
+- L-4 specifically checks for co-occurrence of `PSScriptAnalyzer` AND `exit 1` on same line to catch accidental hard-fail behavior
+
+### Key Pattern Decisions
+
+1. **Followed Group K pattern:** Used existing `Test-Scenario` helper, `$RepoRoot` path construction, ASCII-only strings
+2. **L-3 defensive OR check:** Accepts EITHER skip message OR module check (implementation could use either pattern)
+3. **L-4 line-by-line scan:** Reads file as array of lines to check each individually — prevents false positive from unrelated `exit 1` (main branch guard)
+4. **L-5 exact shebang match:** Requires EXACTLY `#!/bin/sh` to enforce POSIX sh requirement (Git Bash on Windows compatibility)
+
+### Coordination
+
+Goofy's branch `squad/147-prepush-psscriptanalyzer` already existed with the hook implementation. Checked out branch, added tests after Group K, committed with Conventional Commits format and Co-authored-by trailer, pushed directly to Goofy's branch as instructed.
+
+### Outcome
+
+✅ 5 new tests added (Group L) to `tests/test_windows_setup.ps1`
+✅ Commit 467aeae pushed to `squad/147-prepush-psscriptanalyzer`
+✅ Tests ready for CI validation once branch is merged
+
+**Testing Philosophy:** Static validation tests like these catch structural issues (missing guards, wrong shebang, accidental hard-fail) without requiring a full git environment or execution context. They complement integration tests and catch regressions early.

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -17,6 +17,23 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### [2026-04-19] Issue #147: PSScriptAnalyzer advisory check in pre-push hook (PR #149)
+**Branch:** `squad/147-prepush-psscriptanalyzer`
+**Status:** ✅ PR opened
+
+Added PSScriptAnalyzer lint check to `hooks/pre-push` following the existing shellcheck pattern. Advisory only -- prints warnings but never blocks push (exit 0 all paths).
+
+**Implementation:**
+- Check if `pwsh` is available before attempting to run PSScriptAnalyzer
+- Check if PSScriptAnalyzer module is installed via `Get-Module -ListAvailable`
+- Only scan changed `.ps1` files from push diff (`git diff --name-only HEAD~1 HEAD`)
+- Use `Write-Warning` to display violations in pwsh
+- Silent skip when `pwsh` not found (common on Linux/macOS without PS Core)
+- Notice skip when PSScriptAnalyzer module not installed
+- Follows POSIX sh -- no bash-isms, no `[[`, no arrays, no `local`
+
+**Key learning:** Hook patterns for optional lint tools should have three-tier graceful degradation: (1) silent skip when tool unavailable, (2) notice skip when dependencies missing, (3) advisory-only output when available. Never block on optional quality checks in pre-push hooks.
+
 ### [2026-04-18] Fix PR #130 regressions
 - Test-Path Variable:* guard is BROKEN under Set-StrictMode -Version Latest on PS 5.1
 - Even with short-circuit -and, strict mode throws VariableIsUndefined on $IsWindows
@@ -353,3 +370,23 @@ PR #146 implemented three complementary fixes for Issue #138 (Windows PowerShell
 **Key Learning:** `$PROFILE` is version-specific — always write to explicit paths for cross-version compatibility. The refactor from `$PROFILE` to explicit `$profilePaths` array solved the root cause of aliases not loading in PS 5.1 terminals even though setup ran in PS 7+.
 
 **Related Issues:** #138 (parent), #144 (sentinel skip), #141/#142 (psmux aliases that triggered discovery)
+
+## [2026-04-19] Issue #147: Fix CI test L-4 failure — PSScriptAnalyzer exit 1 check (PR #149)
+**Branch:** `squad/147-prepush-psscriptanalyzer`
+**Status:** ✅ Committed and pushed
+
+**Problem:** Test L-4 checks that no line in `hooks/pre-push` contains both `PSScriptAnalyzer` AND `exit 1` (to verify the check is advisory-only). The module availability check used `exit 1` inside a quoted PowerShell command string, which triggered the regex even though the shell never actually exits 1.
+
+**Fix:** Replaced exit-code-based module check with output-based check:
+```sh
+# BEFORE (exit 1 in string triggered L-4):
+if pwsh -NoProfile -Command "if (Get-Module -ListAvailable PSScriptAnalyzer) { exit 0 } else { exit 1 }" 2>/dev/null; then
+
+# AFTER (no exit codes, output-based):
+PSANALYZER_AVAIL=$(pwsh -NoProfile -Command "if (Get-Module -ListAvailable -Name 'PSScriptAnalyzer') { 'yes' } else { 'no' }" 2>/dev/null)
+if [ "$PSANALYZER_AVAIL" = "yes" ]; then
+```
+
+**Result:** L-4 now passes correctly. Behavior is identical — module check still works, PSScriptAnalyzer runs if available, skips with message if not. Zero logic change, purely syntax refactor to satisfy test constraint.
+
+**Key learning:** When tests enforce regex-based line checks, avoid using forbidden patterns even in quoted strings or comments. Output-based checks (`'yes'`/`'no'`) are cleaner than exit-code-based checks when the exit code itself is what's being tested.

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -599,3 +599,37 @@ This session completed the sentinel fix lifecycle: scoped issue #144, reviewed a
 **Outcome:** PR #146 merged to develop. Issue #138 closed. PR #148 (develop→main) merged with 10/10 CI green. Issue #147 created for future pre-hook enhancement.
 
 **Key Reflection:** The PSScriptAnalyzer evaluation highlighted the importance of distinguishing between "CI-only as hard gate" vs. "CI-only means never local." Advisory soft checks with graceful degradation add developer convenience without the platform-dependency problems of hard gates.
+
+---
+
+## 2026-04-19 — PR #149 Review: PSScriptAnalyzer pre-push hook (Issue #147)
+
+**Branch:** `squad/147-prepush-psscriptanalyzer`
+**Verdict:** ✅ APPROVED
+
+### Review Summary
+
+Reviewed Goofy's hook implementation and Chip's Group L tests. All 7 acceptance criteria from Issue #147 verified:
+1. Hook updated with PSScriptAnalyzer advisory section
+2. Only pushed `.ps1` files checked (via `git diff --name-only`)
+3. Graceful skip when `pwsh` absent (silent `:` no-op)
+4. Graceful skip when PSScriptAnalyzer module absent (prints notice)
+5. Violations printed as `Write-Warning`, never blocks push (all paths exit 0)
+6. Existing main-branch guard and shellcheck sections untouched
+7. `--no-verify` bypass unaffected (standard git behavior)
+
+**POSIX compliance:** Clean — no `[[`, `local`, arrays, `$(( ))`, or other bash-isms. Shebang is `#!/bin/sh`. `set -e` interactions handled correctly with `|| true` guards and `if` conditions.
+
+**Group L tests (L-1 through L-5):** Structurally sound static validation. Each test reads `hooks/pre-push` and asserts a specific structural requirement with meaningful failure messages. L-4's line-by-line scan correctly avoids false positives from the unrelated `exit 1` in the main-branch guard.
+
+**Commits:** All 3 follow conventional format (`feat`, `test`, `docs` scopes).
+
+**Files modified:** Only expected files — `hooks/pre-push`, `tests/test_windows_setup.ps1`, `.squad/agents/chip/history.md`.
+
+## Learnings
+
+### 2026-04-19 — Advisory Hook Pattern Validated
+
+- **Advisory hook pattern is now proven end-to-end.** The `command -v` → module check → `|| true` → `Write-Warning` chain established in Issue #147 is the canonical pattern for optional-tooling hooks. Future hooks (e.g., markdownlint, yamllint) should copy this structure.
+- **Static tests are sufficient for hook structural validation.** Group L demonstrates that reading the hook file and asserting patterns (guards, shebang, no `exit 1` co-occurrence) catches the important regressions without requiring a full git execution environment.
+- **`set -e` requires explicit `|| true` on every non-if command substitution.** Both the shellcheck block and PSScriptAnalyzer block use this correctly, but it's easy to forget on new additions.

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -25,3 +25,21 @@ if command -v shellcheck >/dev/null 2>&1; then
     echo "$CHANGED" | xargs shellcheck || true
   fi
 fi
+
+# Run PSScriptAnalyzer on changed .ps1 files if pwsh is available (advisory)
+if command -v pwsh >/dev/null 2>&1; then
+  PS1_CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep '\.ps1$' || true)
+  if [ -n "$PS1_CHANGED" ]; then
+    if pwsh -NoProfile -Command "if (Get-Module -ListAvailable PSScriptAnalyzer) { exit 0 } else { exit 1 }" 2>/dev/null; then
+      echo "[pre-push] Running PSScriptAnalyzer on changed .ps1 files (advisory)..."
+      echo "$PS1_CHANGED" | while read -r ps1file; do
+        pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path '$ps1file' | ForEach-Object { Write-Warning \$_.Message }" 2>/dev/null || true
+      done
+    else
+      echo "[pre-push] PSScriptAnalyzer not installed -- skipping PS lint check."
+    fi
+  fi
+else
+  # pwsh not available (common on Linux/macOS without PS Core)
+  : # silent skip
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -30,7 +30,8 @@ fi
 if command -v pwsh >/dev/null 2>&1; then
   PS1_CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep '\.ps1$' || true)
   if [ -n "$PS1_CHANGED" ]; then
-    if pwsh -NoProfile -Command "if (Get-Module -ListAvailable PSScriptAnalyzer) { exit 0 } else { exit 1 }" 2>/dev/null; then
+    PSANALYZER_AVAIL=$(pwsh -NoProfile -Command "if (Get-Module -ListAvailable -Name 'PSScriptAnalyzer') { 'yes' } else { 'no' }" 2>/dev/null)
+    if [ "$PSANALYZER_AVAIL" = "yes" ]; then
       echo "[pre-push] Running PSScriptAnalyzer on changed .ps1 files (advisory)..."
       echo "$PS1_CHANGED" | while read -r ps1file; do
         pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path '$ps1file' | ForEach-Object { Write-Warning \$_.Message }" 2>/dev/null || true

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -723,6 +723,74 @@ Test-Scenario "K-5: Write-PowerShellProfile contains RemoteSigned (remediation h
 }
 
 # ---------------------------------------------------------------------------
+# Group L: PSScriptAnalyzer block in pre-push hook (Issue #147)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group L: PSScriptAnalyzer block in pre-push hook (Issue #147)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "L-1: Hook file contains command -v pwsh guard (graceful skip path)" {
+    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    if (-not (Test-Path $hookPath)) {
+        throw "Hook file not found: $hookPath"
+    }
+    $hookContent = Get-Content $hookPath -Raw
+    if ($hookContent -notmatch 'command -v pwsh') {
+        throw "pre-push hook does not contain 'command -v pwsh' guard - graceful skip path is missing"
+    }
+}
+
+Test-Scenario "L-2: Hook file contains Invoke-ScriptAnalyzer invocation" {
+    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    if (-not (Test-Path $hookPath)) {
+        throw "Hook file not found: $hookPath"
+    }
+    $hookContent = Get-Content $hookPath -Raw
+    if ($hookContent -notmatch 'Invoke-ScriptAnalyzer') {
+        throw "pre-push hook does not contain 'Invoke-ScriptAnalyzer' - PS lint check is missing"
+    }
+}
+
+Test-Scenario "L-3: Hook file contains PSScriptAnalyzer not installed message OR module check" {
+    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    if (-not (Test-Path $hookPath)) {
+        throw "Hook file not found: $hookPath"
+    }
+    $hookContent = Get-Content $hookPath -Raw
+    $hasSkipMessage = $hookContent -match 'PSScriptAnalyzer not installed'
+    $hasModuleCheck = $hookContent -match 'Get-Module.*PSScriptAnalyzer'
+    if (-not ($hasSkipMessage -or $hasModuleCheck)) {
+        throw "pre-push hook does not contain skip message or module check for PSScriptAnalyzer"
+    }
+}
+
+Test-Scenario "L-4: Hook file does NOT contain exit 1 on PSScriptAnalyzer lines (advisory only)" {
+    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    if (-not (Test-Path $hookPath)) {
+        throw "Hook file not found: $hookPath"
+    }
+    $hookLines = Get-Content $hookPath
+    foreach ($line in $hookLines) {
+        # Check if line mentions PSScriptAnalyzer AND contains exit 1
+        if (($line -match 'PSScriptAnalyzer') -and ($line -match 'exit 1')) {
+            throw "pre-push hook contains 'exit 1' on a PSScriptAnalyzer line - check must be advisory: $line"
+        }
+    }
+}
+
+Test-Scenario "L-5: Hook file shebang is #!/bin/sh (not bash, must stay POSIX)" {
+    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    if (-not (Test-Path $hookPath)) {
+        throw "Hook file not found: $hookPath"
+    }
+    $firstLine = Get-Content $hookPath -TotalCount 1
+    if ($firstLine -ne '#!/bin/sh') {
+        throw "pre-push hook shebang is '$firstLine' but must be '#!/bin/sh' for POSIX compatibility"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -731,7 +731,7 @@ Write-Host " Group L: PSScriptAnalyzer block in pre-push hook (Issue #147)" -For
 Write-Host "========================================================" -ForegroundColor Cyan
 
 Test-Scenario "L-1: Hook file contains command -v pwsh guard (graceful skip path)" {
-    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    $hookPath = Join-Path (Join-Path $RepoRoot 'hooks') 'pre-push'
     if (-not (Test-Path $hookPath)) {
         throw "Hook file not found: $hookPath"
     }
@@ -742,7 +742,7 @@ Test-Scenario "L-1: Hook file contains command -v pwsh guard (graceful skip path
 }
 
 Test-Scenario "L-2: Hook file contains Invoke-ScriptAnalyzer invocation" {
-    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    $hookPath = Join-Path (Join-Path $RepoRoot 'hooks') 'pre-push'
     if (-not (Test-Path $hookPath)) {
         throw "Hook file not found: $hookPath"
     }
@@ -753,7 +753,7 @@ Test-Scenario "L-2: Hook file contains Invoke-ScriptAnalyzer invocation" {
 }
 
 Test-Scenario "L-3: Hook file contains PSScriptAnalyzer not installed message OR module check" {
-    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    $hookPath = Join-Path (Join-Path $RepoRoot 'hooks') 'pre-push'
     if (-not (Test-Path $hookPath)) {
         throw "Hook file not found: $hookPath"
     }
@@ -766,7 +766,7 @@ Test-Scenario "L-3: Hook file contains PSScriptAnalyzer not installed message OR
 }
 
 Test-Scenario "L-4: Hook file does NOT contain exit 1 on PSScriptAnalyzer lines (advisory only)" {
-    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    $hookPath = Join-Path (Join-Path $RepoRoot 'hooks') 'pre-push'
     if (-not (Test-Path $hookPath)) {
         throw "Hook file not found: $hookPath"
     }
@@ -780,7 +780,7 @@ Test-Scenario "L-4: Hook file does NOT contain exit 1 on PSScriptAnalyzer lines 
 }
 
 Test-Scenario "L-5: Hook file shebang is #!/bin/sh (not bash, must stay POSIX)" {
-    $hookPath = Join-Path $RepoRoot 'hooks' 'pre-push'
+    $hookPath = Join-Path (Join-Path $RepoRoot 'hooks') 'pre-push'
     if (-not (Test-Path $hookPath)) {
         throw "Hook file not found: $hookPath"
     }


### PR DESCRIPTION
Closes #147

## Changes
- `hooks/pre-push`: added PSScriptAnalyzer advisory section after shellcheck block

## Behavior
- If `pwsh` is available AND PSScriptAnalyzer module is installed: runs `Invoke-ScriptAnalyzer` on changed `.ps1` files, prints violations as warnings
- If `pwsh` not found: silent skip
- If PSScriptAnalyzer not installed: prints skip notice
- Push is never blocked -- exit 0 in all paths
- `--no-verify` bypasses as normal

## Not included
- No PS 5.1 check (`powershell.exe`) -- Linux-only codespace, stays CI-only
- No changes to `validate.yml` CI jobs