### PR TITLE
fix(windows): nvm.ps1 lib path off-by-one

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -232,3 +232,11 @@ Fixed three regressions introduced by PR #130:
 - **Design:** HTML-comment-wrapped guidance in template prevents render clutter in PR body but remains visible in editor. Combined with Jiminy's CI gate (separate PR), provides both human-readable confirmation AND automated enforcement.
 - **Key Pattern:** Hygiene checklist goes BEFORE first PR body is authored (visible during composition), creates friction against skipping items. This is why appending to history.md in this very commit proves the pattern works — if Goofy had skipped it, the template itself would fail its own checklist.
 - 2026-05-16 Hygiene retro complete -- 4 action items shipped (pre-spawn-checklist skill + squad-history-check CI gate + PR template + 6 standing rules). See .squad/log/2026-05-16-hygiene-retro-complete.md.
+
+## Learnings -- Issue #221 (nvm.ps1 lib path off-by-one)
+- **Date:** 2026-05-16
+- **Bug:** `nvm.ps1` used one `Split-Path -Parent` from `` (landing in `scripts\windows\lib\`) but `Read-ToolVersion.ps1` lives in `scripts\lib\` (two levels up from `scripts\windows\tools\`).
+- **Fix:** Changed to two-level `Split-Path` and added a `Test-Path` assertion so the failure is immediate and descriptive instead of a cryptic dot-source error.
+- **Spot-check:** Verified `uv.ps1` and `copilot.ps1` do NOT reference `Read-ToolVersion.ps1` -- no contagion.
+- **Pattern:** When tool scripts under `scripts\windows\tools\` need shared libs, the path is always `Split-Path (Split-Path $PSScriptRoot -Parent) -Parent | Join-Path -ChildPath 'lib'`. Add a guard assertion every time.
+- **Test:** Added Group W (W-1 through W-3) in `test_windows_setup.ps1` verifying path resolution, runtime assertion presence, and two-level Split-Path usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/windows/tools/nvm.ps1` resolved wrong lib path (one level up instead of two); `Read-ToolVersion.ps1` not found at runtime (closes #221)
+- Added runtime assertion in `nvm.ps1` to catch missing lib directory early
+
 ### Added
 - macOS CI validation via new `validate-macos` job in `validate.yml` (closes #181)
 - Windows GitHub auth step via `scripts/windows/auth.ps1` (closes #191)

--- a/scripts/windows/tools/nvm.ps1
+++ b/scripts/windows/tools/nvm.ps1
@@ -18,8 +18,16 @@ function Refresh-SessionPath {
 
 function Install-Nvm {
     # Load pinned versions from .tool-versions
-    $libDir = Join-Path (Split-Path $PSScriptRoot -Parent) 'lib'
-    . (Join-Path $libDir 'Read-ToolVersion.ps1')
+    # Two levels up: tools -> windows -> scripts, then into shared lib/
+    $libDir = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib'
+    if (-not (Test-Path $libDir)) {
+        throw "Shared lib directory not found at $libDir"
+    }
+    $readToolVersion = Join-Path $libDir 'Read-ToolVersion.ps1'
+    if (-not (Test-Path $readToolVersion)) {
+        throw "Read-ToolVersion.ps1 not found at $readToolVersion"
+    }
+    . $readToolVersion
     $pinnedNode = Get-ToolVersion -Name 'nodejs'
 
     # -- Check if Node is already installed at the pinned version -----------

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1315,6 +1315,43 @@ Test-Scenario "V-3 dot-sourcing logging.ps1 twice is idempotent" {
 }
 
 # ---------------------------------------------------------------------------
+# Group W: nvm.ps1 lib path resolution (Issue #221)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group W: nvm.ps1 lib path resolution (Issue #221)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+$nvmScript = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'tools' | Join-Path -ChildPath 'nvm.ps1'
+$nvmContent = Get-Content $nvmScript -Raw
+
+Test-Scenario "W-1 nvm.ps1 resolves lib path two levels up from tools dir" {
+    # Simulate the same path logic used in nvm.ps1
+    $toolsDir = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'tools'
+    $resolvedLib = Join-Path (Split-Path (Split-Path $toolsDir -Parent) -Parent) 'lib'
+    $target = Join-Path $resolvedLib 'Read-ToolVersion.ps1'
+    if (-not (Test-Path $target)) {
+        throw "Read-ToolVersion.ps1 not found at resolved path: $target"
+    }
+}
+
+Test-Scenario "W-2 nvm.ps1 contains runtime assertion for lib path" {
+    if ($nvmContent -notmatch 'Test-Path.*libDir') {
+        throw "nvm.ps1 missing runtime assertion (Test-Path) for lib directory"
+    }
+    if ($nvmContent -notmatch 'throw.*not found') {
+        throw "nvm.ps1 missing throw when lib path does not exist"
+    }
+}
+
+Test-Scenario "W-3 nvm.ps1 uses two-level Split-Path (not one)" {
+    # Ensure the fix uses two levels of Split-Path -Parent
+    if ($nvmContent -notmatch 'Split-Path\s*\(\s*Split-Path\s+\$PSScriptRoot\s+-Parent\s*\)\s+-Parent') {
+        throw "nvm.ps1 does not use two-level Split-Path for lib resolution"
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes the lib path resolution in `scripts/windows/tools/nvm.ps1` which used a single `Split-Path -Parent` from ``, landing at `scripts/windows/lib/` instead of the correct `scripts/lib/` where `Read-ToolVersion.ps1` actually lives (two levels up from `scripts/windows/tools/`).

## Changes

- **Fix:** Use two-level `Split-Path` to correctly resolve to `scripts/lib/`
- **Guard:** Added runtime `Test-Path` assertion with descriptive `throw` so future path errors fail immediately
- **Tests:** Group W (W-1 through W-3) in `test_windows_setup.ps1` verifying:
  - W-1: Resolved path points to an existing file
  - W-2: Runtime assertion is present in the script
  - W-3: Two-level Split-Path pattern is used
- **Spot-check:** Verified `uv.ps1` and `copilot.ps1` do NOT reference `Read-ToolVersion.ps1` -- no contagion

## Hygiene Checklist

- [x] Updated `.squad/agents/goofy/history.md` with Learnings entry
- [x] Decisions inbox drained (N/A)
- [x] Skill captured for new pattern (N/A -- existing pattern)
- [x] ASCII-only enforcement for PS/YAML files
- [x] Conventional Commits format on all commits
- [x] Co-authored-by Copilot trailer on all commits
- [x] Branch forked from develop
- [x] No rogue files outside canonical `.squad/` paths

Closes #221