### PR TITLE
test: add alias parity check across Linux + Windows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,6 +75,11 @@ jobs:
           chmod +x tests/test_aliases.sh
           bash tests/test_aliases.sh
 
+      - name: Run alias parity test
+        run: |
+          chmod +x tests/test_alias_parity.sh
+          bash tests/test_alias_parity.sh
+
   lint-shell-scripts:
     name: Lint Shell Scripts
     runs-on: ubuntu-latest

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -144,3 +144,20 @@ Updated all 5 Group K tests (K-1 through K-5) to track new file locations after 
 **Confidence:** high
 
 Formalized the PS 5.1 CP1252 encoding trap as a reusable skill. Covers detection, fix patterns, common offender table, and when-to-apply rules. Cite this skill in any future `.ps1` file review or creation task.
+
+---
+
+## [2026-05-17] Issue #187: Alias Parity Test
+
+**Branch:** `squad/187-alias-parity`
+**Status:** PR opened
+
+Added `tests/test_alias_parity.sh` -- a bash test that extracts alias names from both Linux (`config/dotfiles/.aliases`) and Windows (`scripts/windows/tools/profile.ps1`), compares the two sets, and fails on undocumented drift.
+
+**Design Choices:**
+- Bash test (not PS) -- simpler cross-file text parsing; runs in `validate-linux` CI job
+- `ALLOWED_ALIAS_DRIFT` array documents intentional platform-only aliases (navigation, ls variants, Docker, editor shortcuts on Linux; rm/touch/gb/New-PsmuxSession on Windows)
+- Windows extraction filters out internal helper functions (Write-Info, etc.) and backing functions (Invoke-Git*) -- only Set-Alias -Name targets and user-facing functions count
+- Wired into validate.yml as "Run alias parity test" step after existing alias unit tests
+
+**Key file:** `tests/test_alias_parity.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Alias parity test between Linux .aliases and Windows PowerShell profile (PR #187)
 - Shutdown aliases: `sdn`, `tsdn`, `cancel_tsdn` for Windows and Linux (PRs #175-#177)
 - Modular tool installer split -- 451-line `setup.ps1` monolith refactored into 76-line orchestrator + 9 per-tool files under `scripts/windows/tools/` (PR #195)
 - PS 5.1 test groups N, O, P and ASCII-clean test runner (PR #200)

--- a/tests/test_alias_parity.sh
+++ b/tests/test_alias_parity.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# tests/test_alias_parity.sh — Alias parity check between Linux and Windows
+#
+# Extracts alias/function names from:
+#   - config/dotfiles/.aliases          (Linux: alias X=..., function X() {...})
+#   - scripts/windows/tools/profile.ps1 (Windows: Set-Alias -Name X, function X {...})
+#
+# Compares the two sets and reports asymmetric differences.
+# Test PASSES if sets are equal OR differences are in ALLOWED_ALIAS_DRIFT.
+# Test FAILS if there are undocumented differences.
+#
+# Usage (from repo root):
+#   bash tests/test_alias_parity.sh
+#
+# Exit codes:
+#   0 — all aliases in parity (or drift is documented)
+#   1 — undocumented alias drift detected
+
+set -uo pipefail
+
+# ── Path setup ────────────────────────────────────────────────────────────────
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LINUX_ALIASES="$REPO_ROOT/config/dotfiles/.aliases"
+WINDOWS_PROFILE="$REPO_ROOT/scripts/windows/tools/profile.ps1"
+
+if [[ ! -f "$LINUX_ALIASES" ]]; then
+    echo "ERROR: $LINUX_ALIASES not found." >&2
+    exit 1
+fi
+
+if [[ ! -f "$WINDOWS_PROFILE" ]]; then
+    echo "ERROR: $WINDOWS_PROFILE not found." >&2
+    exit 1
+fi
+
+# ── Allowed drift ─────────────────────────────────────────────────────────────
+# Aliases that intentionally exist on one platform but not the other.
+# Format: "alias_name:platform" where platform is "linux" or "windows"
+# meaning the alias exists ONLY on that platform.
+
+ALLOWED_ALIAS_DRIFT=(
+    "gb:windows"          # git branch shortcut — Windows only (no Linux equivalent yet)
+    "..:linux"            # cd .. — navigation shortcut, not applicable on Windows
+    "...:linux"           # cd ../.. — navigation shortcut
+    "....:linux"          # cd ../../.. — navigation shortcut
+    "~:linux"             # cd ~ — navigation shortcut
+    "-:linux"             # cd - — navigation shortcut
+    "ls:linux"            # ls --color=auto — ls is not aliased on Windows
+    "ll:linux"            # ls -alF — ls variant
+    "la:linux"            # ls -A — ls variant
+    "l:linux"             # ls -CF — ls variant
+    "lh:linux"            # ls -alFh — ls variant
+    "path:linux"          # echo PATH — Linux-specific
+    "reload:linux"        # source ~/.zshrc — Linux-specific
+    "ports:linux"         # ss -tulnp — Linux-specific
+    "vb:linux"            # vim ~/.bashrc — Linux-specific
+    "sb:linux"            # source ~/.bashrc — Linux-specific
+    "vz:linux"            # vim ~/.zshrc — Linux-specific
+    "sz:linux"            # source ~/.zshrc — Linux-specific
+    "vv:linux"            # vim ~/.vimrc — Linux-specific
+    "va:linux"            # vim ~/.aliases — Linux-specific
+    "pip:linux"           # pip3 — handled differently on Windows
+    "dk:linux"            # docker — not aliased on Windows
+    "dkc:linux"           # docker-compose — not aliased on Windows
+    "dkps:linux"          # docker ps — not aliased on Windows
+    "dkpsa:linux"         # docker ps -a — not aliased on Windows
+    "rm:windows"          # Remove-CustomItem — Windows-specific override
+    "touch:windows"       # Set-FileTimestamp — Windows-specific override
+    "start_up:linux"      # shell startup function — Linux-specific
+    "create_tmux:linux"   # tmux session create — Linux uses tmux directly
+    "New-PsmuxSession:windows"  # Windows equivalent of create_tmux
+)
+
+# ── Extract Linux aliases ─────────────────────────────────────────────────────
+
+extract_linux_aliases() {
+    local file="$1"
+    # Extract alias names: lines matching "alias NAME=..."
+    grep -E '^\s*alias\s+' "$file" \
+        | sed -E "s/^\s*alias\s+([^=]+)=.*/\1/" \
+        | sed 's/^-- //'
+
+    # Extract function names: lines matching "funcname() {"
+    grep -E '^\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)\s*\{' "$file" \
+        | sed -E 's/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\).*/\1/'
+}
+
+# ── Extract Windows aliases ───────────────────────────────────────────────────
+
+extract_windows_aliases() {
+    local file="$1"
+    # Extract Set-Alias -Name X names
+    grep -iE '^\s*Set-Alias\s+-Name\s+' "$file" \
+        | sed -E 's/.*-Name\s+([^ ]+).*/\1/'
+
+    # Extract function names (exclude helper/internal functions)
+    # Internal functions: Write-Info, Write-Ok, Write-Warn, Write-Err, Write-PowerShellProfile
+    grep -E '^\s*function\s+[A-Za-z]' "$file" \
+        | sed -E 's/^\s*function\s+([A-Za-z_][A-Za-z0-9_-]*).*/\1/' \
+        | grep -vE '^(Write-Info|Write-Ok|Write-Warn|Write-Err|Write-PowerShellProfile|Remove-CustomItem|Set-FileTimestamp|Get-GitStatus|Invoke-GitCommit|Get-GitBranch|Add-GitFiles|Get-GitLogPretty|Get-GitLog|Invoke-GitFetch|Invoke-GitFetchPrune|Invoke-GitStash|Get-GitStashList|Add-GitAllFiles|Invoke-GitCommitMessage|New-GitBranch|Invoke-GitCheckout|Get-GitDiff|Get-GitDiffStaged|Invoke-GitStashPop|Invoke-GitPush|Invoke-GitPushForce|Invoke-GitPull|Invoke-GitRebase|Invoke-GitRebaseInteractive|Invoke-GitRestore|Invoke-GitRestoreStaged|New-GhPR|Get-GhPRList|Get-GhPRView|Get-GhIssueList|Get-GhIssueView|Invoke-UvRun|Invoke-UvSync|Invoke-NpmInstall|Invoke-NpmRun|Invoke-NpmRunDev|Invoke-NpmRunTest|Invoke-Python|Get-MyIp|Invoke-PingBing|Edit-Profile|Invoke-PsmuxList|Invoke-PsmuxKillServer|Invoke-PsmuxNewSession|Invoke-PsmuxAttach|Invoke-ShutdownNow|Invoke-TimedShutdown|Invoke-CancelTimedShutdown)$'
+}
+
+# ── Compare ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo ">>> tests/test_alias_parity.sh -- Cross-platform alias parity check"
+echo ""
+
+# Get sorted unique alias lists
+LINUX_SET=$(extract_linux_aliases "$LINUX_ALIASES" | sort -u)
+WINDOWS_SET=$(extract_windows_aliases "$WINDOWS_PROFILE" | sort -u)
+
+echo "Linux aliases found:   $(echo "$LINUX_SET" | wc -l | tr -d ' ')"
+echo "Windows aliases found: $(echo "$WINDOWS_SET" | wc -l | tr -d ' ')"
+echo ""
+
+# Find differences
+LINUX_ONLY=$(comm -23 <(echo "$LINUX_SET") <(echo "$WINDOWS_SET"))
+WINDOWS_ONLY=$(comm -13 <(echo "$LINUX_SET") <(echo "$WINDOWS_SET"))
+
+UNDOCUMENTED_DRIFT=0
+
+# Check Linux-only aliases against allowed drift
+if [[ -n "$LINUX_ONLY" ]]; then
+    echo "Aliases in Linux but not Windows:"
+    while IFS= read -r alias_name; do
+        [[ -z "$alias_name" ]] && continue
+        allowed=false
+        for drift in "${ALLOWED_ALIAS_DRIFT[@]}"; do
+            drift_name="${drift%%:*}"
+            drift_platform="${drift##*:}"
+            if [[ "$drift_name" == "$alias_name" && "$drift_platform" == "linux" ]]; then
+                allowed=true
+                break
+            fi
+        done
+        if $allowed; then
+            echo "  [allowed] $alias_name"
+        else
+            echo "  [UNDOCUMENTED] $alias_name"
+            UNDOCUMENTED_DRIFT=$((UNDOCUMENTED_DRIFT + 1))
+        fi
+    done <<< "$LINUX_ONLY"
+    echo ""
+fi
+
+# Check Windows-only aliases against allowed drift
+if [[ -n "$WINDOWS_ONLY" ]]; then
+    echo "Aliases in Windows but not Linux:"
+    while IFS= read -r alias_name; do
+        [[ -z "$alias_name" ]] && continue
+        allowed=false
+        for drift in "${ALLOWED_ALIAS_DRIFT[@]}"; do
+            drift_name="${drift%%:*}"
+            drift_platform="${drift##*:}"
+            if [[ "$drift_name" == "$alias_name" && "$drift_platform" == "windows" ]]; then
+                allowed=true
+                break
+            fi
+        done
+        if $allowed; then
+            echo "  [allowed] $alias_name"
+        else
+            echo "  [UNDOCUMENTED] $alias_name"
+            UNDOCUMENTED_DRIFT=$((UNDOCUMENTED_DRIFT + 1))
+        fi
+    done <<< "$WINDOWS_ONLY"
+    echo ""
+fi
+
+# ── Result ────────────────────────────────────────────────────────────────────
+
+if [[ "$UNDOCUMENTED_DRIFT" -eq 0 ]]; then
+    if [[ -z "$LINUX_ONLY" && -z "$WINDOWS_ONLY" ]]; then
+        echo "[PASS] Alias sets are identical across platforms."
+    else
+        echo "[PASS] All alias differences are documented in ALLOWED_ALIAS_DRIFT."
+    fi
+    exit 0
+else
+    echo "[FAIL] $UNDOCUMENTED_DRIFT undocumented alias difference(s) found."
+    echo ""
+    echo "To fix: either add the alias to both platforms, or document the"
+    echo "difference in the ALLOWED_ALIAS_DRIFT list in this test file."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `tests/test_alias_parity.sh` - a cross-platform alias parity test that:

1. Extracts alias names from Linux `config/dotfiles/.aliases` (`alias X=...` and function names)
2. Extracts alias names from Windows `scripts/windows/tools/profile.ps1` (`Set-Alias -Name X` targets and user-facing functions)
3. Compares the two sets and reports asymmetric differences
4. Passes if differences are documented in `ALLOWED_ALIAS_DRIFT`; fails otherwise

## Changes

- `tests/test_alias_parity.sh` - new parity test
- `.github/workflows/validate.yml` - wired into `validate-linux` job
- `CHANGELOG.md` - added entry

## Known Drift (documented in ALLOWED_ALIAS_DRIFT)

- **Linux-only:** navigation (`..`, `...`), ls variants, Docker aliases, editor/reload shortcuts, tmux functions
- **Windows-only:** `gb` (git branch), `rm`/`touch` (overrides), `New-PsmuxSession`

Closes #187