### PR TITLE
feat(windows): install dotfiles on Windows with .bak backup

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -171,3 +171,13 @@ Fixed three regressions introduced by PR #130:
 - **What:** Replaced skip-with-warning hack with real winget install using correct ID `marlocarlo.psmux`. Removed stale NOTE comment and dead nicowillis/psmux URL.
 - **Key finding:** Correct winget ID is `marlocarlo.psmux` (confirmed 2026-05-15). Real upstream repo: `psmux/psmux`.
 - **Tests:** All psmux groups (H, I, P) pass. ASCII safety verified.
+
+## Learnings
+
+### Issue #180 - Windows dotfiles installer (2026-05-16)
+- Created `scripts/windows/tools/dotfiles.ps1` with `Install-Dotfiles` function
+- Pattern: copy with .bak backup (no symlinks on Windows -- avoids admin/developer mode requirement)
+- File mappings: .editorconfig, .gitconfig.template->.gitconfig, .npmrc.template->.npmrc, .vimrc->_vimrc
+- Windows uses `_vimrc` convention (underscore prefix) unlike Linux `.vimrc`
+- Placed Install-Dotfiles after Install-SquadCli and before Write-PowerShellProfile in setup chain
+- Tests in Group Q of test_windows_setup.ps1 using temp USERPROFILE override

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Windows now installs dotfiles (gitconfig, editorconfig, npmrc, vimrc) with .bak backup (PR #180)
 - Alias parity test between Linux .aliases and Windows PowerShell profile (PR #187)
 - Shutdown aliases: `sdn`, `tsdn`, `cancel_tsdn` for Windows and Linux (PRs #175-#177)
 - Modular tool installer split -- 451-line `setup.ps1` monolith refactored into 76-line orchestrator + 9 per-tool files under `scripts/windows/tools/` (PR #195)

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -31,6 +31,7 @@ function Test-WingetAvailable {
 . "$PSScriptRoot\tools\psmux.ps1"
 . "$PSScriptRoot\tools\copilot.ps1"
 . "$PSScriptRoot\tools\squad-cli.ps1"
+. "$PSScriptRoot\tools\dotfiles.ps1"
 . "$PSScriptRoot\tools\profile.ps1"
 
 function Install-GitHook {
@@ -61,6 +62,7 @@ function Main {
     Install-Psmux
     Install-CopilotCli
     Install-SquadCli
+    Install-Dotfiles
     Write-PowerShellProfile
     Install-GitHook
 

--- a/scripts/windows/tools/dotfiles.ps1
+++ b/scripts/windows/tools/dotfiles.ps1
@@ -1,0 +1,61 @@
+# scripts/windows/tools/dotfiles.ps1 - Dotfile installer for Windows
+#
+# Owner: Goofy (#2)
+# Copies dotfiles to %USERPROFILE% with .bak backup if existing file differs.
+# No symlinks -- plain copy for maximum compatibility (no admin/developer mode).
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Info  { param([string]$Msg) Write-Output "[INFO]  $Msg" }
+function Write-Ok    { param([string]$Msg) Write-Output "[OK]    $Msg" }
+function Write-Warn  { param([string]$Msg) Write-Output "[WARN]  $Msg" }
+
+function Install-Dotfiles {
+    Write-Info "Installing dotfiles..."
+
+    $dotfilesDir = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent) 'config\dotfiles'
+    $home_ = $env:USERPROFILE
+
+    # Mapping: source filename -> target filename under USERPROFILE
+    $fileMappings = @(
+        @{ Source = '.editorconfig';       Target = '.editorconfig' }
+        @{ Source = '.gitconfig.template'; Target = '.gitconfig' }
+        @{ Source = '.npmrc.template';     Target = '.npmrc' }
+        @{ Source = '.vimrc';              Target = '_vimrc' }
+    )
+
+    foreach ($mapping in $fileMappings) {
+        $srcPath = Join-Path $dotfilesDir $mapping.Source
+        $destPath = Join-Path $home_ $mapping.Target
+
+        if (-not (Test-Path $srcPath)) {
+            Write-Warn "Source not found: $srcPath - skipping"
+            continue
+        }
+
+        Write-Info "Installing $($mapping.Source) to $destPath"
+
+        if (Test-Path $destPath) {
+            $srcContent = Get-Content $srcPath -Raw
+            $destContent = Get-Content $destPath -Raw
+
+            if ($srcContent -eq $destContent) {
+                Write-Ok "$($mapping.Target) already up to date - skipped"
+                continue
+            }
+
+            # Back up only if no .bak exists yet
+            $bakPath = "$destPath.bak"
+            if (-not (Test-Path $bakPath)) {
+                Write-Warn "$destPath exists -- backing up to $bakPath"
+                Copy-Item -Path $destPath -Destination $bakPath -Force
+            }
+        }
+
+        Copy-Item -Path $srcPath -Destination $destPath -Force
+        Write-Ok "$($mapping.Target) installed"
+    }
+
+    Write-Ok "Dotfiles installation complete"
+}

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1026,6 +1026,70 @@ Test-Scenario "P-3: Install-Psmux is idempotent (second call does not throw)" {
 }
 
 # ---------------------------------------------------------------------------
+# Group Q: Dotfiles installer (Issue #180)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group Q: Dotfiles installer" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "Q-1: dotfiles.ps1 parses without errors and defines Install-Dotfiles" {
+    $script = Join-Path $RepoRoot 'scripts\windows\tools\dotfiles.ps1'
+    # Parse check - throws if syntax errors
+    $null = [System.Management.Automation.Language.Parser]::ParseFile(
+        $script, [ref]$null, [ref]$null
+    )
+    # Dot-source and verify function exists
+    . $script
+    $cmd = Get-Command Install-Dotfiles -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw "Install-Dotfiles function not defined after dot-sourcing dotfiles.ps1"
+    }
+}
+
+Test-Scenario "Q-2: Install-Dotfiles is idempotent (calling twice does not throw)" {
+    $script = Join-Path $RepoRoot 'scripts\windows\tools\dotfiles.ps1'
+    $tempHome = Join-Path $env:TEMP "dotfiles_test_$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempHome -Force | Out-Null
+    $origProfile = $env:USERPROFILE
+    try {
+        $env:USERPROFILE = $tempHome
+        . $script
+        Install-Dotfiles | Out-Null
+        Install-Dotfiles | Out-Null
+    } finally {
+        $env:USERPROFILE = $origProfile
+        Remove-Item -Recurse -Force $tempHome -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Scenario "Q-3: Install-Dotfiles creates .bak when target differs" {
+    $script = Join-Path $RepoRoot 'scripts\windows\tools\dotfiles.ps1'
+    $tempHome = Join-Path $env:TEMP "dotfiles_bak_test_$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempHome -Force | Out-Null
+    $origProfile = $env:USERPROFILE
+    try {
+        $env:USERPROFILE = $tempHome
+        # Create a .editorconfig with different content
+        $targetFile = Join-Path $tempHome '.editorconfig'
+        Set-Content -Path $targetFile -Value 'old content that differs' -Encoding UTF8
+        . $script
+        Install-Dotfiles | Out-Null
+        $bakFile = "$targetFile.bak"
+        if (-not (Test-Path $bakFile)) {
+            throw ".bak file was not created when target content differed"
+        }
+        $bakContent = Get-Content $bakFile -Raw
+        if ($bakContent -notmatch 'old content that differs') {
+            throw ".bak file does not contain original content"
+        }
+    } finally {
+        $env:USERPROFILE = $origProfile
+        Remove-Item -Recurse -Force $tempHome -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `Install-Dotfiles` to the Windows setup chain (`scripts/windows/tools/dotfiles.ps1`).

**Behavior:**
- Copies dotfiles from `config/dotfiles/` to `%USERPROFILE%`
- If target exists with different content and no `.bak` exists, backs up to `<target>.bak`
- If target already matches source, skips (idempotent)
- No symlinks -- plain copy avoids admin/developer mode requirement

**File mappings:**
| Source | Target |
|--------|--------|
| `.editorconfig` | `%USERPROFILE%\.editorconfig` |
| `.gitconfig.template` | `%USERPROFILE%\.gitconfig` |
| `.npmrc.template` | `%USERPROFILE%\.npmrc` |
| `.vimrc` | `%USERPROFILE%\_vimrc` |

**Tests:** Group Q (Q-1 parse/define, Q-2 idempotency, Q-3 .bak creation)

Closes #180