### PR TITLE
docs(github): pull_request_template.md - hygiene checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- One-paragraph description: what is the change and why is it needed? -->
+
+
+## Changes
+<!-- Bullet-point list of files modified, features added, or bugs fixed. -->
+
+-
+
+
+## Test plan
+<!-- How was this change verified? List commands run, CI checks expected, or manual testing steps. -->
+
+
+## Related
+<!-- Link to related issues: "Closes #N", "Refs #N", or "N/A" if no related issues -->
+
+
+## Hygiene checklist
+
+<!-- Before submitting, verify all items below. Unchecked items may be flagged by Jiminy (hygiene auditor). -->
+
+- [ ] Updated `.squad/agents/{name}/history.md` with a Learnings entry
+- [ ] Decisions inbox drained (or noted N/A for this PR)
+- [ ] Skill captured for any new pattern (or noted N/A)
+- [ ] ASCII-only in all `.ps1` / `test_windows_setup.ps1` / `.yml` files (no em dashes, curly quotes, smart apostrophes — they break PS 5.1 CP1252 parsing)
+- [ ] Conventional Commits format on all commits
+- [ ] Co-authored-by: Copilot trailer on all commits
+- [ ] Branch forked from develop (not from another `squad/*` branch — prevents ancestry bleed)
+- [ ] No rogue files outside the canonical `.squad/` paths (`agents/{name}/charter.md|history.md`, `decisions.md`, `decisions/inbox/*.md`, `orchestration-log/*.md`, `log/*.md`, `skills/{name}/SKILL.md`, `templates/*.md`, `casting/*.json`, `identity/*.md`, `plugins/*.json`, `team.md|routing.md|ceremonies.md|config.json`)
+
+<!-- Tip: Jiminy auto-runs before coordinator returns control. Catching hygiene issues before submit saves a round-trip. -->

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -216,3 +216,18 @@ Fixed three regressions introduced by PR #130:
 - **Method:** Systematic file inspection + citations to exact locations; compared against ps51-runtime-file-encoding skill
 - **Report:** .squad/agents/goofy/VERIFICATION_REPORT.md (13KB, detailed analysis per finding)
 - 2026-05-16: Jiminy joined the squad as Hygiene Auditor (process QA, not code review). Will audit your hygiene compliance after spawns. See .squad/agents/jiminy/charter.md for scope.
+
+### Retro Action: PR Template with Hygiene Checklist (2026-05-17)
+- **Retro:** 2026-05-16 hygiene retro, action item `retro-pr-template`
+- **Context:** Recurring sprint hygiene gaps — agents forget to update history.md, drain decisions inbox, capture skills, verify ASCII-only compliance in PS files. Root cause: No visible checklist at PR authoring time. Goofy owned this action item as closure on #215 miss (forgot to update history.md when Chip merged PR #215 tool-versions feature).
+- **Solution:** Created `.github/pull_request_template.md` with 8-item hygiene checklist:
+  1. Updated `.squad/agents/{name}/history.md` with Learnings entry
+  2. Decisions inbox drained (or N/A)
+  3. Skill captured for new pattern (or N/A)
+  4. ASCII-only enforcement for PS/YAML files (em dashes, curly quotes, smart apostrophes break PS 5.1 CP1252)
+  5. Conventional Commits format on all commits
+  6. Co-authored-by Copilot trailer on all commits
+  7. Branch forked from develop (prevents `squad/*` ancestry bleed)
+  8. No rogue files outside canonical `.squad/` paths
+- **Design:** HTML-comment-wrapped guidance in template prevents render clutter in PR body but remains visible in editor. Combined with Jiminy's CI gate (separate PR), provides both human-readable confirmation AND automated enforcement.
+- **Key Pattern:** Hygiene checklist goes BEFORE first PR body is authored (visible during composition), creates friction against skipping items. This is why appending to history.md in this very commit proves the pattern works — if Goofy had skipped it, the template itself would fail its own checklist.


### PR DESCRIPTION
## Summary
Adds \.github/pull_request_template.md\ with an 8-item hygiene checklist to address recurring sprint gaps.

## Changes
- \.github/pull_request_template.md\ — new file with Summary, Changes, Test plan, Related, and Hygiene checklist sections
- \.squad/agents/goofy/history.md\ — appended Learnings entry documenting the template rationale

## Test plan
Verified template renders correctly with HTML comments visible in editor but hidden in rendered view.

## Related
Retro action item from 2026-05-16 hygiene retro (retro-pr-template). Closure on #215 miss.

## Hygiene checklist

- [x] Updated \.squad/agents/goofy/history.md\ with a Learnings entry
- [x] Decisions inbox drained (N/A for this PR)
- [x] Skill captured for any new pattern (N/A for this PR)
- [x] ASCII-only in all \.ps1\ / \	est_windows_setup.ps1\ / \.yml\ files
- [x] Conventional Commits format on all commits
- [x] Co-authored-by: Copilot trailer on all commits
- [x] Branch forked from develop
- [x] No rogue files outside canonical \.squad/\ paths

<!-- Tip: Jiminy auto-runs before coordinator returns control. Catching hygiene issues before submit saves a round-trip. -->