### PR TITLE
refactor(dotfiles): make tmux auto-attach opt-in via TMUX_AUTOSTART

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -205,3 +205,9 @@ Delivered 30 PowerShell aliases with full git/gh/dev parity, conflict guards for
 - Grouped ~60 PRs into meaningful bullets by theme rather than listing each individually
 - Branch: squad/188-add-changelog -> develop
 
+### 2025-07-14: Tmux auto-attach opt-in (Issue #192)
+- Wrapped `start_up` invocation in `.zshrc.template` behind `TMUX_AUTOSTART=1` guard
+- Breaking change: auto-attach now OFF by default; users must export the var
+- Used POSIX `[ "${VAR:-}" = "1" ]` for bash/zsh compatibility
+- Branch: squad/192-tmux-opt-in -> develop
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modular tool installer split -- 451-line `setup.ps1` monolith refactored into 76-line orchestrator + 9 per-tool files under `scripts/windows/tools/` (PR #195)
 - PS 5.1 test groups N, O, P and ASCII-clean test runner (PR #200)
 
+### Changed
+- Made tmux auto-attach opt-in via `TMUX_AUTOSTART=1` env var (was always-on)
+
 ### Fixed
 - PS 5.1 compat: psmux install skip-with-warning + profile write diagnostics (PR #198)
 

--- a/config/dotfiles/.zshrc.template
+++ b/config/dotfiles/.zshrc.template
@@ -19,8 +19,12 @@ export NVM_DIR="$HOME/.nvm"
 
 # ── Startup ──────────────────────────────────────────────────────────────────
 
-# Launch or attach to a tmux session on shell startup (no-op if start_up not defined)
-type start_up &>/dev/null && start_up
+# Auto-attach tmux on shell startup when TMUX_AUTOSTART=1 is exported.
+# Default OFF -- export TMUX_AUTOSTART=1 in your env (or ~/.zshrc) to keep
+# the legacy auto-attach behavior.
+if [ "${TMUX_AUTOSTART:-}" = "1" ]; then
+  type start_up &>/dev/null && start_up
+fi
 
 # ── Prompt (optional — customize or use oh-my-zsh/starship) ─────────────────
 


### PR DESCRIPTION
## Summary

Make tmux auto-attach opt-in instead of always-on.

The `start_up` call in `.zshrc.template` is now gated behind `TMUX_AUTOSTART=1`.
Users who want the old behavior must export the variable.

## Changes

- Wrapped `start_up` invocation in a POSIX-compatible `[ "${TMUX_AUTOSTART:-}" = "1" ]` guard
- Updated CHANGELOG.md with a Changed entry

## Breaking Change

Tmux auto-attach is now **OFF by default**. To restore the previous behavior:

```sh
export TMUX_AUTOSTART=1
```

Closes #192