### PR TITLE
feat(aliases): add sdn, tsdn, cancel_tsdn shutdown functions

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -60,6 +60,10 @@ Completed Issue #97 — updated Ralph charter and issue-lifecycle template to ba
 
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
+### 2026-05-04 — PR #175 Review: Shutdown Aliases (Issue #174)
+
+Reviewed and approved PR #175 (shutdown aliases for Windows PowerShell + Unix .aliases). All 61 tests pass, zero regressions. Key patterns confirmed: `$LASTEXITCODE` is the correct way to check external command failure in PS (not try/catch), and `2>&1` captures stderr into a variable cleanly. Group M tests (M-1 through M-10) follow the established static-analysis pattern (regex against file content). The `.aliases` companion for Unix adds OS-aware cancel logic via `uname` case statement — good cross-platform parity.
+
 ---
 
 ## 2026-04-18 — Sprint 6 Retro Action Items: Created Issues #109–#111

--- a/.squad/decisions/inbox/mickey-pr175-review.md
+++ b/.squad/decisions/inbox/mickey-pr175-review.md
@@ -1,0 +1,25 @@
+# Mickey — PR #175 Review Decision
+
+**PR:** #175 (`squad/174-sdn-windows-profile` → `develop`)
+**Issue:** #174 — Shutdown aliases for Windows PowerShell
+**Date:** 2026-05-04
+**Verdict:** APPROVED
+
+## Checklist Results
+
+- [x] Functions follow `Invoke-XxxYyy` naming and `function + Set-Alias` pattern
+- [x] All code inside the `@'...'@` heredoc (lines 340–366, between markers at L154 and L368)
+- [x] `Invoke-TimedShutdown` has `[Parameter(Mandatory)]` and `[ValidateRange(1, [int]::MaxValue)]`
+- [x] `Invoke-CancelTimedShutdown` catches failure and prints `"No pending shutdown to cancel."`
+- [x] PS 5.1 compatible — no unguarded `$IsWindows`/`$IsLinux`/`$IsMacOS`
+- [x] Group M tests (M-1 through M-10) — correct group letter
+- [x] Tests use ASCII-only string literals (Unicode only in pre-existing harness)
+- [x] Tests verify `[Parameter` decoration (M-9) AND `* 60` multiplication (M-10)
+- [x] All 61 tests pass — confirmed locally
+- [x] No regressions to Groups A–L
+
+## Notes
+
+- Bonus: Unix-side aliases added in `config/dotfiles/.aliases` (sdn, tsdn, cancel_tsdn with OS-aware cancel logic). Clean implementation.
+- `$result = shutdown /a 2>&1` captures stderr properly; `$LASTEXITCODE` check is the right PS pattern for external commands.
+- No merge performed — coordinator handles that after both PRs are approved.

--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -120,3 +120,31 @@ create_tmux() {
 start_up() {
   create_tmux
 }
+
+# ── Shutdown (requires sudo on Linux/macOS) ──────────────────────────────────
+
+# Shut down immediately
+sdn() {
+  sudo shutdown -h now
+}
+
+# Timed shutdown — usage: tsdn <minutes>
+tsdn() {
+  if [[ ! "$1" =~ ^[1-9][0-9]*$ ]]; then
+    echo "tsdn: minutes must be a positive integer"
+    return 1
+  fi
+  sudo shutdown -h +"$1"
+}
+
+# Cancel a pending timed shutdown (OS-aware)
+cancel_tsdn() {
+  case "$(uname)" in
+    Linux*)  cmd="sudo shutdown -c" ;;
+    Darwin*) cmd="sudo killall shutdown" ;;
+    *)       echo "cancel_tsdn: unsupported OS"; return 1 ;;
+  esac
+  if ! eval "$cmd" 2>/dev/null; then
+    echo "No pending shutdown to cancel."
+  fi
+}


### PR DESCRIPTION
Closes #173

## Changes
- Added `sdn()` — immediate shutdown (Linux/macOS)
- Added `tsdn()` — timed shutdown with input validation
- Added `cancel_tsdn()` — cancel pending shutdown with OS detection and friendly error handling

## Notes
- `tsdn` rejects non-positive integers
- `cancel_tsdn` handles no-pending-shutdown gracefully
- `sudo` required for shutdown on Linux/macOS (commented inline)