### PR TITLE
release: merge develop → main (fix #160 gcm/gcb AllScope guards)

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -404,3 +404,23 @@ if [ "$PSANALYZER_AVAIL" = "yes" ]; then
 **Result:** L-4 now passes correctly. Behavior is identical — module check still works, PSScriptAnalyzer runs if available, skips with message if not. Zero logic change, purely syntax refactor to satisfy test constraint.
 
 **Key learning:** When tests enforce regex-based line checks, avoid using forbidden patterns even in quoted strings or comments. Output-based checks (`'yes'`/`'no'`) are cleaner than exit-code-based checks when the exit code itself is what's being tested.
+
+---
+
+## [2026-04-25] Issue #160: Expand PS 5.1 alias fix to include gcb (Mickey Lead Decision)
+
+**Issue:** #160  
+**Scope:** gcm + gcb alias fixes  
+**Status:** Awaiting implementation
+
+**Context:**
+Earl reported `gcm` (Get-Command) alias breaks on PS 5.1 with AllScope error. Investigation by Mickey revealed `gcb` (Get-Content) has identical problem. Both are PS 5.1 built-in aliases with AllScope flag that can't be overwritten by `Set-Alias` alone.
+
+**Decision:**
+Expand fix scope to both `gcm` AND `gcb`. Codebase already guards 8 other aliases (`rm`, `gc`, `gl`, `gp`, `grb`, `grs`, `ni`, `h`) with `Remove-Item -Force Alias:\<name> -ErrorAction SilentlyContinue` before `Set-Alias`. Full audit confirmed only `gcm` and `gcb` are affected PS 5.1 built-ins. Fix is two lines each, same pattern, no new code pattern required.
+
+**Rationale:**
+Ship both together — same root cause, same file, same pattern. Partial fix would leave `gcb` broken.
+
+**Next:**
+Implement both aliases in `scripts/windows/setup.ps1`.

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -17,15 +17,18 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
-### [2026-04-19] Issue #151: Documentation update for #138 and #147 (PR TBD)
+### [2026-04-19] Issue #151: Documentation update for #138 and #147 (PR #152, #153) ✅ MERGED
 **Branch:** `squad/151-update-docs`
-**Status:** ✅ PR opened
+**Status:** ✅ Complete — merged to develop and main
 
 Targeted additions to README.md, CONTRIBUTING.md, and ARCHITECTURE.md to document:
 - Windows PowerShell alias table (`ta`, `tt`, `tls`, `tks`, `gpl`, `ggsls`) and the dual-path profile injection pattern from #138
 - Pre-push hook workflow (shellcheck + PSScriptAnalyzer advisory) from #147
 - How to install PSScriptAnalyzer locally
+- hooks/ directory ownership in ARCHITECTURE.md
 
+**Reviewed and approved by:** Mickey (5/5 CI green on PR #152)
+**Released:** PR #153 (develop → main), 10/10 CI green
 **Key learning:** Docs PRs should only add what is missing — never rewrite existing content. Use the existing heading style and table formats of each file. Advisory-only hooks should be clearly labelled as such in docs to prevent confusion about push failures.
 
 ### [2026-04-19] Issue #147: PSScriptAnalyzer advisory check in pre-push hook (PR #149)

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -633,3 +633,58 @@ Reviewed Goofy's hook implementation and Chip's Group L tests. All 7 acceptance 
 - **Advisory hook pattern is now proven end-to-end.** The `command -v` → module check → `|| true` → `Write-Warning` chain established in Issue #147 is the canonical pattern for optional-tooling hooks. Future hooks (e.g., markdownlint, yamllint) should copy this structure.
 - **Static tests are sufficient for hook structural validation.** Group L demonstrates that reading the hook file and asserting patterns (guards, shebang, no `exit 1` co-occurrence) catches the important regressions without requiring a full git execution environment.
 - **`set -e` requires explicit `|| true` on every non-if command substitution.** Both the shellcheck block and PSScriptAnalyzer block use this correctly, but it's easy to forget on new additions.
+
+---
+
+## 2026-04-19 — Issue #151 Documentation Review & Approval
+
+**Session ID:** issue-151-docs-review  
+**PR:** #152 (squad/151-update-docs → develop)  
+**Branch Completion:** PR #153 (develop → main)
+
+**Role:** Reviewer/Approver  
+
+### Review Summary (PR #152)
+
+**Files Changed:** README.md, CONTRIBUTING.md, ARCHITECTURE.md
+
+**README.md changes:**
+- ✅ Added Windows PowerShell aliases section with full 6-alias table (`ta`, `tt`, `tls`, `tks`, `gpl`, `ggsls`)
+- ✅ Documented dual-path profile injection pattern from Issue #138
+- ✅ Added pre-push hook overview referencing shellcheck + PSScriptAnalyzer advisory
+
+**CONTRIBUTING.md changes:**
+- ✅ Added pre-push hook workflow section with shellcheck + PSScriptAnalyzer steps
+- ✅ Documented advisory-only behavior of PSScriptAnalyzer check ("warns, never blocks")
+- ✅ Added local PSScriptAnalyzer installation instructions
+
+**ARCHITECTURE.md changes:**
+- ✅ Added `hooks/` directory to directory structure table with description
+- ✅ Added PowerShell conventions and rules rows to OS/Stack matrix
+- ✅ Updated ownership map with Goofy as hooks owner
+
+### Acceptance Criteria Verification
+
+All 4 acceptance criteria from Issue #151 met:
+1. ✅ Windows PowerShell aliases documented with explanation and reference table
+2. ✅ Dual-path profile injection from Issue #138 clearly explained in README
+3. ✅ Pre-push hook workflow explained (shellcheck + PSScriptAnalyzer advisory)
+4. ✅ Content adds only — no rewrites; all additions follow existing file style conventions
+
+### Quality Gates
+
+- **Style consistency:** All additions match existing heading styles, table formats, and voice in respective files
+- **No content rewrites:** All changes are additive; existing sections left untouched
+- **Clarity on advisory:** PSScriptAnalyzer check clearly labeled "warn-only" to prevent confusion
+- **CI:** 5/5 checks passing
+
+**Verdict:** ✅ APPROVED — ready to merge
+
+### Release (PR #153)
+
+Merged PR #153 (develop → main) — 10/10 CI checks passing. Documentation now reflects Issues #138 and #147 work.
+
+### Key Learnings
+
+- **Documentation PRs that span multiple files need careful attention to existing patterns.** The formats and voice differ across README (bullet lists, technical details), CONTRIBUTING (procedural step lists), and ARCHITECTURE (tables, ownership structures). Respecting these patterns requires reading the full current state, not just the "add here" spots.
+- **Advisory-only hooks need explicit documentation.** Without clear labeling that PSScriptAnalyzer "warns but never blocks," users may panic on warnings or misunderstand why a push wasn't rejected.

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -688,3 +688,24 @@ Merged PR #153 (develop → main) — 10/10 CI checks passing. Documentation now
 
 - **Documentation PRs that span multiple files need careful attention to existing patterns.** The formats and voice differ across README (bullet lists, technical details), CONTRIBUTING (procedural step lists), and ARCHITECTURE (tables, ownership structures). Respecting these patterns requires reading the full current state, not just the "add here" spots.
 - **Advisory-only hooks need explicit documentation.** Without clear labeling that PSScriptAnalyzer "warns but never blocks," users may panic on warnings or misunderstand why a push wasn't rejected.
+
+---
+
+## 2026-04-25 — Issue #160 Refinement: gcm/gcb AllScope Alias Bug
+
+**Task:** Refine manually-created Issue #160 ("gcm alias not working").
+
+**What I found:**
+- `gcm` alias at line 215 of `scripts/windows/setup.ps1` missing `Remove-Item` guard — confirmed PS 5.1 AllScope conflict with `Get-Command`.
+- `gcb` alias at line 218 has **same bug** — conflicts with PS 5.1 AllScope `Get-Clipboard`. Unreported but same root cause.
+- 8 other aliases already have the guard (`rm`, `gc`, `gl`, `gp`, `grb`, `grs`, `ni`, `h`). Pattern is established.
+- Full audit of all 40+ aliases confirmed no other missing guards.
+
+**Changes to issue:**
+- Title: Expanded to cover both `gcm` and `gcb`, added conventional commit prefix
+- Body: Rewrote with root cause analysis, alias audit table, exact fix locations, and testable acceptance criteria
+- Labels: Added `type:bug`, `squad:goofy`, `go:yes` (Goofy owns Windows setup script)
+
+**Decision filed:** `.squad/decisions/inbox/mickey-gcm-alias-scope.md` — expand fix scope to both aliases.
+
+**Key learning:** When one PS 5.1 AllScope alias is missing a guard, audit ALL aliases in the profile for the same pattern gap. Built-in AllScope aliases in PS 5.1 include `gcm` (Get-Command), `gcb` (Get-Clipboard), `gc` (Get-Content), `gl` (Get-Location), `gp` (Get-ItemProperty), `ni` (New-Item), `rm` (Remove-Item), `h` (Get-History), and many more.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2305,3 +2305,25 @@ Advisory check sidesteps platform-dependency concern by gracefully skipping when
 
 - Sprint 7 decision: PSScriptAnalyzer in CI only (hard gate)
 - Issue #147: feat(hooks) — add PSScriptAnalyzer warn-only check to pre-push hook (future implementation)
+
+---
+
+## # Decision: PSScriptAnalyzer Hook Implementation Complete
+
+**Date:** 2026-04-19  
+**Agent:** Goofy  
+**Status:** ✅ Implemented and merged (PR #149, #150)
+
+### Implementation Summary
+
+PSScriptAnalyzer advisory check added to `hooks/pre-push` per Issue #147.
+
+**Behavior:**
+- Warn-only (exit 0 all paths — never blocks push)
+- Silent skip when `pwsh` unavailable (platform graceful degradation)
+- Notice skip when PSScriptAnalyzer module missing (helpful feedback)
+- POSIX `/bin/sh` syntax only (no bashisms)
+
+**Motivation:** Reduce revision cycles on PS script changes by catching PSScriptAnalyzer violations in local pre-push hook before CI-stage reviews.
+
+**Related Decisions:** Builds on Sprint 7 PSScriptAnalyzer CI-only decision; extends to local advisory-only hook as soft-check complement.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2327,3 +2327,48 @@ PSScriptAnalyzer advisory check added to `hooks/pre-push` per Issue #147.
 **Motivation:** Reduce revision cycles on PS script changes by catching PSScriptAnalyzer violations in local pre-push hook before CI-stage reviews.
 
 **Related Decisions:** Builds on Sprint 7 PSScriptAnalyzer CI-only decision; extends to local advisory-only hook as soft-check complement.
+
+---
+
+## # Decision: Style Directive — Caveman Speak
+
+**Date:** 2026-04-25T18:12:26Z  
+**By:** Earl Tankard, Jr., Ph.D.
+
+### What
+All agents and coordinator responses use caveman speak — short, direct, clear, simple language. No big words.
+
+### Why
+User directive. Saves tokens. Keep responses short and dense. Cut filler words.
+
+### Scope
+All team agents, all responses.
+
+---
+
+## # Decision: Scope gcm alias fix to include gcb (Issue #160)
+
+**Issue:** #160  
+**Agent:** Mickey (Lead)  
+**Date:** 2026-04-25
+
+### Context
+
+Earl reported `gcm` alias breaks on PS 5.1 with AllScope error. Investigation found `gcb` has the same problem — both are PS 5.1 built-in aliases with AllScope flag that can't be overwritten by `Set-Alias` alone.
+
+### Decision
+
+**Expand fix scope from just `gcm` to both `gcm` and `gcb`.**
+
+- Codebase already uses `Remove-Item -Force Alias:\<name> -ErrorAction SilentlyContinue` before `Set-Alias` for 8 other aliases (`rm`, `gc`, `gl`, `gp`, `grb`, `grs`, `ni`, `h`).
+- `gcm` and `gcb` are only two missing the guard that conflict with PS 5.1 AllScope built-ins.
+- Full audit of 40+ aliases confirmed no other aliases affected.
+- Fix: two lines, same pattern. No new pattern needed.
+
+### Assigned to
+
+Goofy (owner of `scripts/windows/setup.ps1`).
+
+### Rationale
+
+Ship both fixes together — same root cause, same file, same pattern. Fixing only `gcm` and leaving `gcb` broken would be sloppy.

--- a/.squad/logs/session_log.md
+++ b/.squad/logs/session_log.md
@@ -1,0 +1,98 @@
+# Session Log
+
+Cumulative log of completed squad sessions.
+
+---
+
+## 2026-04-19 — Windows PowerShell Aliases & PSScriptAnalyzer Hook
+
+**Issues closed:** #138, #147
+**PRs merged:** #145 (rejected initial attempt), #146, #148, #149, #150
+**Agents:** Mickey (Lead), Donald (Shell Dev), Goofy (Cross-Platform Dev), Chip (Tester)
+
+### Issue #138 — Windows PowerShell aliases not working after setup
+
+**Root cause:** `setup.ps1` wrote only to the first `$PROFILE` path, and
+`Set-Alias` calls lacked `-Force -Scope Global`.
+
+**Fix (PR #146, Donald):**
+- Dual-path profile injection — writes to both PS 5.1 (`WindowsPowerShell`)
+  and PS 7+ (`PowerShell`) profile paths
+- `-Force -Scope Global` on all `Set-Alias` calls
+- Sentinel strip+re-inject pattern to ensure idempotent profile updates
+- Execution-policy diagnostic warning
+
+**PR #145** was the initial attempt but was rejected during review due to test
+regressions (K-2, C-1, C-4). Donald's PR #146 resolved all regressions.
+
+**Tests:** Group K added to `tests/test_windows_setup.ps1`; CI 5/5 green.
+
+**Release:** PR #148 (develop → main), 10/10 CI green.
+
+### Issue #147 — PSScriptAnalyzer advisory pre-push hook
+
+**Implementation (PR #149, Goofy + Chip):**
+- Added PSScriptAnalyzer advisory section to `hooks/pre-push`
+- Output-based module availability check (`'yes'`/`'no'` pattern)
+- Warns on violations but never blocks push
+- Graceful skip if `pwsh` or PSScriptAnalyzer module absent
+- POSIX `/bin/sh` only — no bashisms
+
+**Tests:** Group L (L-1 through L-5) in `tests/test_windows_setup.ps1`.
+Key fix during development: PS 5.1 `Join-Path` only accepts 2 positional args;
+used nested `Join-Path (Join-Path $root 'hooks') 'pre-push'`.
+
+**CI:** 5/5 green. **Release:** PR #150 (develop → main), 10/10 CI green.
+
+### Key Decisions & Learnings
+
+1. **PS 5.1 `Join-Path` limit:** Only accepts 2 positional args — must nest:
+   `Join-Path (Join-Path $root 'a') 'b'`
+2. **Output-based checks over exit-code checks:** Exit-code-based
+   `pwsh -Command "... exit 1 ..."` checks are ambiguous in pre-push hooks —
+   prefer output-based (`'yes'`/`'no'`) checks for module availability
+3. **PSScriptAnalyzer hook philosophy:** Warn-only, graceful degradation,
+   POSIX sh — never block a push on advisory linting
+4. **Dual-path profile injection:** Required for Windows because PS 5.1 and
+   PS 7+ use different profile directories
+
+### Sprint Wrap-up
+
+- All stale branches deleted locally and remotely
+- Aliases confirmed working by Earl: `ta`, `tt`, `tls`, `tks`, `gpl`, `ggsls`
+
+---
+
+## 2026-04-19 — Issue #151 Documentation Update
+
+**Issue closed:** #151  
+**PRs merged:** #152 (docs → develop), #153 (develop → main)  
+**Agents:** Goofy (Docs Author), Mickey (Reviewer/Approver)
+
+### Issue #151 — Document PowerShell aliases and pre-push hook workflow
+
+**Documentation scope:**
+- README.md: Windows PowerShell aliases section with full table (`ta`, `tt`, `tls`, `tks`, `gpl`, `ggsls`), dual-path profile injection pattern, pre-push hook overview
+- CONTRIBUTING.md: Pre-push hook workflow (shellcheck + PSScriptAnalyzer advisory), PSScriptAnalyzer install instructions
+- ARCHITECTURE.md: `hooks/` directory entry, PowerShell conventions rows added to OS/Stack matrix, ownership map updated with Goofy as hooks owner
+
+**Acceptance Criteria (All Met):**
+1. ✅ Windows PowerShell aliases documented with table and explanation
+2. ✅ Dual-path profile injection pattern documented from #138 work
+3. ✅ Pre-push hook workflow (shellcheck + advisory) explained from #147 work
+4. ✅ All additions follow existing file styles; no content rewritten
+
+**Review & Approval (PR #152):**
+- Mickey reviewed all changes and confirmed acceptance criteria met
+- Content style consistency verified across all three files
+- 5/5 CI checks passing
+
+**Release (PR #153):**
+- develop → main merge, 10/10 CI checks passing
+- Branch `squad/151-update-docs` deleted locally and remotely post-merge
+
+### Key Learnings
+
+1. **Docs PR scope:** Only add missing documentation. Never rewrite existing sections. Respect heading styles and table formats already in place.
+2. **Advisory-only hooks:** When documenting warning-level hooks, clearly label them as such to prevent confusion about push blocking behavior.
+3. **Cross-file consistency:** Documentation PRs spanning multiple files require careful attention to voice, tense, and existing formatting conventions in each file.

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -212,9 +212,11 @@ function Add-GitAllFiles { git add --all $args }            # stage all changes
 Set-Alias -Name gaa -Value Add-GitAllFiles -Force -Scope Global
 
 function Invoke-GitCommitMessage { git commit -m $args }    # commit with inline message
+Remove-Item -Force Alias:\gcm -ErrorAction SilentlyContinue
 Set-Alias -Name gcm -Value Invoke-GitCommitMessage -Force -Scope Global
 
 function New-GitBranch { git checkout -b $args }            # create and switch to new branch
+Remove-Item -Force Alias:\gcb -ErrorAction SilentlyContinue
 Set-Alias -Name gcb -Value New-GitBranch -Force -Scope Global
 
 function Invoke-GitCheckout { git checkout $args }          # switch branch or restore file


### PR DESCRIPTION
Regular merge — develop → main.

Includes:
- fix(profile): add Remove-Item guards for gcm and gcb AllScope aliases (closes #160)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>