### PR TITLE
feat(windows): add gh auth step to Windows setup (closes #191)

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -420,3 +420,10 @@ both platform branches get the package to maintain the cross-platform parity doc
 - Windows profile paths: Documents/WindowsPowerShell and Documents/PowerShell
 - Uninstallers are idempotent; tools intentionally left installed
 - PS1 ASCII safety: box-drawing chars (U+2500 range) trigger the same CP1252 issue as em dashes
+
+### Issue #191 - Windows GitHub auth step (2026-05-16)
+- PR: TBD -- `feat(windows): add gh auth step`
+- Branch: `squad/191-windows-auth` from `develop`
+- What: Added scripts/windows/auth.ps1 with Invoke-GhAuth that mirrors Linux auth.sh
+- Key findings: Linux uses gh auth login with no flags; Windows uses --hostname github.com --git-protocol https --web for explicit interactive flow. Auth failure is always non-fatal (warn and continue). Non-interactive detection via CI/CODESPACES env vars and [Environment]::UserInteractive.
+- Tests: Group S verifies function exists (S-1), exits cleanly when gh missing (S-2), skips prompt when already authenticated (S-3)

--- a/.squad/decisions/inbox/donald-191-windows-auth-nonfatal.md
+++ b/.squad/decisions/inbox/donald-191-windows-auth-nonfatal.md
@@ -1,0 +1,26 @@
+# Decision: Windows auth uses --web flag and is non-fatal
+
+**Issue:** #191
+**Author:** Donald (Shell Dev)
+**Date:** 2026-05-16
+
+## Context
+
+Windows setup needed a gh auth step matching Linux parity. Two design
+choices were made:
+
+## Decisions
+
+1. **Auth failure is non-fatal.** Invoke-GhAuth catches all errors and
+   emits warnings. It never throws or exits non-zero. This matches the
+   Linux auth.sh philosophy -- auth is optional quality-of-life, not a
+   hard requirement for setup to succeed.
+
+2. **Windows uses `--web` flag.** The `gh auth login` call uses
+   `--hostname github.com --git-protocol https --web` to open the
+   browser-based device flow. This avoids prompting the user for
+   protocol/hostname interactively, reducing friction.
+
+3. **Non-interactive detection.** Uses `$env:CI`, `$env:CODESPACES`,
+   and `[Environment]::UserInteractive` to detect CI/headless runs.
+   In those environments, auth is skipped with a warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Windows GitHub auth step via `scripts/windows/auth.ps1` (closes #191)
 - `.tool-versions` file for pinning tool versions (nodejs, nvm, uv, copilot-cli)
 - `scripts/lib/read-tool-version.sh` -- POSIX sh helper to read pinned versions
 - `scripts/lib/Read-ToolVersion.ps1` -- PowerShell `Get-ToolVersion` function

--- a/scripts/windows/auth.ps1
+++ b/scripts/windows/auth.ps1
@@ -25,13 +25,19 @@ function Invoke-GhAuth {
     }
 
     # Already authenticated?
-    $null = gh auth status 2>&1
-    if ($LASTEXITCODE -eq 0) {
+    $isAuthed = $false
+    try {
+        $null = & gh auth status 2>&1 | Out-String
+        if ($LASTEXITCODE -eq 0) { $isAuthed = $true }
+    } catch {
+        # gh auth status failed - not authenticated
+    }
+    if ($isAuthed) {
         $ghUser = 'authenticated'
         try {
-            $apiOut = gh api user --jq '.login' 2>&1
+            $apiOut = & gh api user --jq '.login' 2>&1 | Out-String
             if ($LASTEXITCODE -eq 0 -and $apiOut) {
-                $ghUser = $apiOut
+                $ghUser = $apiOut.Trim()
             }
         } catch {
             # ignore - fall back to generic message
@@ -64,13 +70,19 @@ function Invoke-GhAuth {
     Write-Host ''
 
     # Verify result
-    $null = gh auth status 2>&1
-    if ($LASTEXITCODE -eq 0) {
+    $loginOk = $false
+    try {
+        $null = & gh auth status 2>&1 | Out-String
+        if ($LASTEXITCODE -eq 0) { $loginOk = $true }
+    } catch {
+        # auth status failed
+    }
+    if ($loginOk) {
         $ghUser = 'authenticated'
         try {
-            $apiOut = gh api user --jq '.login' 2>&1
+            $apiOut = & gh api user --jq '.login' 2>&1 | Out-String
             if ($LASTEXITCODE -eq 0 -and $apiOut) {
-                $ghUser = $apiOut
+                $ghUser = $apiOut.Trim()
             }
         } catch {
             # ignore

--- a/scripts/windows/auth.ps1
+++ b/scripts/windows/auth.ps1
@@ -1,0 +1,82 @@
+# scripts/windows/auth.ps1 - GitHub authentication check and prompt
+#
+# Called by: scripts/windows/setup.ps1 (after gh CLI is installed)
+# Owner:     Goofy (#2)
+# Idempotent: yes - exits cleanly if already authenticated
+#
+# Mirrors scripts/linux/tools/auth.sh behavior:
+#   1. If gh not on PATH, warn and return (non-fatal)
+#   2. If already authenticated, report user and return
+#   3. If non-interactive, warn and return
+#   4. Otherwise launch gh auth login interactively
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Info  { param([string]$Msg) Write-Output "[INFO]  $Msg" }
+function Write-Ok    { param([string]$Msg) Write-Output "[OK]    $Msg" }
+function Write-Warn  { param([string]$Msg) Write-Output "[WARN]  $Msg" }
+
+function Invoke-GhAuth {
+    # Guard: gh CLI must be available
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Warn 'gh CLI not found -- skipping auth check (install gh first)'
+        return
+    }
+
+    # Already authenticated?
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $ghUser = 'authenticated'
+        try {
+            $apiOut = gh api user --jq '.login' 2>&1
+            if ($LASTEXITCODE -eq 0 -and $apiOut) {
+                $ghUser = $apiOut
+            }
+        } catch {
+            # ignore - fall back to generic message
+        }
+        Write-Ok "GitHub: already authenticated as @$ghUser"
+        return
+    }
+
+    # Detect non-interactive environments
+    $nonInteractive = $false
+    if ($env:CI -eq 'true') { $nonInteractive = $true }
+    if ($env:CODESPACES -eq 'true') { $nonInteractive = $true }
+    if (-not [Environment]::UserInteractive) { $nonInteractive = $true }
+
+    if ($nonInteractive) {
+        Write-Warn 'GitHub: not authenticated (non-interactive environment)'
+        Write-Warn "Run 'gh auth login' after setup to enable gh CLI and Copilot CLI"
+        return
+    }
+
+    # Interactive: launch auth flow
+    Write-Info 'GitHub CLI is installed but you are not authenticated.'
+    Write-Info "Launching 'gh auth login' now..."
+    Write-Host ''
+    try {
+        gh auth login --hostname github.com --git-protocol https --web
+    } catch {
+        Write-Warn "gh auth login encountered an error: $_"
+    }
+    Write-Host ''
+
+    # Verify result
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $ghUser = 'authenticated'
+        try {
+            $apiOut = gh api user --jq '.login' 2>&1
+            if ($LASTEXITCODE -eq 0 -and $apiOut) {
+                $ghUser = $apiOut
+            }
+        } catch {
+            # ignore
+        }
+        Write-Ok "GitHub: authenticated as @$ghUser"
+    } else {
+        Write-Warn "GitHub auth may not have completed. Run 'gh auth login' manually if needed."
+    }
+}

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -33,6 +33,7 @@ function Test-WingetAvailable {
 . "$PSScriptRoot\tools\squad-cli.ps1"
 . "$PSScriptRoot\tools\dotfiles.ps1"
 . "$PSScriptRoot\tools\profile.ps1"
+. "$PSScriptRoot\auth.ps1"
 
 function Install-GitHook {
     Write-Info "Configuring git hooks..."
@@ -58,6 +59,7 @@ function Main {
     Install-Uv
     Install-Nvm
     Install-GhCli
+    Invoke-GhAuth
     Install-Vim
     Install-Psmux
     Install-CopilotCli
@@ -71,7 +73,6 @@ function Main {
     Write-Info "Next steps:"
     Write-Info "  1. Restart your terminal to apply PATH changes"
     Write-Info "  2. Run: nvm install lts && nvm use lts"
-    Write-Info "  3. Run: gh auth login"
 }
 
 Main

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1175,11 +1175,17 @@ Test-Scenario "S-3 Invoke-GhAuth does not prompt when already authenticated" {
     # Only run if gh is available and already authenticated
     $hasGh = $null -ne (Get-Command gh -ErrorAction SilentlyContinue)
     if (-not $hasGh) {
-        throw 'SKIP: gh not on PATH'
+        $script:TestsPassed--
+        $script:TestsSkipped++
+        Write-Host "[SKIP] gh not on PATH" -ForegroundColor Yellow
+        return
     }
     $null = gh auth status 2>&1
     if ($LASTEXITCODE -ne 0) {
-        throw 'SKIP: not authenticated -- cannot test skip-when-authed path'
+        $script:TestsPassed--
+        $script:TestsSkipped++
+        Write-Host "[SKIP] not authenticated" -ForegroundColor Yellow
+        return
     }
     # Should return immediately with "already authenticated" message
     $output = Invoke-GhAuth 2>&1 | Out-String

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1180,8 +1180,14 @@ Test-Scenario "S-3 Invoke-GhAuth does not prompt when already authenticated" {
         Write-Host "[SKIP] gh not on PATH" -ForegroundColor Yellow
         return
     }
-    $null = gh auth status 2>&1
-    if ($LASTEXITCODE -ne 0) {
+    $isAuthed = $false
+    try {
+        $authOut = & gh auth status 2>&1 | Out-String
+        if ($LASTEXITCODE -eq 0) { $isAuthed = $true }
+    } catch {
+        # gh auth status failed - not authenticated
+    }
+    if (-not $isAuthed) {
         $script:TestsPassed--
         $script:TestsSkipped++
         Write-Host "[SKIP] not authenticated" -ForegroundColor Yellow

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1135,6 +1135,60 @@ Test-Scenario "R-4 Get-ToolVersion throws on unknown tool" {
 }
 
 # ---------------------------------------------------------------------------
+# Group S: GitHub auth step (Issue #191)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group S: GitHub auth step (Issue #191)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+$authScript = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'auth.ps1'
+
+. $authScript
+
+Test-Scenario "S-1 Invoke-GhAuth is a function after dot-sourcing auth.ps1" {
+    $cmd = Get-Command Invoke-GhAuth -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw 'Invoke-GhAuth not found after dot-sourcing auth.ps1'
+    }
+    if ($cmd.CommandType -ne 'Function') {
+        throw "Expected Function, got $($cmd.CommandType)"
+    }
+}
+
+Test-Scenario "S-2 Invoke-GhAuth exits cleanly when gh is missing" {
+    # Temporarily hide gh by aliasing it to a nonexistent command
+    $origPath = $env:PATH
+    try {
+        # Set PATH to empty so gh cannot be found
+        $env:PATH = ''
+        $output = Invoke-GhAuth 2>&1 | Out-String
+        if ($output -notmatch 'not found') {
+            throw "Expected warning about gh not found, got: $output"
+        }
+    } finally {
+        $env:PATH = $origPath
+    }
+}
+
+Test-Scenario "S-3 Invoke-GhAuth does not prompt when already authenticated" {
+    # Only run if gh is available and already authenticated
+    $hasGh = $null -ne (Get-Command gh -ErrorAction SilentlyContinue)
+    if (-not $hasGh) {
+        throw 'SKIP: gh not on PATH'
+    }
+    $null = gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw 'SKIP: not authenticated -- cannot test skip-when-authed path'
+    }
+    # Should return immediately with "already authenticated" message
+    $output = Invoke-GhAuth 2>&1 | Out-String
+    if ($output -notmatch 'already authenticated') {
+        throw "Expected 'already authenticated' message, got: $output"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a Windows GitHub auth step that mirrors the existing Linux `scripts/linux/tools/auth.sh` behavior. After `gh` CLI is installed via winget, `Invoke-GhAuth` checks auth status and prompts the user to log in if needed.

## Files changed

- **`scripts/windows/auth.ps1`** (new) - `Invoke-GhAuth` function with:
  - Guard: skip if `gh` not on PATH
  - Skip if already authenticated (`gh auth status` exit 0)
  - Skip in non-interactive environments (CI, Codespaces)
  - Interactive: `gh auth login --hostname github.com --git-protocol https --web`
  - All errors are warnings, never fatal
- **`scripts/windows/setup.ps1`** - dot-source auth.ps1, call `Invoke-GhAuth` after `Install-GhCli`
- **`tests/test_windows_setup.ps1`** - Group S (3 tests): function exists, clean exit when gh missing, skips when already authed
- **`CHANGELOG.md`** - Added entry under [Unreleased]
- **`.squad/agents/donald/history.md`** - Session log
- **`.squad/decisions/inbox/donald-191-windows-auth-nonfatal.md`** - Decision record

## Verification

1. Run `powershell -ExecutionPolicy Bypass -File tests\test_windows_setup.ps1`
2. Confirm S-1, S-2, S-3 all pass
3. On a machine with gh installed: run `scripts\windows\setup.ps1` and verify auth step runs after gh install

Closes #191
