### PR TITLE
fix(windows): use curl.exe in Get-MyIp to avoid Invoke-WebRequest alias

### DIFF
--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -300,7 +300,7 @@ Set-Alias -Name c -Value Clear-Host -Force -Scope Global    # clear the screen
 
 # -- Utility --------------------------------------------------------------------
 
-function Get-MyIp { curl -s ifconfig.me $args }             # show public IP
+function Get-MyIp { curl.exe -s ifconfig.me $args }         # show public IP
 Set-Alias -Name myip -Value Get-MyIp -Force -Scope Global
 
 function Invoke-PingBing { ping bing.com $args }            # quick connectivity check


### PR DESCRIPTION
## Summary

Fixes the `myip` command on Windows.

PowerShell aliases `curl` to `Invoke-WebRequest`, which does not support the `-s` flag and breaks the `myip` shortcut. Using `curl.exe` forces invocation of the real curl binary.

## Change

```powershell
# Before
function Get-MyIp { curl -s ifconfig.me $args }

# After
function Get-MyIp { curl.exe -s ifconfig.me $args }
```

## Testing

- `myip` now correctly returns the public IP address instead of throwing an `Invoke-WebRequest` error.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>