### PR TITLE
ci: wire test_git_hooks.ps1 into validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -135,6 +135,12 @@ jobs:
       - name: Run Remove-CustomItem regression test
         run: pwsh tests/test_remove_custom_item.ps1
 
+      - name: Configure git hooks path
+        run: git config core.hooksPath hooks
+
+      - name: Run git hooks tests
+        run: pwsh tests/test_git_hooks.ps1
+
   validate-ps51:
     name: Validate PowerShell 5.1 Compatibility
     runs-on: windows-latest
@@ -208,3 +214,13 @@ jobs:
         shell: powershell
         run: |
           powershell -ExecutionPolicy Bypass -File tests\test_windows_setup.ps1
+
+      - name: Configure git hooks path
+        shell: powershell
+        run: |
+          git config core.hooksPath hooks
+
+      - name: Run git hooks tests (PS 5.1)
+        shell: powershell
+        run: |
+          powershell -ExecutionPolicy Bypass -File tests\test_git_hooks.ps1

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -57,6 +57,13 @@ Established CI/CD validation framework and cross-platform test coverage infrastr
 
 ## Recent Work
 
+## [2026-05-18T00:00:00Z] Issue #183: Wire test_git_hooks.ps1 into validate.yml
+
+**Branch:** `squad/183-test-git-hooks-ci`
+**What:** Added `tests/test_git_hooks.ps1` to both `validate-powershell` (pwsh) and `validate-ps51` (powershell) CI jobs. Added prerequisite `git config core.hooksPath hooks` step so the hook-path assertion passes on fresh runner checkouts.
+
+---
+
 ## [2026-05-16T01:30:00Z] Issue #197: Non-ASCII Test File Fix (CP1252 Encoding Cleanup)
 
 **Branch:** `squad/197-ps51-compat-fix`  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CI now runs `tests/test_git_hooks.ps1` to catch git hook regressions
 - Alias parity test between Linux .aliases and Windows PowerShell profile (PR #187)
 - Shutdown aliases: `sdn`, `tsdn`, `cancel_tsdn` for Windows and Linux (PRs #175-#177)
 - Modular tool installer split -- 451-line `setup.ps1` monolith refactored into 76-line orchestrator + 9 per-tool files under `scripts/windows/tools/` (PR #195)

--- a/tests/test_git_hooks.ps1
+++ b/tests/test_git_hooks.ps1
@@ -89,6 +89,11 @@ Test-Scenario "Hook files exist and are non-empty" {
 # ---------------------------------------------------------------------------
 # Group B: commit-msg hook validation
 # ---------------------------------------------------------------------------
+# NOTE: Temp commit-msg files MUST be written with -Encoding ASCII (not UTF8).
+# PS 5.1's Set-Content -Encoding UTF8 writes UTF-8 WITH BOM, which the POSIX
+# sh-based commit-msg hook reads as the first bytes of the line, breaking the
+# conventional-commits regex. ASCII is safe on both PS 5.1 and PS 7 and the
+# test content is pure ASCII anyway.
 
 Write-Host "`n========================================================" -ForegroundColor Cyan
 Write-Host " Group B: commit-msg hook validation" -ForegroundColor Cyan
@@ -97,7 +102,7 @@ Write-Host "========================================================" -Foregroun
 Test-Scenario "commit-msg hook rejects non-conventional message" {
     $tempMsgFile = Join-Path $PSScriptRoot "temp_commit_msg_$(Get-Random).txt"
     try {
-        Set-Content $tempMsgFile -Value "This is not conventional" -Encoding UTF8
+        Set-Content $tempMsgFile -Value "This is not conventional" -Encoding ASCII
         
         $hookPath = Join-Path $RepoRoot "hooks\commit-msg"
         
@@ -125,7 +130,7 @@ Test-Scenario "commit-msg hook rejects non-conventional message" {
 Test-Scenario "commit-msg hook accepts valid conventional message" {
     $tempMsgFile = Join-Path $PSScriptRoot "temp_commit_msg_valid_$(Get-Random).txt"
     try {
-        Set-Content $tempMsgFile -Value "feat(hooks): add commit message validation" -Encoding UTF8
+        Set-Content $tempMsgFile -Value "feat(hooks): add commit message validation" -Encoding ASCII
         
         $hookPath = Join-Path $RepoRoot "hooks\commit-msg"
         
@@ -163,7 +168,7 @@ Test-Scenario "commit-msg hook accepts multiple valid formats" {
     foreach ($msg in $validMessages) {
         $tempMsgFile = Join-Path $PSScriptRoot "temp_commit_msg_multi_$(Get-Random).txt"
         try {
-            Set-Content $tempMsgFile -Value $msg -Encoding UTF8
+            Set-Content $tempMsgFile -Value $msg -Encoding ASCII
             
             $hookPath = Join-Path $RepoRoot "hooks\commit-msg"
             


### PR DESCRIPTION
Wire `tests/test_git_hooks.ps1` into the `validate.yml` CI workflow so git hook regressions are caught automatically.

## Changes

- **validate-powershell job (pwsh):** Added `git config core.hooksPath hooks` prerequisite step + `pwsh tests/test_git_hooks.ps1` execution step.
- **validate-ps51 job (powershell 5.1):** Added equivalent steps using `powershell -ExecutionPolicy Bypass -File tests\test_git_hooks.ps1`.
- **CHANGELOG:** Added entry under [Unreleased] -> Added.

The test verifies hook file presence, `core.hooksPath` configuration, and commit-msg conventional-commit validation logic.

Closes #183