### PR TITLE
fix(windows): use correct psmux winget id

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -164,3 +164,10 @@ Fixed three regressions introduced by PR #130:
 **Correct Pattern:** `$PSVersionTable.PSVersion.Major -ge 6 -and $IsWindows` — RHS never evaluated on PS 5.x.
 
 **Key Learning:** PSVersion-based short-circuit checks are ONLY safe pattern for PS 5.1 strict mode.
+
+#### Issue #179 -- Fix psmux winget package ID
+- **PR:** #204 -- `fix(windows): use correct psmux winget id (closes #179)`
+- **Branch:** `squad/179-psmux-winget-id` from `develop`
+- **What:** Replaced skip-with-warning hack with real winget install using correct ID `marlocarlo.psmux`. Removed stale NOTE comment and dead nicowillis/psmux URL.
+- **Key finding:** Correct winget ID is `marlocarlo.psmux` (confirmed 2026-05-15). Real upstream repo: `psmux/psmux`.
+- **Tests:** All psmux groups (H, I, P) pass. ASCII safety verified.

--- a/scripts/windows/tools/psmux.ps1
+++ b/scripts/windows/tools/psmux.ps1
@@ -2,7 +2,6 @@
 #
 # Owner: Goofy (#2)
 # Installs psmux - terminal multiplexer for Windows PowerShell
-# NOTE: Known issue #179 - winget ID may not be correct, preserved as-is for now
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -18,10 +17,7 @@ function Install-Psmux {
         Write-Ok "psmux already installed: $(psmux --version 2>&1)"
         return
     }
-    # psmux is not yet available as a valid winget package ID (see issue #179, #197).
-    # Attempting `winget install --id psmux` fails on all setups - skip with warning
-    # rather than aborting the entire setup. User must install manually.
-    Write-Warn "psmux is not yet available via winget (see #179, #197)."
-    Write-Warn "Install manually from: https://github.com/nicowillis/psmux"
-    Write-Warn "Skipping psmux install - continuing setup."
+    Write-Info "Installing psmux..."
+    winget install --id marlocarlo.psmux --accept-source-agreements --accept-package-agreements --silent
+    Write-Ok "psmux installed."
 }

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -991,20 +991,38 @@ Test-Scenario "P-1: psmux.ps1 can be dot-sourced without error and Install-Psmux
 }
 
 if ($null -ne (Get-Command psmux -ErrorAction SilentlyContinue)) {
-    Write-Skip "P-2: Install-Psmux emits [WARN] when psmux not installed" `
+    Write-Skip "P-2: Install-Psmux invokes winget install when psmux missing" `
         "psmux binary is present on this machine - not-installed code path cannot be exercised"
 } else {
-    Test-Scenario "P-2: Install-Psmux emits [WARN] when psmux is not installed (not a fatal error)" {
-        $output = Install-Psmux 2>&1 | Out-String
-        if ($output -notmatch '\[WARN\]') {
-            throw "Install-Psmux did not emit [WARN] when psmux is absent (output: $output)"
+    Test-Scenario "P-2: Install-Psmux invokes 'winget install --id marlocarlo.psmux' when psmux is not installed" {
+        $script:WingetCalled = $false
+        $script:WingetArgs = $null
+        function global:winget {
+            $script:WingetCalled = $true
+            $script:WingetArgs = $args
+        }
+        try {
+            $output = Install-Psmux 2>&1 | Out-String
+            if (-not $script:WingetCalled) {
+                throw "Install-Psmux did not invoke winget when psmux is absent. Output: $output"
+            }
+            if (($script:WingetArgs -join ' ') -notmatch 'marlocarlo\.psmux') {
+                throw "Install-Psmux invoked winget with wrong package ID. Args: $($script:WingetArgs -join ' ')"
+            }
+        } finally {
+            Remove-Item -Force Function:winget -ErrorAction SilentlyContinue
         }
     }
 }
 
 Test-Scenario "P-3: Install-Psmux is idempotent (second call does not throw)" {
-    Install-Psmux | Out-Null
-    Install-Psmux | Out-Null
+    function global:winget { }
+    try {
+        Install-Psmux | Out-Null
+        Install-Psmux | Out-Null
+    } finally {
+        Remove-Item -Force Function:winget -ErrorAction SilentlyContinue
+    }
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Use correct winget package ID for psmux installation (closes #179).

## Changes

- Replace skip-with-warning hack with real `winget install` using correct package ID `marlocarlo.psmux`
- Remove stale `NOTE: Known issue #179` comment header
- Remove dead GitHub URL reference (`nicowillis/psmux` is 404; real upstream is `psmux/psmux`)

## Research

Confirmed correct ID via `winget search psmux` (2026-05-15):
- Package ID: `marlocarlo.psmux`
- Source: winget

## Verification

- ASCII safety: no bytes > 127 in `.ps1` file
- All psmux-related tests pass (Groups H, I, P)
- Pre-existing unrelated failures unchanged

closes #179