### PR TITLE
feat(windows): add ep alias to open PowerShell profile in editor

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -395,3 +395,20 @@ Replaced the entire copilot-cli installation approach. Prior attempts using `CI=
 **Outcome:** PR #146 merged to develop. Issue #138 fully closed. Feature shipped via PR #148 (develop→main).
 
 **Reflection:** Test regression fixes on this session reinforced the pattern: when a refactor changes variable names or implementation structure, source inspection tests must adapt. The fix was straightforward once the root causes (K-2 regex, C-1 variable name, C-4 loop variable) were identified in Mickey's rejection.
+
+---
+
+### 2026-04-20: Fix — Missing Remove-Item AllScope guard for `ep` alias (PR #170)
+
+PR #170 (branch `squad/168-ep-alias-edit-profile`) added the `ep` alias for `Edit-Profile` in `scripts/windows/setup.ps1` but was missing the `Remove-Item -Force Alias:\ep -ErrorAction SilentlyContinue` guard before the `Set-Alias` call. Without it, PowerShell can fail to re-set the alias if an AllScope alias named `ep` already exists from a prior run — violating the idempotency requirement.
+
+**Fix applied (line 313):**
+```powershell
+function Edit-Profile { notepad $PROFILE }  # open PS profile in editor
+Remove-Item -Force Alias:\ep -ErrorAction SilentlyContinue
+Set-Alias -Name ep -Value Edit-Profile -Force -Scope Global
+```
+
+**Rule:** Every `Set-Alias -Scope Global` in `setup.ps1` must be preceded by a matching `Remove-Item -Force Alias:\<name> -ErrorAction SilentlyContinue` guard. See the `h` alias (~line 309) as the canonical reference pattern.
+
+Branch: `squad/168-ep-alias-edit-profile` — PR #170.

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -17,6 +17,28 @@
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### [2026-04-20] Issue #168: Add `ep` alias to open PowerShell profile in editor (PR #170)
+**Branch:** `squad/168-ep-alias-edit-profile`
+**Status:** ✅ PR opened → develop
+
+Added `ep` alias across Windows and Linux/macOS:
+- **Windows:** `Edit-Profile` function calls `notepad $PROFILE`; `Set-Alias -Name ep -Value Edit-Profile`
+- **Linux/macOS:** `alias ep='${EDITOR:-vim} ~/.bash_profile'` in `config/dotfiles/.aliases`
+- Test F-5 in `tests/test_windows_setup.ps1` updated to include `ep` in utility alias check
+- README.md utility alias table updated
+
+**Key learning:** When adding a new utility alias, update four places: `scripts/windows/setup.ps1`, `tests/test_windows_setup.ps1` (F-5 test), `config/dotfiles/.aliases`, and `README.md` alias table.
+
+### [2026-04-20] Issue #167: Fix `myip` curl alias on Windows (PR #169)
+**Branch:** `squad/167-fix-myip-curl-exe`
+**Status:** ✅ PR opened → develop
+
+PowerShell aliases `curl` to `Invoke-WebRequest` by default. Any call to `curl -s ifconfig.me` in a PS script silently invokes IWR instead of the real curl binary, breaking the `-s` flag and the expected plain-text response.
+
+**Fix:** Changed `curl` to `curl.exe` in `Get-MyIp` inside `scripts/windows/setup.ps1`. The `.exe` suffix bypasses the PowerShell alias resolver and forces the real Win32 binary.
+
+**Key learning:** Always use `curl.exe` (not `curl`) in PowerShell scripts when you need real curl behaviour. Same pattern applies to `wget.exe` vs the `wget` alias.
+
 ### [2026-04-19] Issue #151: Documentation update for #138 and #147 (PR #152, #153) ✅ MERGED
 **Branch:** `squad/151-update-docs`
 **Status:** ✅ Complete — merged to develop and main

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ After running setup, you get shortcuts for common git, dev, and utility commands
 
 **Dev tools:** `uvr`, `uvs`, `ni`, `nr`, `nrd`, `nrt`, `py`, `c`
 
-**Utility:** `myip`, `pb`, `h`
+**Utility:** `myip`, `pb`, `h`, `ep`
 
 **tmux/psmux:** `ta` (attach), `tt` (new session), `tls` (list sessions), `tks` (kill server)
 

--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -92,6 +92,7 @@ alias vz="vim ~/.zshrc"                       # edit zsh config in vim
 alias sz='[[ -n "$ZSH_VERSION"  ]] && source ~/.zshrc  || echo "[sz] Not in zsh — use sb"'    # reload zsh config (zsh only)
 alias vv="vim ~/.vimrc"                       # edit vim config in vim
 alias va="vim ~/.aliases"                     # edit aliases file in vim
+alias ep='${EDITOR:-vim} ~/.bash_profile'    # open profile in editor
 
 # ── Dev shortcuts ────────────────────────────────────────────────────────────
 

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -310,6 +310,7 @@ Remove-Item -Force Alias:\h -ErrorAction SilentlyContinue
 Set-Alias -Name h -Value Get-History -Force -Scope Global   # command history
 
 function Edit-Profile { notepad $PROFILE }  # open PS profile in editor
+Remove-Item -Force Alias:\ep -ErrorAction SilentlyContinue
 Set-Alias -Name ep -Value Edit-Profile -Force -Scope Global
 
 # -- psmux (tmux for Windows) -----------------------------------------------

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -309,6 +309,9 @@ Set-Alias -Name pb -Value Invoke-PingBing -Force -Scope Global
 Remove-Item -Force Alias:\h -ErrorAction SilentlyContinue
 Set-Alias -Name h -Value Get-History -Force -Scope Global   # command history
 
+function Edit-Profile { notepad $PROFILE }  # open PS profile in editor
+Set-Alias -Name ep -Value Edit-Profile -Force -Scope Global
+
 # -- psmux (tmux for Windows) -----------------------------------------------
 
 function Invoke-PsmuxList { psmux ls $args }                    # list active psmux sessions

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -431,8 +431,8 @@ Test-Scenario "F-4: Dev shortcut aliases present (uvr, uvs, ni, nr, nrd, nrt, py
     }
 }
 
-Test-Scenario "F-5: Utility aliases present (myip, pb, h)" {
-    $utilAliases = @('myip', 'pb', 'h')
+Test-Scenario "F-5: Utility aliases present (myip, pb, h, ep)" {
+    $utilAliases = @('myip', 'pb', 'h', 'ep')
     foreach ($alias in $utilAliases) {
         if ($windowsSetupProfileContent -notmatch "Set-Alias\s+-Name\s+$alias\b") {
             throw "Missing utility alias '$alias' in scripts/windows/setup.ps1"


### PR DESCRIPTION
Closes #168

## Changes

- **`scripts/windows/setup.ps1`**: Added `Edit-Profile` function and `ep` Set-Alias in the utility aliases section of `Write-PowerShellProfile`
- **`tests/test_windows_setup.ps1`**: Added `ep` to the F-5 utility alias test (`myip`, `pb`, `h`, `ep`)
- **`config/dotfiles/.aliases`**: Added `alias ep='${EDITOR:-vim} ~/.bash_profile'` for Linux/macOS equivalent
- **`README.md`**: Updated utility aliases list to include `ep`

## Usage

- **Windows (PowerShell):** `ep` opens `$PROFILE` in Notepad
- **Linux/macOS:** `ep` opens `~/.bash_profile` in `$EDITOR` (falls back to vim)