### PR TITLE
chore(ci): add shellcheck linting for config/dotfiles/.aliases

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -104,6 +104,9 @@ jobs:
             shellcheck "$script"
           done
 
+      - name: Lint config/dotfiles/.aliases
+        run: shellcheck -s bash config/dotfiles/.aliases
+
   lint-powershell:
     name: Lint PowerShell Scripts
     runs-on: ubuntu-latest

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -52,6 +52,8 @@ Established CI/CD validation framework and cross-platform test coverage infrastr
 - PowerShell 5.1 validation requires explicit source-level guards, not runtime version checks — test suite requirements > runtime logic correctness
 - Test suite can check one pattern (e.g., PSVersion guards) but code implements different valid pattern -- tests must be updated in sync
 - PS 5.1 CI step runs `tests/test_windows_setup.ps1` directly via `powershell -File`, so the test file itself must be ASCII-clean (no emojis, em dashes, arrows, or any non-ASCII chars)
+- shellcheck `-s bash` flag is needed for sourced dotfiles like `.aliases` that have no shebang -- tells shellcheck the dialect without requiring SC2148 fix
+- `config/dotfiles/.aliases` passes shellcheck clean as of issue #193 -- no directives needed, no SC1090/SC2034/SC2148 violations
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CI shellcheck linting for `config/dotfiles/.aliases` in lint-shell-scripts job
 - Uninstall scripts (`scripts/linux/uninstall.sh`, `scripts/windows/uninstall.ps1`) that revert profile blocks and restore dotfile .bak files. Tools remain installed.
 - Windows now installs dotfiles (gitconfig, editorconfig, npmrc, vimrc) with .bak backup (PR #180)
 - CI now runs `tests/test_git_hooks.ps1` to catch git hook regressions


### PR DESCRIPTION
## Summary

Adds `config/dotfiles/.aliases` to the shellcheck lint target in CI.

## Changes

- New step in `lint-shell-scripts` job: `shellcheck -s bash config/dotfiles/.aliases`
- Uses `-s bash` flag since `.aliases` is sourced (no shebang)
- File passes shellcheck clean -- no violations found
- CHANGELOG entry added under `[Unreleased] > Added`

## Testing

- Ran `shellcheck -s bash config/dotfiles/.aliases` locally -- zero warnings
- Diff is minimal: one new workflow step, one changelog line

Closes #193