### PR TITLE
docs: update README and CONTRIBUTING for issues #138 and #147

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -17,6 +17,17 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### [2026-04-19] Issue #151: Documentation update for #138 and #147 (PR TBD)
+**Branch:** `squad/151-update-docs`
+**Status:** ✅ PR opened
+
+Targeted additions to README.md, CONTRIBUTING.md, and ARCHITECTURE.md to document:
+- Windows PowerShell alias table (`ta`, `tt`, `tls`, `tks`, `gpl`, `ggsls`) and the dual-path profile injection pattern from #138
+- Pre-push hook workflow (shellcheck + PSScriptAnalyzer advisory) from #147
+- How to install PSScriptAnalyzer locally
+
+**Key learning:** Docs PRs should only add what is missing — never rewrite existing content. Use the existing heading style and table formats of each file. Advisory-only hooks should be clearly labelled as such in docs to prevent confusion about push failures.
+
 ### [2026-04-19] Issue #147: PSScriptAnalyzer advisory check in pre-push hook (PR #149)
 **Branch:** `squad/147-prepush-psscriptanalyzer`
 **Status:** ✅ PR opened

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,9 @@ dev-setup/
 │   ├── Microsoft.PowerShell_profile-example.ps1  # PowerShell aliases
 │   └── README.md                   # Explains each file and how to use them
 │
+├── hooks/
+│   └── pre-push                # Pre-push hook: blocks pushes to main; advisory shellcheck (.sh) and PSScriptAnalyzer (.ps1)
+│
 ├── .squad/                         # Internal squad coordination (not shipped)
 │
 └── ARCHITECTURE.md                 # This file
@@ -131,6 +134,8 @@ Uses PowerShell's built-in `$IsWindows`, `$IsLinux`, `$IsMacOS` booleans. If Pow
 | Idempotency | `Get-Command <tool> -ErrorAction SilentlyContinue` before installing |
 | Logging | Use `Write-Info`, `Write-Ok`, `Write-Warn`, `Write-Err` helpers (copy from `setup.ps1`) |
 | Install method | Prefer `winget`; fall back to `scoop` or direct download |
+| Profile injection | `Write-PowerShellProfile` writes aliases to **both** PS 5.1 (`Documents\WindowsPowerShell\`) and PS 7+ (`Documents\PowerShell\`) paths; sentinel strip+re-inject makes it idempotent |
+| Alias registration | All `Set-Alias` calls use `-Force -Scope Global` so aliases work in the current session immediately |
 
 ---
 
@@ -214,5 +219,6 @@ This means running `bash setup.sh` on a fully-configured machine is a no-op.
 | `scripts/linux/tools/gh.sh` | Donald | #7 |
 | `scripts/linux/tools/copilot-cli.sh` | Donald | #7 |
 | `scripts/windows/setup.ps1` | Goofy | #2 |
+| `hooks/pre-push` | Goofy | #138, #147 |
 | `config/dotfiles/` | Pluto | #8, #10, #11 |
 | `.github/workflows/` | Chip | #12, #13 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,39 @@ Since the dev environment runs PS 7+, you cannot natively run PS 5.1 tests. Manu
 
 ---
 
+## Pre-push Hook
+
+The hook lives at `hooks/pre-push`. Install it once after cloning:
+
+```bash
+cp hooks/pre-push .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+### What it does
+
+| Check | Platform | Behavior |
+|-------|----------|----------|
+| Block push to `main` | All | **Hard block** — exits 1, push is rejected |
+| `shellcheck` on changed `.sh` files | Linux / macOS | Advisory — warnings printed, push continues |
+| `PSScriptAnalyzer` on changed `.ps1` files | Any with `pwsh` | Advisory — warnings printed, push continues |
+
+### Advisory-only rule
+
+The lint checks (shellcheck and PSScriptAnalyzer) are **advisory only** — they print warnings but always exit 0. They will never block a push. Fixes are expected before opening a PR, not before every push.
+
+### Installing PSScriptAnalyzer locally
+
+To get PS lint feedback locally, install the module once in PowerShell:
+
+```powershell
+Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+```
+
+The hook auto-detects `pwsh` and the module. If either is absent the PS check is silently skipped — no action needed on Linux/macOS-only machines.
+
+---
+
 ## Direct-Push Override Policy
 
 Normally, all changes flow through PRs into `develop`. Direct pushes to `main` are **never** allowed as routine workflow.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,40 @@ dev-setup/
 
 Root entry points (`setup.sh`, `setup.ps1`) are thin routers — they detect the OS and delegate to the appropriate script under `scripts/`. They install nothing themselves.
 
+## Windows PowerShell Aliases
+
+After running `setup.ps1`, a set of shortcuts is injected into your PowerShell profile automatically — on **both** the PS 5.1 path (`Documents\WindowsPowerShell\`) and the PS 7+ path (`Documents\PowerShell\`). The injection is idempotent: re-running setup strips the old block and writes a fresh one.
+
+**Confirmed working aliases:**
+
+| Alias | Command |
+|-------|---------|
+| `ta` | tmux/psmux attach |
+| `tt` | new tmux/psmux session |
+| `tls` | list tmux/psmux sessions |
+| `tks` | kill tmux/psmux server |
+| `gpl` | `git pull` |
+| `ggsls` | `git stash list` |
+
+Full alias list lives in `scripts/windows/setup.ps1` (the `Write-PowerShellProfile` function). All aliases use `-Force -Scope Global` so they are available immediately in the current session after sourcing the profile.
+
+## Pre-push Hook
+
+`hooks/pre-push` runs automatically when you push. It:
+
+1. **Blocks** direct pushes to `main` (hard stop).
+2. **Runs shellcheck** on changed `.sh` files — advisory, never blocks (Linux/macOS).
+3. **Runs PSScriptAnalyzer** on changed `.ps1` files — advisory, never blocks (requires `pwsh` + PSScriptAnalyzer module; silently skipped if absent).
+
+Install the hook once after cloning:
+
+```bash
+cp hooks/pre-push .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+---
+
 ## Customization
 
 **Dotfiles:** Edit or add templates in `config/dotfiles/`. Each file is copied into your home directory on first run. Existing files are not overwritten unless you pass `--force`.


### PR DESCRIPTION
Closes #151

Updates README.md, CONTRIBUTING.md, and ARCHITECTURE.md to document:
- Windows PowerShell aliases (ta, tt, tls, tks, gpl, ggsls) and dual-path profile injection (#138)
- PSScriptAnalyzer advisory pre-push hook behavior (#147)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>