### PR TITLE
feat: add uninstall / cleanup scripts for Linux and Windows

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -408,3 +408,15 @@ both platform branches get the package to maintain the cross-platform parity doc
 - Windows users with existing checkout still have CRLF .sh files; bind-mount sees `set: pipefail\r` errors
 - Fix: `onCreateCommand` strips `\r` before `postCreateCommand` runs
 - Rule: When adding .gitattributes eol rules, always add devcontainer onCreateCommand CRLF strip as defensive guard
+
+## Learnings
+
+### Issue #189 - Uninstall/cleanup scripts (2025-07-17)
+
+- Created scripts/linux/uninstall.sh and scripts/windows/uninstall.ps1
+- Linux markers: # --- dev-setup managed block (do not edit) --- / # --- end dev-setup managed block ---
+- Windows markers: # BEGIN dev-setup profile / # END dev-setup profile
+- Dotfile .bak paths: ~/.gitconfig, ~/.npmrc, ~/.editorconfig, ~/.aliases, ~/.vimrc
+- Windows profile paths: Documents/WindowsPowerShell and Documents/PowerShell
+- Uninstallers are idempotent; tools intentionally left installed
+- PS1 ASCII safety: box-drawing chars (U+2500 range) trigger the same CP1252 issue as em dashes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Uninstall scripts (`scripts/linux/uninstall.sh`, `scripts/windows/uninstall.ps1`) that revert profile blocks and restore dotfile .bak files. Tools remain installed.
 - Alias parity test between Linux .aliases and Windows PowerShell profile (PR #187)
 - Shutdown aliases: `sdn`, `tsdn`, `cancel_tsdn` for Windows and Linux (PRs #175-#177)
 - Modular tool installer split -- 451-line `setup.ps1` monolith refactored into 76-line orchestrator + 9 per-tool files under `scripts/windows/tools/` (PR #195)

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/linux/uninstall.sh
+#
+# Idempotent uninstaller for dev-setup.
+# - Restores dotfile .bak files created by config/dotfiles/install.sh
+# - Removes dev-setup managed blocks from ~/.zshrc and ~/.bashrc
+# - Does NOT remove installed tools (uv, nvm, gh, vim, copilot, etc.)
+#
+# Usage:
+#   ./scripts/linux/uninstall.sh
+
+set -euo pipefail
+
+# ── Colour helpers ───────────────────────────────────────────────────────────
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+ok()   { printf "${GREEN}[OK] %s${RESET}\n" "$*"; }
+info() { printf "${CYAN}[INFO] %s${RESET}\n" "$*"; }
+skip() { printf "${YELLOW}[SKIP] %s${RESET}\n" "$*"; }
+
+# ── Restore dotfile .bak files ───────────────────────────────────────────────
+restore_backup() {
+  local target="$1"
+  local backup="${target}.bak"
+
+  if [[ -f "$backup" ]]; then
+    mv "$backup" "$target"
+    ok "Restored $target from $backup"
+  else
+    skip "No backup found for $target"
+  fi
+}
+
+printf "\n${CYAN}dev-setup uninstaller${RESET}\n\n"
+
+# Dotfiles that install.sh may have backed up
+DOTFILES=(
+  "$HOME/.gitconfig"
+  "$HOME/.npmrc"
+  "$HOME/.editorconfig"
+  "$HOME/.aliases"
+  "$HOME/.vimrc"
+)
+
+for dotfile in "${DOTFILES[@]}"; do
+  restore_backup "$dotfile"
+done
+
+# ── Remove managed blocks from shell rc files ────────────────────────────────
+remove_managed_block() {
+  local file="$1"
+  local begin_marker="# --- dev-setup managed block (do not edit) ---"
+  local end_marker="# --- end dev-setup managed block ---"
+
+  if [[ ! -f "$file" ]]; then
+    skip "$file does not exist"
+    return
+  fi
+
+  if ! grep -qF "$begin_marker" "$file"; then
+    skip "No dev-setup block in $file"
+    return
+  fi
+
+  # Remove the managed block (inclusive of markers) and any leading blank line
+  sed -i.tmp "/$begin_marker/,/$end_marker/d" "$file"
+  # Clean up the temp file sed creates with -i
+  rm -f "${file}.tmp"
+
+  ok "Removed dev-setup block from $file"
+}
+
+remove_managed_block "$HOME/.zshrc"
+remove_managed_block "$HOME/.bashrc"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+printf "\n${GREEN}[OK] Uninstalled. Tools (uv, nvm, gh, etc.) remain. Remove them manually if you wish.${RESET}\n\n"

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -1,0 +1,109 @@
+# scripts/windows/uninstall.ps1
+#
+# Idempotent uninstaller for dev-setup (Windows).
+# - Restores dotfile .bak files in $HOME (if any exist)
+# - Removes the dev-setup profile block from PowerShell profiles
+# - Does NOT remove installed tools (uv, nvm, gh, vim, copilot, etc.)
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File scripts/windows/uninstall.ps1
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Ok   { param([string]$Msg) Write-Host "[OK]   $Msg" -ForegroundColor Green }
+function Write-Skip { param([string]$Msg) Write-Host "[SKIP] $Msg" -ForegroundColor Yellow }
+function Write-Info { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Cyan }
+
+# -- Restore dotfile .bak files ------------------------------------------------
+function Restore-DotfileBackup {
+    param([string]$Target)
+    $backup = "$Target.bak"
+    if (Test-Path $backup) {
+        Move-Item -Path $backup -Destination $Target -Force
+        Write-Ok "Restored $Target from $backup"
+    } else {
+        Write-Skip "No backup found for $Target"
+    }
+}
+
+Write-Host ""
+Write-Info "dev-setup uninstaller (Windows)"
+Write-Host ""
+
+# Check for any .bak files in USERPROFILE (dotfiles install may or may not exist yet)
+$dotfiles = @(
+    (Join-Path $HOME '.gitconfig'),
+    (Join-Path $HOME '.npmrc'),
+    (Join-Path $HOME '.editorconfig'),
+    (Join-Path $HOME '.aliases'),
+    (Join-Path $HOME '.vimrc')
+)
+
+$foundAny = $false
+foreach ($dotfile in $dotfiles) {
+    if (Test-Path "$dotfile.bak") {
+        $foundAny = $true
+        break
+    }
+}
+
+if ($foundAny) {
+    foreach ($dotfile in $dotfiles) {
+        Restore-DotfileBackup -Target $dotfile
+    }
+} else {
+    Write-Skip "No dotfiles to restore"
+}
+
+# -- Remove dev-setup profile block from PowerShell profiles -------------------
+function Remove-DevSetupProfileBlock {
+    param([string]$ProfilePath)
+
+    if (-not (Test-Path $ProfilePath)) {
+        Write-Skip "Profile not found: $ProfilePath"
+        return
+    }
+
+    $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrEmpty($content)) {
+        Write-Skip "Profile is empty: $ProfilePath"
+        return
+    }
+
+    $beginMarker = '# BEGIN dev-setup profile'
+    $endMarker   = '# END dev-setup profile'
+
+    if ($content -notmatch [regex]::Escape($beginMarker)) {
+        Write-Skip "No dev-setup block in $ProfilePath"
+        return
+    }
+
+    # Strip the managed block (handles both LF and CRLF)
+    $pattern = "(?s)\r?\n?" + [regex]::Escape($beginMarker) + ".*?" + [regex]::Escape($endMarker) + "\r?\n?"
+    $cleaned = $content -replace $pattern, ''
+
+    # Avoid writing an empty file with only whitespace
+    if ([string]::IsNullOrWhiteSpace($cleaned)) {
+        Remove-Item $ProfilePath -Force
+        Write-Ok "Removed profile (was only dev-setup block): $ProfilePath"
+    } else {
+        Set-Content $ProfilePath $cleaned -NoNewline
+        Write-Ok "Removed dev-setup block from $ProfilePath"
+    }
+}
+
+# Target both PS 5.1 and PS 7+ profile paths
+$profilePaths = @(
+    [System.IO.Path]::Combine($HOME, 'Documents', 'WindowsPowerShell', 'Microsoft.PowerShell_profile.ps1'),
+    [System.IO.Path]::Combine($HOME, 'Documents', 'PowerShell', 'Microsoft.PowerShell_profile.ps1')
+)
+
+foreach ($p in $profilePaths) {
+    Remove-DevSetupProfileBlock -ProfilePath $p
+}
+
+# -- Summary -------------------------------------------------------------------
+Write-Host ""
+Write-Ok "Uninstalled. Tools remain."
+Write-Host ""


### PR DESCRIPTION
## Summary

Adds uninstall/cleanup scripts for both Linux and Windows that:

1. **Restore dotfile .bak files** created by the original install
2. **Remove dev-setup managed blocks** from shell profiles
3. **Leave tools installed** (uv, nvm, gh, etc.) - users remove manually if desired

Both scripts are idempotent (safe to run multiple times).

### Files added
- `scripts/linux/uninstall.sh` - Bash uninstall script
- `scripts/windows/uninstall.ps1` - PowerShell uninstall script

### Behavior
- Linux: restores ~/.gitconfig.bak, ~/.npmrc.bak, ~/.editorconfig.bak, ~/.aliases.bak, ~/.vimrc.bak; removes managed blocks from ~/.zshrc and ~/.bashrc
- Windows: restores %USERPROFILE% .bak files (if any); removes profile block from PS 5.1 and PS 7+ profiles

Closes #189
