### PR TITLE
chore(release): cut 0.8.0 + establish tag discipline

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -803,3 +803,29 @@ Reviewed PRs #243, #245, #246. Skipped #244 (self-authored).
 - All 3 PRs used Conventional Commits + Co-authored-by Copilot trailer correctly.
 - Goofy and Chip used the PR template; Pluto used a custom checklist (close but not exact match).
 - Test coverage is good across the batch -- both pass and fail paths covered.
+## Learnings -- Issue #222: Retroactive Tag Discipline (2026-05-16)
+
+### Design Decisions
+
+1. **Tag format:** Annotated tags (`git tag -a`) -- carry messages, author, date; work with `git describe`
+2. **Tag signing:** Skipped (no GPG infra configured)
+3. **Tag naming:** `0.X.0` (no `v` prefix) -- matches CHANGELOG convention
+4. **SHA mapping strategy:** Prefer explicit "release:" or "promote:" commits where they exist; fall back to sprint-wrap docs commits or develop-to-main merge PRs
+
+### SHA-to-Version Mapping Table
+
+| Version | SHA       | Commit Message                                                        | Rationale                              |
+|---------|-----------|-----------------------------------------------------------------------|----------------------------------------|
+| 0.1.0   | 03d20aa   | release: sprint 1 -- initial dev-setup complete                       | Explicit release commit                |
+| 0.2.0   | 7183b14   | docs(ralph): update history with Sprint 2 work log                    | Last sprint-2 commit; no explicit release commit exists |
+| 0.3.0   | 7668c22   | release: sprint 3 complete -- owner shortcuts, vimrc, examples, bug fixes | Explicit release commit            |
+| 0.4.0   | b4343ef   | release: sprint 4 complete -- branch protection, merge gate, pip->uv  | Explicit release commit                |
+| 0.5.0   | e66e2a5   | chore: promote Sprint 5 to main                                       | Explicit promotion commit              |
+| 0.6.0   | 3f0fb3a   | fix: hotfix Sprint 6 post-merge CI + vim PATH (Sprint 6 wrap #2)      | Last Sprint 6 commit (hotfix included) |
+| 0.7.0   | 64938aa   | Merge pull request #172 from primetimetank21/develop                  | develop->main release merge on 2026-04-25 (matches CHANGELOG date) |
+
+### Gotchas
+
+- Sprint 2 had no explicit "release:" commit -- used the sprint work-log doc commit as anchor
+- Sprint 7's last feature PR (#170) was followed by a develop->main merge (#172) on the same day -- used the merge as it represents the actual release point
+- 0.8.0 tag will be created AFTER PR merges to develop and develop merges to main (cannot tag unreleased code on a feature branch)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- `scripts/windows/tools/nvm.ps1` resolved wrong lib path (one level up instead of two); `Read-ToolVersion.ps1` not found at runtime (closes #221)
-- Added runtime assertion in `nvm.ps1` to catch missing lib directory early
+## [0.8.0] - 2026-05-16
 
 ### Added
 - Pre-commit hygiene checks: ASCII-only enforcement on staged `.ps1` files, rogue `.squad/` path validation, staged inbox file detection, and branch ancestry verification for squad branches (closes #240)
@@ -38,8 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Shared logging helpers extracted to `scripts/linux/lib/log.sh` and `scripts/windows/lib/logging.ps1` (closes #186)
 - Support for `merge` type in commit-msg hook type allowlist (#212)
-
-### Changed
 - `squad-cli` install failure is now a loud error with actionable hints (was silent warning)
 - `scripts/linux/tools/nvm.sh` installs pinned Node version from `.tool-versions` (was `--lts`)
 - `scripts/linux/tools/nvm.sh` reads nvm version from `.tool-versions` instead of fetching latest
@@ -51,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - commit-msg no longer needs special-case bypass for merge/revert -- prepare-commit-msg now normalizes them (#212)
 
 ### Fixed
+- `scripts/windows/tools/nvm.ps1` resolved wrong lib path (one level up instead of two); `Read-ToolVersion.ps1` not found at runtime (closes #221)
+- Added runtime assertion in `nvm.ps1` to catch missing lib directory early
 - PS 5.1 compat: psmux install skip-with-warning + profile write diagnostics (PR #198)
 
 ## [0.7.0] - 2026-04-25 -- Sprint 7: Hooks, psmux, and profile hardening


### PR DESCRIPTION
## Summary

Cut release 0.8.0 from the current [Unreleased] section and establish retroactive git tag discipline for versions 0.1.0 through 0.7.0. This fixes GitHub release automation, `git describe`, and tag-based workflows that were broken due to zero tags existing in the repository.

## Changes

- Renamed `[Unreleased]` to `[0.8.0] -- 2026-05-16` in CHANGELOG.md
- Added fresh empty `[Unreleased]` section above 0.8.0
- Created 7 annotated tags (0.1.0-0.7.0) pointing at historical release commits
- Pushed all 7 tags to origin
- Created GitHub releases for 0.1.0-0.7.0 with CHANGELOG bodies (in progress)
- Documented SHA mapping and design decisions in mickey/history.md

## Test plan

- `git tag -l` shows 0.1.0 through 0.7.0 (verified locally + remote)
- `git ls-remote --tags origin` confirms all 7 on remote
- CHANGELOG.md structure validated manually
- 0.8.0 tag will be created after this PR merges to develop and develop merges to main

## Related

Closes #222

## Hygiene checklist

- [x] Updated `.squad/agents/mickey/history.md` with a Learnings entry
- [x] Decisions inbox drained (N/A for this PR)
- [x] Skill captured for any new pattern (N/A -- standard git tagging)
- [x] ASCII-only in all `.ps1` / `test_windows_setup.ps1` / `.yml` files (no ps1/yml touched)
- [x] Conventional Commits format on all commits
- [x] Co-authored-by: Copilot trailer on all commits
- [x] Branch forked from develop (not from another squad/* branch)
- [x] No rogue files outside the canonical `.squad/` paths