### PR TITLE
fix(profile): add Remove-Item guard for gcm and gcb AllScope aliases

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -212,9 +212,11 @@ function Add-GitAllFiles { git add --all $args }            # stage all changes
 Set-Alias -Name gaa -Value Add-GitAllFiles -Force -Scope Global
 
 function Invoke-GitCommitMessage { git commit -m $args }    # commit with inline message
+Remove-Item -Force Alias:\gcm -ErrorAction SilentlyContinue
 Set-Alias -Name gcm -Value Invoke-GitCommitMessage -Force -Scope Global
 
 function New-GitBranch { git checkout -b $args }            # create and switch to new branch
+Remove-Item -Force Alias:\gcb -ErrorAction SilentlyContinue
 Set-Alias -Name gcb -Value New-GitBranch -Force -Scope Global
 
 function Invoke-GitCheckout { git checkout $args }          # switch branch or restore file


### PR DESCRIPTION
Fixes #160

## What
Add Remove-Item guard before Set-Alias for gcm and gcb. Both AllScope built-ins in PS 5.1. Break without guard.

## Why
8 other aliases use pattern. gcm and gcb missed.

## Test
- [ ] gcm work in new PS 5.1 terminal
- [ ] gcb work in new PS 5.1 terminal
- [ ] No break other aliases