### PR TITLE
ci(workflows): squad-history-check - enforce history.md updates on squad/* PRs

### DIFF
--- a/.github/workflows/squad-history-check.yml
+++ b/.github/workflows/squad-history-check.yml
@@ -1,0 +1,73 @@
+name: Squad History Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  squad-history-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get PR labels and changed files
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Extract squad:* labels from PR
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep '^squad:' || true)
+          
+          # Check if any squad:* labels exist
+          if [ -z "$LABELS" ]; then
+            echo "no_squad_labels=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "no_squad_labels=false" >> $GITHUB_OUTPUT
+          echo "labels<<EOF" >> $GITHUB_OUTPUT
+          echo "$LABELS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Get list of changed files (name only)
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only)
+          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Validate squad history files
+        if: steps.pr-info.outputs.no_squad_labels == 'false'
+        env:
+          LABELS: ${{ steps.pr-info.outputs.labels }}
+          CHANGED_FILES: ${{ steps.pr-info.outputs.changed_files }}
+        run: |
+          FAILURE=0
+          
+          while IFS= read -r LABEL; do
+            # Extract agent name from squad:NAME label
+            AGENT_NAME="${LABEL#squad:}"
+            HISTORY_FILE=".squad/agents/${AGENT_NAME}/history.md"
+            
+            # Check if the history file is in the changed files
+            if ! echo "$CHANGED_FILES" | grep -q "^${HISTORY_FILE}$"; then
+              echo "::error::squad:${AGENT_NAME} PR but .squad/agents/${AGENT_NAME}/history.md not modified. Append a Learnings entry and push."
+              FAILURE=1
+            fi
+          done <<< "$LABELS"
+          
+          if [ $FAILURE -eq 1 ]; then
+            exit 1
+          fi
+
+      - name: Skip check for non-squad PRs
+        if: steps.pr-info.outputs.no_squad_labels == 'true'
+        run: |
+          echo "No squad:* labels found. History check skipped for this PR."

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -257,3 +257,24 @@ Added `tests/test_alias_parity.sh` -- a bash test that extracts alias names from
 - Related: Supersedes #226 (macOS parity, narrower); overlaps #238 (uninstall tests)
 - Terminology: psmux is Windows tmux alias (NOT wezterm — coordinator error corrected)
 - 2026-05-16: Jiminy joined the squad as Hygiene Auditor (process QA, not code review). Will audit your hygiene compliance after spawns. See .squad/agents/jiminy/charter.md for scope.
+
+---
+
+## [2026-05-16T08:00:00Z] Retro Item: CI Enforcement Gate for Squad History.md
+
+**Retro:** 2026-05-16 hygiene retro, item `retro-ci-gate` (enforcer: Chip)  
+**Issue:** #239 (P0, squad:chip)  
+**Context:** Recurring issue - agents complete work but forget to append Learnings to their history.md. Goofy skipped update on PR #215; history backfilled manually post-merge. Earl wants this enforced at CI level so PR cannot merge without history append.
+
+**Solution:** New workflow `.github/workflows/squad-history-check.yml` enforces rule: Any PR carrying at least one `squad:*` label (e.g., `squad:goofy`, `squad:chip`, etc.) MUST modify the matching agent's `.squad/agents/{name}/history.md` file.
+
+**Implementation Details:**
+- **Trigger:** PR open/sync/reopen/label/unlabel events targeting develop or main branches
+- **Label Mapping:** `squad:{name}` label maps to `.squad/agents/{name}/history.md` file path check
+- **Validation Logic:** For each `squad:*` label on the PR, verify history file appears in changed files (via `gh pr diff --name-only`)
+- **Failure Mode:** If history file not modified, emit `::error::` with clear message: "squad:{name} PR but .squad/agents/{name}/history.md not modified. Append a Learnings entry and push."
+- **Multi-label Handling:** If PR has multiple squad labels (rare), ALL matching history files must be touched
+- **Non-squad PRs:** PRs without any `squad:*` label skip the check entirely (pass through)
+- **Hard Gate:** Per Earl directive, no override path exists. Gate is strict and cannot be bypassed.
+
+**Key Integration:** The squad-history-check workflow itself enforces squad operational hygiene. It uses `squad:chip` label on its own PR, so it validates the new gate works before merge ("dogfood test").


### PR DESCRIPTION
New CI gate enforces operational hygiene for squad branches. Any PR labeled with a squad:* label must modify the matching agent's .squad/agents/{name}/history.md file. Retro origin: 2026-05-16 hygiene retro, action item retro-ci-gate. Supports all 8 squad agents. PRs without squad:* labels skip the check. Hard gate with no override path per Earl's directive. Self-validating: this PR uses squad:chip label to test the gate works.