### PR TITLE
fix(macos): add vim to Homebrew prerequisites install

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -472,3 +472,12 @@ Added three shutdown control aliases to config/dotfiles/.aliases:
 ### Outcome
 
 Shutdown control is now available across all platforms: Windows (PowerShell functions) + Unix-like (shell aliases).
+
+## Learnings
+
+### 2026-04-19: Issue #178 — macOS/Linux install_prerequisites divergence
+
+The `install_prerequisites()` function in `scripts/linux/setup.sh` maintains separate package lists
+for macOS (brew) and Linux (apt). These lists can silently drift apart — vim was present in the
+Linux apt path but missing from the macOS brew path. When adding new prerequisites, always verify
+both platform branches get the package to maintain the cross-platform parity documented in README.

--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -63,7 +63,7 @@ install_prerequisites() {
       log_warn "Homebrew not found — install it from https://brew.sh and re-run setup"
       return 0
     fi
-    brew install curl git tmux
+    brew install curl git vim tmux
   else
     sudo apt-get update -qq
     sudo apt-get install -y curl git build-essential vim tmux


### PR DESCRIPTION
Closes #178

## Change
Added `vim` to the `brew install` line in the macOS branch of `install_prerequisites()` in `scripts/linux/setup.sh`.

Linux apt path already installs vim. This restores cross-platform parity as documented in README.