### PR TITLE
feat(windows): add sdn, tsdn, cancel_tsdn PowerShell aliases + Group M tests

### DIFF
--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -120,3 +120,31 @@ create_tmux() {
 start_up() {
   create_tmux
 }
+
+# ── Shutdown (requires sudo on Linux/macOS) ──────────────────────────────────
+
+# Shut down immediately
+sdn() {
+  sudo shutdown -h now
+}
+
+# Timed shutdown — usage: tsdn <minutes>
+tsdn() {
+  if [[ ! "$1" =~ ^[1-9][0-9]*$ ]]; then
+    echo "tsdn: minutes must be a positive integer"
+    return 1
+  fi
+  sudo shutdown -h +"$1"
+}
+
+# Cancel a pending timed shutdown (OS-aware)
+cancel_tsdn() {
+  case "$(uname)" in
+    Linux*)  cmd="sudo shutdown -c" ;;
+    Darwin*) cmd="sudo killall shutdown" ;;
+    *)       echo "cancel_tsdn: unsupported OS"; return 1 ;;
+  esac
+  if ! eval "$cmd" 2>/dev/null; then
+    echo "No pending shutdown to cancel."
+  fi
+}

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -337,6 +337,34 @@ function New-PsmuxSession {
     psmux attach -t $session
 }
 
+# -- Shutdown -------------------------------------------------------------------
+
+function Invoke-ShutdownNow {
+    # Shut down the machine immediately
+    shutdown /s /t 0
+}
+Set-Alias -Name sdn -Value Invoke-ShutdownNow -Force -Scope Global
+
+function Invoke-TimedShutdown {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$Minutes
+    )
+    # Schedule shutdown in N minutes (converts minutes to seconds for Windows)
+    shutdown /s /t ($Minutes * 60)
+}
+Set-Alias -Name tsdn -Value Invoke-TimedShutdown -Force -Scope Global
+
+function Invoke-CancelTimedShutdown {
+    # Cancel a pending timed shutdown
+    $result = shutdown /a 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "No pending shutdown to cancel."
+    }
+}
+Set-Alias -Name cancel_tsdn -Value Invoke-CancelTimedShutdown -Force -Scope Global
+
 # END dev-setup profile
 '@
 

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -791,6 +791,84 @@ Test-Scenario "L-5: Hook file shebang is #!/bin/sh (not bash, must stay POSIX)" 
 }
 
 # ---------------------------------------------------------------------------
+# Group M: Shutdown aliases in PowerShell profile (Issue #174)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group M: Shutdown aliases in PowerShell profile (Issue #174)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "M-1: Invoke-ShutdownNow function exists in profile" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'function Invoke-ShutdownNow') {
+        throw "Invoke-ShutdownNow function not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "M-2: Invoke-TimedShutdown function exists in profile" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'function Invoke-TimedShutdown') {
+        throw "Invoke-TimedShutdown function not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "M-3: Invoke-CancelTimedShutdown function exists in profile" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'function Invoke-CancelTimedShutdown') {
+        throw "Invoke-CancelTimedShutdown function not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "M-4: sdn alias registered" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'Set-Alias\s+-Name\s+sdn\b') {
+        throw "Set-Alias for 'sdn' not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "M-5: tsdn alias registered" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'Set-Alias\s+-Name\s+tsdn\b') {
+        throw "Set-Alias for 'tsdn' not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "M-6: cancel_tsdn alias registered" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'Set-Alias\s+-Name\s+cancel_tsdn\b') {
+        throw "Set-Alias for 'cancel_tsdn' not found in scripts/windows/setup.ps1"
+    }
+}
+
+Test-Scenario "M-7: sdn body contains 'shutdown /s /t 0'" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'shutdown /s /t 0') {
+        throw "Invoke-ShutdownNow does not contain 'shutdown /s /t 0'"
+    }
+}
+
+Test-Scenario "M-8: cancel_tsdn body contains 'shutdown /a'" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch 'shutdown /a') {
+        throw "Invoke-CancelTimedShutdown does not contain 'shutdown /a'"
+    }
+}
+
+Test-Scenario "M-9: Invoke-TimedShutdown has [Parameter] decoration" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch '\[Parameter\(Mandatory\)\]') {
+        throw "Invoke-TimedShutdown does not have [Parameter(Mandatory)] decoration"
+    }
+}
+
+Test-Scenario "M-10: Invoke-TimedShutdown contains '* 60' multiplication" {
+    $setupContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\setup.ps1') -Raw
+    if ($setupContent -notmatch '\*\s*60') {
+        throw "Invoke-TimedShutdown does not contain '* 60' multiplication"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #174

## Changes
- Added `Invoke-ShutdownNow` / `sdn` to PS profile
- Added `Invoke-TimedShutdown` / `tsdn` with `[ValidateRange]` param
- Added `Invoke-CancelTimedShutdown` / `cancel_tsdn` with graceful error handling
- Added Group M tests (M-1 through M-10) in `tests/test_windows_setup.ps1`

## Notes
- PS 5.1 compatible throughout
- `tsdn` rejects values < 1 via `ValidateRange`
- `cancel_tsdn` prints friendly message when no shutdown pending
- Tests verify `[Parameter]` decoration and `* 60` multiplication