### PR TITLE
feat(setup): auto-install Node LTS via nvm; harden squad-cli bootstrap (closes #201)

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -189,3 +189,11 @@ Fixed three regressions introduced by PR #130:
 - **Tests:** Group R (R-1 through R-4) all pass; bash tests in `test_tool_versions.sh`. ASCII safety verified on all .ps1 files (per ps51-runtime-file-encoding skill).
 - **Docs:** README "Version Pinning" section, CHANGELOG under [Unreleased].
 - **Key pattern:** `.tool-versions` format is one `tool version` line per row, `#`-prefixed comments allowed. POSIX parser uses `awk` to find the matching row; PowerShell parser uses `Get-Content | Where-Object`.
+
+### Issue #201 - nvm LTS auto-install + squad-cli bootstrap (2026-05-16)
+- PR: TBD -- `feat(setup): auto-install Node LTS via nvm`
+- Branch: `squad/201-nvm-bootstrap` from `develop`
+- **What:** After nvm installs, auto-run `nvm install <version>` and `nvm use <version>` using pinned nodejs version from `.tool-versions`. Refresh PATH so node/npm are usable in the same session. Changed squad-cli npm-missing from silent WARN to hard ERROR with actionable hints.
+- **Key findings:** Windows PATH refresh requires re-reading Machine+User registry (session-only entries lost). nvm-windows writes active Node dir to user PATH on `nvm use`. Linux uses `\. "$NVM_DIR/nvm.sh"` (POSIX dot, not `source`) to load nvm into current shell. Idempotency: skip if node --version matches pinned version.
+- **Tests:** Groups S (S-1 to S-4) and T (T-1 to T-3) in test_windows_setup.ps1; test_nvm_bootstrap.sh for Linux side.
+- **Related to #190:** Reads pinned nodejs version via `Get-ToolVersion -Name 'nodejs'` (PS) and `read-tool-version.sh nodejs` (bash) -- both from `.tool-versions` file added in #190.

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -191,7 +191,7 @@ Fixed three regressions introduced by PR #130:
 - **Key pattern:** `.tool-versions` format is one `tool version` line per row, `#`-prefixed comments allowed. POSIX parser uses `awk` to find the matching row; PowerShell parser uses `Get-Content | Where-Object`.
 
 ### Issue #201 - nvm LTS auto-install + squad-cli bootstrap (2026-05-16)
-- PR: TBD -- `feat(setup): auto-install Node LTS via nvm`
+- PR: #218 -- `feat(setup): auto-install Node LTS via nvm`
 - Branch: `squad/201-nvm-bootstrap` from `develop`
 - **What:** After nvm installs, auto-run `nvm install <version>` and `nvm use <version>` using pinned nodejs version from `.tool-versions`. Refresh PATH so node/npm are usable in the same session. Changed squad-cli npm-missing from silent WARN to hard ERROR with actionable hints.
 - **Key findings:** Windows PATH refresh requires re-reading Machine+User registry (session-only entries lost). nvm-windows writes active Node dir to user PATH on `nvm use`. Linux uses `\. "$NVM_DIR/nvm.sh"` (POSIX dot, not `source`) to load nvm into current shell. Idempotency: skip if node --version matches pinned version.

--- a/.squad/skills/path-refresh-windows/SKILL.md
+++ b/.squad/skills/path-refresh-windows/SKILL.md
@@ -1,0 +1,55 @@
+# Skill: PATH Refresh on Windows (Registry Read)
+
+**Confidence:** high (verified on PS 5.1 and PS 7+; used in nvm.ps1 since #201)
+**Owner:** Goofy (Cross-Platform Dev)
+**Issue:** #201
+
+---
+
+## What
+
+After a tool installer modifies the Windows PATH (via winget, nvm, or
+`SetEnvironmentVariable`), the current PowerShell session does NOT see
+the change. `$env:Path` is a snapshot taken when the process started.
+
+To make newly installed binaries discoverable without restarting the
+terminal, re-read PATH from the registry:
+
+```powershell
+function Refresh-SessionPath {
+    $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $userPath    = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    $env:Path    = "$machinePath;$userPath"
+}
+```
+
+---
+
+## When to use
+
+- After `winget install` of any tool that adds itself to PATH
+- After `nvm use <version>` (nvm-windows writes the active Node dir to user PATH)
+- After any `[System.Environment]::SetEnvironmentVariable('PATH', ..., 'User')` call
+- Any time the setup chain needs a just-installed binary in the same session
+
+---
+
+## Gotchas
+
+1. **Session-only entries are lost.** If earlier code added something to
+   `$env:Path` without writing to the registry, `Refresh-SessionPath` will
+   drop it. Call it only when you know all important PATH entries are
+   persisted in the registry.
+
+2. **Machine before User.** Windows resolves PATH left-to-right. Putting
+   Machine first matches the default shell behavior.
+
+3. **No equivalent on Linux.** On Linux, `nvm` modifies `$PATH` in the
+   current shell via `source nvm.sh` -- no registry involved.
+
+---
+
+## Citations
+
+- `scripts/windows/tools/nvm.ps1` -- `Refresh-SessionPath` function (PR #201)
+- `scripts/windows/tools/vim.ps1` -- earlier inline PATH refresh (same pattern)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Automatic Node LTS install via nvm during setup; reads pinned version from `.tool-versions` (closes #201)
+- `tests/test_nvm_bootstrap.sh` -- bash tests for nvm/squad-cli bootstrap behavior
+- Group S tests in `test_windows_setup.ps1` for nvm.ps1 Node auto-install logic
+- Group T tests in `test_windows_setup.ps1` for squad-cli.ps1 loud error behavior
 - `.tool-versions` file for pinning tool versions (nodejs, nvm, uv, copilot-cli)
 - `scripts/lib/read-tool-version.sh` -- POSIX sh helper to read pinned versions
 - `scripts/lib/Read-ToolVersion.ps1` -- PowerShell `Get-ToolVersion` function
@@ -25,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `merge` type in commit-msg hook type allowlist (#212)
 
 ### Changed
+- `squad-cli` install failure is now a loud error with actionable hints (was silent warning)
+- `scripts/linux/tools/nvm.sh` installs pinned Node version from `.tool-versions` (was `--lts`)
 - `scripts/linux/tools/nvm.sh` reads nvm version from `.tool-versions` instead of fetching latest
 - `scripts/linux/tools/uv.sh` reads uv version from `.tool-versions` instead of fetching latest
 - `scripts/linux/tools/copilot-cli.sh` reads copilot-cli version from `.tool-versions`

--- a/scripts/linux/tools/nvm.sh
+++ b/scripts/linux/tools/nvm.sh
@@ -1,36 +1,65 @@
 #!/usr/bin/env bash
-# scripts/linux/tools/nvm.sh — Install nvm (Node Version Manager) + Node LTS
+# scripts/linux/tools/nvm.sh -- Install nvm (Node Version Manager) + pinned Node
 #
 # Called by: scripts/linux/setup.sh
-# Owner:     Donald (#4)
-# Idempotent: yes — checks if nvm is already installed before acting
+# Owner:     Goofy (#2) / Donald (#4)
+# Idempotent: yes -- checks if pinned Node version is already installed
 
 set -euo pipefail
 
 log_info()  { printf '\033[0;34m[INFO]\033[0m  %s\n' "$*"; }
 log_ok()    { printf '\033[0;32m[OK]\033[0m    %s\n' "$*"; }
 log_warn()  { printf '\033[0;33m[WARN]\033[0m  %s\n' "$*"; }
+log_error() { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 
-if [[ -s "${NVM_DIR}/nvm.sh" ]]; then
-  log_ok "nvm already installed at ${NVM_DIR}"
-  exit 0
+# Read pinned Node version from .tool-versions
+PINNED_NODE="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" nodejs)"
+
+# -- Check if Node is already at the pinned version -----------------------
+if command -v node &>/dev/null; then
+  CURRENT_VER="$(node --version 2>/dev/null | sed 's/^v//')"
+  if [ "$CURRENT_VER" = "$PINNED_NODE" ]; then
+    log_ok "Node ${PINNED_NODE} already installed -- skipping"
+    exit 0
+  fi
+  log_info "Node ${CURRENT_VER} found but pinned version is ${PINNED_NODE}"
 fi
 
-log_info "Installing nvm..."
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NVM_VERSION="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" nvm)"
-curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash
+# -- Install nvm if missing -----------------------------------------------
+if [ ! -s "${NVM_DIR}/nvm.sh" ]; then
+  NVM_VERSION="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" nvm)"
+  log_info "Installing nvm (pinned: ${NVM_VERSION})..."
+  curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash
+else
+  log_ok "nvm already installed at ${NVM_DIR}"
+fi
 
 # Source nvm in current shell session
 export NVM_DIR="$NVM_DIR"
 # shellcheck source=/dev/null
-[[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+\. "$NVM_DIR/nvm.sh"
 
-log_ok "nvm installed: $(nvm --version 2>/dev/null || echo 'restart shell to activate')"
+log_ok "nvm ready: $(nvm --version 2>/dev/null || echo 'unknown')"
 
-# Install LTS Node
-log_info "Installing Node.js LTS..."
-nvm install --lts \
-  || log_warn "nvm install --lts failed — source ~/.nvm/nvm.sh in a new shell and retry"
+# -- Install and activate pinned Node version ------------------------------
+log_info "Installing Node.js ${PINNED_NODE} via nvm..."
+nvm install "$PINNED_NODE" || {
+  log_error "nvm install ${PINNED_NODE} failed -- try 'nvm install ${PINNED_NODE}' manually"
+  exit 1
+}
+nvm use "$PINNED_NODE"
+
+# -- Verify ----------------------------------------------------------------
+if command -v node &>/dev/null; then
+  log_ok "node $(node --version) ready"
+else
+  log_warn "node not found on PATH after nvm install"
+fi
+if command -v npm &>/dev/null; then
+  log_ok "npm $(npm --version) ready"
+else
+  log_warn "npm not found on PATH after nvm install"
+fi

--- a/scripts/linux/tools/squad-cli.sh
+++ b/scripts/linux/tools/squad-cli.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# scripts/linux/tools/squad-cli.sh — Install squad-cli globally via npm
+# scripts/linux/tools/squad-cli.sh -- Install squad-cli globally via npm
 #
 # Called by: scripts/linux/setup.sh
 # Owner:     Goofy (#106)
-# Idempotent: yes — checks for squad binary before attempting install.
+# Idempotent: yes -- checks for squad binary before attempting install.
 
 set -euo pipefail
 
 log_info()  { printf '\033[0;34m[INFO]\033[0m  %s\n' "$*"; }
 log_ok()    { printf '\033[0;32m[OK]\033[0m    %s\n' "$*"; }
-log_warn()  { printf '\033[0;33m[WARN]\033[0m  %s\n' "$*"; }
+log_error() { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
 
 if command -v squad &>/dev/null; then
   log_ok "squad-cli already installed: $(squad --version 2>&1)"
@@ -17,8 +17,11 @@ if command -v squad &>/dev/null; then
 fi
 
 if ! command -v npm &>/dev/null; then
-  log_warn "npm not found -- skipping squad-cli install"
-  exit 0
+  log_error "npm not found after nvm install. Possible causes:"
+  log_error "  1. PATH refresh failed -- close this terminal and open a new one, then re-run setup"
+  log_error "  2. nvm install failed silently -- check 'nvm list' and try 'nvm install <version>' manually"
+  log_error "  3. Node is installed elsewhere but not on PATH"
+  exit 1
 fi
 
 log_info "Installing squad-cli..."

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -70,8 +70,7 @@ function Main {
     Write-Ok "Setup complete!"
     Write-Info "Next steps:"
     Write-Info "  1. Restart your terminal to apply PATH changes"
-    Write-Info "  2. Run: nvm install lts && nvm use lts"
-    Write-Info "  3. Run: gh auth login"
+    Write-Info "  2. Run: gh auth login"
 }
 
 Main

--- a/scripts/windows/tools/nvm.ps1
+++ b/scripts/windows/tools/nvm.ps1
@@ -1,7 +1,9 @@
-# scripts/windows/tools/nvm.ps1 - nvm-windows installer
+# scripts/windows/tools/nvm.ps1 - nvm-windows + Node.js installer
 #
 # Owner: Goofy (#2)
-# Installs nvm-windows (Node Version Manager for Windows)
+# Installs nvm-windows (Node Version Manager for Windows), then auto-installs
+# the pinned Node.js version from .tool-versions so node/npm are usable in
+# the same setup session.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -11,19 +13,65 @@ function Write-Ok    { param([string]$Msg) Write-Output "[OK]    $Msg" }
 function Write-Warn  { param([string]$Msg) Write-Output "[WARN]  $Msg" }
 function Write-Err   { param([string]$Msg) Write-Output "[ERROR] $Msg" }
 
+function Refresh-SessionPath {
+    $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $userPath    = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    $env:Path    = "$machinePath;$userPath"
+}
+
 function Install-Nvm {
-    if (Get-Command nvm -ErrorAction SilentlyContinue) {
-        Write-Ok "nvm already installed: $(nvm version)"
-        return
-    }
-    # Load pinned version from .tool-versions
+    # Load pinned versions from .tool-versions
     $libDir = Join-Path (Split-Path $PSScriptRoot -Parent) 'lib'
     . (Join-Path $libDir 'Read-ToolVersion.ps1')
-    $nvmVersion = Get-ToolVersion -Name 'nvm'
-    Write-Info "Installing nvm-windows (pinned: $nvmVersion)..."
-    winget install --id CoreyButler.NVMforWindows --silent --accept-source-agreements --accept-package-agreements
-    # Reload PATH so nvm is usable in the current session without restarting
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-    Write-Ok "nvm-windows installed"
-    Write-Warn "Run 'nvm install lts && nvm use lts' in a new terminal to install Node.js"
+    $pinnedNode = Get-ToolVersion -Name 'nodejs'
+
+    # -- Check if Node is already installed at the pinned version -----------
+    $existingNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($existingNode) {
+        $currentVer = (& node --version 2>&1).ToString().TrimStart('v')
+        if ($currentVer -eq $pinnedNode) {
+            Write-Ok "Node $pinnedNode already installed -- skipping"
+            return
+        }
+        Write-Info "Node $currentVer found but pinned version is $pinnedNode"
+    }
+
+    # -- Install nvm-windows if missing ------------------------------------
+    if (-not (Get-Command nvm -ErrorAction SilentlyContinue)) {
+        $nvmVersion = Get-ToolVersion -Name 'nvm'
+        Write-Info "Installing nvm-windows (pinned: $nvmVersion)..."
+        winget install --id CoreyButler.NVMforWindows --silent --accept-source-agreements --accept-package-agreements
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "nvm-windows install failed (winget exit $LASTEXITCODE) -- cannot install Node"
+            return
+        }
+        Refresh-SessionPath
+        if (-not (Get-Command nvm -ErrorAction SilentlyContinue)) {
+            Write-Warn "nvm not found on PATH after install -- open a new terminal and re-run setup"
+            return
+        }
+        Write-Ok "nvm-windows installed"
+    } else {
+        Write-Ok "nvm already installed: $(nvm version)"
+    }
+
+    # -- Install and activate pinned Node version --------------------------
+    Write-Info "Installing Node.js $pinnedNode via nvm..."
+    & nvm install $pinnedNode
+    & nvm use $pinnedNode
+    Refresh-SessionPath
+
+    # -- Verify node/npm are on PATH ---------------------------------------
+    $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+    if ($nodeCmd) {
+        Write-Ok "node $(& node --version) ready"
+    } else {
+        Write-Warn "node not found on PATH after nvm install -- try opening a new terminal"
+    }
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if ($npmCmd) {
+        Write-Ok "npm $(& npm --version) ready"
+    } else {
+        Write-Warn "npm not found on PATH after nvm install -- try opening a new terminal"
+    }
 }

--- a/scripts/windows/tools/squad-cli.ps1
+++ b/scripts/windows/tools/squad-cli.ps1
@@ -18,8 +18,11 @@ function Install-SquadCli {
         return
     }
     if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-        Write-Warn "npm not found -- skipping squad-cli install"
-        return
+        Write-Err "npm not found after nvm install. Possible causes:"
+        Write-Err "  1. PATH refresh failed -- close this terminal and open a new one, then re-run setup"
+        Write-Err "  2. nvm install failed silently -- check 'nvm list' and try 'nvm install <version>' manually"
+        Write-Err "  3. Node is installed elsewhere but not on PATH"
+        exit 1
     }
     Write-Info "Installing squad-cli..."
     npm install -g "@bradygaster/squad-cli"

--- a/tests/test_nvm_bootstrap.sh
+++ b/tests/test_nvm_bootstrap.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# tests/test_nvm_bootstrap.sh -- Verify nvm/squad-cli bootstrap behavior (#201)
+#
+# Checks:
+#   1. nvm.sh sources nvm correctly (uses \. not just source)
+#   2. nvm.sh reads pinned Node version from .tool-versions
+#   3. squad-cli.sh emits ERROR (not WARN) when npm is missing
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+pass() { printf '\033[0;32m[PASS]\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '\033[0;31m[FAIL]\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# --- nvm.sh tests ---
+
+NVM_SCRIPT="${REPO_ROOT}/scripts/linux/tools/nvm.sh"
+
+# T1: nvm.sh sources nvm.sh with POSIX-safe dot
+# shellcheck disable=SC2016
+if grep -q '\\. "\$NVM_DIR/nvm.sh"' "$NVM_SCRIPT"; then
+  pass "nvm.sh sources nvm via POSIX-safe dot command"
+else
+  fail "nvm.sh does not source nvm via POSIX-safe dot command"
+fi
+
+# T2: nvm.sh reads pinned Node version from .tool-versions
+if grep -q 'read-tool-version.sh.*nodejs' "$NVM_SCRIPT"; then
+  pass "nvm.sh reads nodejs version from .tool-versions"
+else
+  fail "nvm.sh does not read nodejs version from .tool-versions"
+fi
+
+# T3: nvm.sh uses pinned version (not --lts)
+if grep -q 'nvm install.*PINNED_NODE' "$NVM_SCRIPT" && ! grep -q 'nvm install --lts' "$NVM_SCRIPT"; then
+  pass "nvm.sh installs pinned version (not --lts)"
+else
+  fail "nvm.sh still uses --lts or does not use PINNED_NODE variable"
+fi
+
+# --- squad-cli.sh tests ---
+
+SQUAD_SCRIPT="${REPO_ROOT}/scripts/linux/tools/squad-cli.sh"
+
+# T4: squad-cli.sh uses ERROR not WARN for npm missing
+if grep -q '\[ERROR\].*npm not found' "$SQUAD_SCRIPT" && ! grep -q '\[WARN\].*npm not found' "$SQUAD_SCRIPT"; then
+  pass "squad-cli.sh emits ERROR (not WARN) when npm missing"
+else
+  fail "squad-cli.sh still uses WARN or missing ERROR for npm-not-found"
+fi
+
+# T5: squad-cli.sh exits non-zero when npm missing
+if grep -q 'exit 1' "$SQUAD_SCRIPT"; then
+  pass "squad-cli.sh exits non-zero when npm missing"
+else
+  fail "squad-cli.sh does not exit non-zero"
+fi
+
+# --- Summary ---
+
+echo ""
+echo "========================================"
+echo "TEST RESULTS"
+echo "========================================"
+echo "Passed: ${PASS}"
+echo "Failed: ${FAIL}"
+echo "========================================"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+echo "All tests passed!"

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -494,12 +494,12 @@ Test-Scenario "G-2: Install-SquadCli is called in Main" {
     }
 }
 
-Test-Scenario "G-3: Install-SquadCli contains npm availability check (skip+warn)" {
+Test-Scenario "G-3: Install-SquadCli contains npm availability check (error+exit)" {
     if ($squadToolContent -notmatch 'Get-Command npm') {
         throw "Install-SquadCli does not check for npm availability"
     }
-    if ($squadToolContent -notmatch 'npm not found -- skipping squad-cli') {
-        throw "Install-SquadCli does not warn when npm is missing"
+    if ($squadToolContent -notmatch 'npm not found after nvm install') {
+        throw "Install-SquadCli does not emit error when npm is missing"
     }
 }
 
@@ -1131,6 +1131,79 @@ Test-Scenario "R-4 Get-ToolVersion throws on unknown tool" {
     }
     if (-not $threw) {
         throw "Expected exception for unknown tool, but none was thrown"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Group S: nvm.ps1 Node auto-install logic (Issue #201)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group S: nvm.ps1 Node auto-install (Issue #201)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+$nvmScript = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'tools' | Join-Path -ChildPath 'nvm.ps1'
+$nvmContent = Get-Content $nvmScript -Raw
+
+Test-Scenario "S-1 nvm.ps1 reads nodejs version from .tool-versions" {
+    if ($nvmContent -notmatch "Get-ToolVersion.*-Name\s+'nodejs'") {
+        throw "nvm.ps1 does not read nodejs version from .tool-versions via Get-ToolVersion"
+    }
+}
+
+Test-Scenario "S-2 nvm.ps1 skips install if node matches pinned version (idempotent)" {
+    if ($nvmContent -notmatch 'already installed.*skipping') {
+        throw "nvm.ps1 does not skip when node version matches pinned version"
+    }
+}
+
+Test-Scenario "S-3 nvm.ps1 refreshes PATH via registry read" {
+    $hasRefresh = $nvmContent -match "GetEnvironmentVariable\('Path',\s*'Machine'\)" -and
+                  $nvmContent -match "GetEnvironmentVariable\('Path',\s*'User'\)"
+    if (-not $hasRefresh) {
+        throw "nvm.ps1 does not refresh PATH from Machine+User registry"
+    }
+}
+
+Test-Scenario "S-4 nvm.ps1 calls nvm install and nvm use with pinned version" {
+    $hasInstall = $nvmContent -match 'nvm install \$pinnedNode'
+    $hasUse     = $nvmContent -match 'nvm use \$pinnedNode'
+    if (-not $hasInstall -or -not $hasUse) {
+        throw "nvm.ps1 does not call nvm install/use with pinned version variable"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Group T: squad-cli.ps1 loud error (Issue #201)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group T: squad-cli.ps1 loud error (Issue #201)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+$squadScript = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'tools' | Join-Path -ChildPath 'squad-cli.ps1'
+$squadContent = Get-Content $squadScript -Raw
+
+Test-Scenario "T-1 squad-cli.ps1 emits ERROR (not WARN) when npm missing" {
+    if ($squadContent -match 'Write-Warn.*npm not found') {
+        throw "squad-cli.ps1 still uses Write-Warn for npm-missing case"
+    }
+    if ($squadContent -notmatch 'Write-Err.*npm not found') {
+        throw "squad-cli.ps1 does not emit Write-Err when npm is missing"
+    }
+}
+
+Test-Scenario "T-2 squad-cli.ps1 exits non-zero when npm missing" {
+    if ($squadContent -notmatch 'exit\s+1') {
+        throw "squad-cli.ps1 does not exit 1 when npm is missing"
+    }
+}
+
+Test-Scenario "T-3 squad-cli.ps1 provides actionable troubleshooting hints" {
+    $hasHint1 = $squadContent -match 'close this terminal'
+    $hasHint2 = $squadContent -match 'nvm.*install.*failed'
+    if (-not $hasHint1 -or -not $hasHint2) {
+        throw "squad-cli.ps1 does not provide actionable troubleshooting hints"
     }
 }
 


### PR DESCRIPTION
## Summary

Auto-install Node.js via nvm during setup and make squad-cli bootstrap failure loud.

### Problem
Two gaps in the Node/npm bootstrap chain meant squad-cli silently failed on fresh installs:
1. `nvm.ps1` printed "run nvm install lts in a new terminal" and exited -- users missed it
2. `squad-cli.ps1` / `squad-cli.sh` logged a quiet `[WARN]` if npm was missing

### Solution

**nvm auto-install (Windows + Linux):**
- Reads pinned Node version from `.tool-versions` (built in #190)
- Runs `nvm install <version>` and `nvm use <version>` in the same session
- Refreshes PATH (Windows: registry re-read; Linux: source nvm.sh)
- Idempotent: skips if `node --version` already matches pinned version

**squad-cli loud error:**
- Changed npm-missing from `[WARN]` + skip to `[ERROR]` + `exit 1`
- Provides 3 actionable troubleshooting hints

## Files Changed

| File | Change |
|------|--------|
| `scripts/windows/tools/nvm.ps1` | Auto-install pinned Node, refresh PATH |
| `scripts/linux/tools/nvm.sh` | Auto-install pinned Node, source nvm.sh |
| `scripts/windows/tools/squad-cli.ps1` | WARN -> ERROR + exit 1 |
| `scripts/linux/tools/squad-cli.sh` | WARN -> ERROR + exit 1 |
| `scripts/windows/setup.ps1` | Remove stale "nvm install lts" from next-steps |
| `tests/test_windows_setup.ps1` | Groups S (nvm bootstrap) and T (squad-cli error) |
| `tests/test_nvm_bootstrap.sh` | Linux-side bootstrap tests |
| `CHANGELOG.md` | Updated [Unreleased] |
| `.squad/agents/goofy/history.md` | Appended #201 entry |
| `.squad/skills/path-refresh-windows/SKILL.md` | New reusable skill |

## Verification

- All new tests pass (Groups S-1 to S-4, T-1 to T-3, bash T1-T5)
- ASCII safety verified on all .ps1 files (no bytes > 0x7F)
- shellcheck clean on all .sh files
- Pre-existing Copilot CLI live test failure is unrelated

Closes #201
