### PR TITLE
ci(macos): add validate-macos job (closes #181)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,67 @@ jobs:
           chmod +x tests/test_alias_parity.sh
           bash tests/test_alias_parity.sh
 
+  validate-macos:
+    name: Validate macOS Setup
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: chmod +x setup.sh scripts/linux/setup.sh scripts/linux/tools/*.sh
+
+      - name: Verify Homebrew available
+        run: |
+          if ! command -v brew &>/dev/null; then
+            echo "FAIL: Homebrew not found on macOS runner"
+            exit 1
+          fi
+          echo "brew: $(brew --version | head -1)"
+
+      - name: Verify shell tools
+        run: |
+          echo "bash: $(bash --version | head -1)"
+          echo "zsh: $(zsh --version)"
+
+      - name: Run setup script
+        run: bash setup.sh
+
+      - name: Validate zsh installed
+        run: |
+          if ! command -v zsh &>/dev/null; then
+            echo "FAIL: zsh not found on PATH"
+            exit 1
+          fi
+          echo "zsh: $(zsh --version)"
+
+      - name: Validate uv installed
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          if ! command -v uv &>/dev/null; then
+            echo "FAIL: uv not found on PATH"
+            exit 1
+          fi
+          echo "uv: $(uv --version)"
+
+      - name: Validate gh CLI installed
+        run: |
+          if ! command -v gh &>/dev/null; then
+            echo "FAIL: gh not found on PATH"
+            exit 1
+          fi
+          echo "gh: $(gh --version | head -1)"
+
+      - name: Test idempotency (run setup a second time)
+        run: |
+          echo "--- Running setup script a second time to test idempotency ---"
+          bash setup.sh
+          echo "Second run completed without errors"
+
+      - name: Run tool version tests
+        run: bash tests/test_tool_versions.sh
+
   lint-shell-scripts:
     name: Lint Shell Scripts
     runs-on: ubuntu-latest

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -61,6 +61,22 @@ Established CI/CD validation framework and cross-platform test coverage infrastr
 
 ## Recent Work
 
+## [2026-05-22T00:00:00Z] Issue #181: macOS CI validation job
+
+**Branch:** `squad/181-macos-ci`
+**PR:** TBD
+**Status:** PR opened
+
+Added `validate-macos` job to `.github/workflows/validate.yml` (6th CI job). Runs on `macos-latest` and validates: Homebrew availability, zsh + gh pre-installed, uv install via curl, nvm + Node.js install, idempotency (second setup run), and `test_tool_versions.sh`. All tool install scripts (`zsh.sh`, `gh.sh`, `uv.sh`, `nvm.sh`) already handle macOS via `uname -s == Darwin` checks -- no script changes needed.
+
+**Key findings:**
+- All tool scripts in `scripts/linux/tools/` already branch on Darwin vs Linux -- no macOS-specific forks required
+- `test_setup_basic.sh` does not exist; `test_tool_versions.sh` is POSIX sh and works cross-platform
+- macOS GitHub runners have Homebrew and zsh pre-installed; gh is also pre-installed
+- Used plain ASCII text in step output (no emoji) to keep the new job ASCII-clean
+
+---
+
 ## [2026-05-19T00:00:00Z] Issue #212: commit-msg hook rejects merge/revert commits
 
 **Branch:** `squad/212-commit-msg-merge-bypass`

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -64,7 +64,7 @@ Established CI/CD validation framework and cross-platform test coverage infrastr
 ## [2026-05-22T00:00:00Z] Issue #181: macOS CI validation job
 
 **Branch:** `squad/181-macos-ci`
-**PR:** TBD
+**PR:** #216
 **Status:** PR opened
 
 Added `validate-macos` job to `.github/workflows/validate.yml` (6th CI job). Runs on `macos-latest` and validates: Homebrew availability, zsh + gh pre-installed, uv install via curl, nvm + Node.js install, idempotency (second setup run), and `test_tool_versions.sh`. All tool install scripts (`zsh.sh`, `gh.sh`, `uv.sh`, `nvm.sh`) already handle macOS via `uname -s == Darwin` checks -- no script changes needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- macOS CI validation via new `validate-macos` job in `validate.yml` (closes #181)
 - `.tool-versions` file for pinning tool versions (nodejs, nvm, uv, copilot-cli)
 - `scripts/lib/read-tool-version.sh` -- POSIX sh helper to read pinned versions
 - `scripts/lib/Read-ToolVersion.ps1` -- PowerShell `Get-ToolVersion` function


### PR DESCRIPTION
## Summary

Adds a `validate-macos` job to `.github/workflows/validate.yml` -- the 6th CI job. macOS was listed as a supported platform in README but had zero CI coverage.

## What the job does

- Runs on `macos-latest`
- Verifies Homebrew, bash, and zsh are available on the runner
- Runs the full `bash setup.sh` pipeline (all tool scripts already handle Darwin)
- Validates zsh, uv, and gh are installed and on PATH after setup
- Runs setup a second time to test idempotency
- Runs `tests/test_tool_versions.sh` (POSIX sh, cross-platform)

## Files changed

- `.github/workflows/validate.yml` -- new `validate-macos` job
- `CHANGELOG.md` -- entry under [Unreleased] > Added
- `.squad/agents/chip/history.md` -- work log entry

## Key findings

- All tool scripts in `scripts/linux/tools/` already branch on `uname -s == Darwin` -- no script changes needed
- `test_tool_versions.sh` is POSIX sh and works on macOS without modification
- macOS GitHub runners have Homebrew, zsh, and gh pre-installed

## Validation

CI should show 6 jobs (5 existing + validate-macos). The new job exercises the full setup pipeline on macOS.

Closes #181