### PR TITLE
fix(hooks): refuse pre-commit directly on develop/main (#249)

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -225,6 +225,14 @@ Delivered 30 PowerShell aliases with full git/gh/dev parity, conflict guards for
 - 2026-05-16: Jiminy joined the squad as Hygiene Auditor (process QA, not code review). Will audit your hygiene compliance after spawns. See .squad/agents/jiminy/charter.md for scope.
 - 2026-05-16 Hygiene retro complete -- 4 action items shipped (pre-spawn-checklist skill + squad-history-check CI gate + PR template + 6 standing rules). See .squad/log/2026-05-16-hygiene-retro-complete.md.
 
+### 2026-05-21: Protected branch guard in pre-commit (Issue #249)
+
+- Recurring incident class: agents and humans committing directly to develop/main. Existing Check 1 catches ancestry bleed (squad/* not forked from develop) but does NOT block commits ON develop/main itself.
+- Fix: added Check 5 to pre-commit hook using `git rev-parse --abbrev-ref HEAD` + case match on develop/main/master. Exits 1 with actionable error message.
+- Renumbered existing shellcheck check from Check 5 to Check 6.
+- Added 5 test cases (develop, main, master refuse; squad/* and pluto/* allow).
+- Priority bumped to P0 this session due to 3+ recurrences.
+
 ### 2026-05-21: Pre-commit hygiene checks (Issue #240)
 
 **Design decisions:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CI: Added nvm + Node.js validation step to validate-macos job, aligning with validate-linux (closes #225)
+- Pre-commit hook now refuses commits directly on `develop`, `main`, or `master` with a clear error message directing the user to create a feature branch (closes #249)
 
 ## [0.8.0] - 2026-05-16
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,7 +5,8 @@
 #   2. ASCII-only on staged *.ps1 files
 #   3. Rogue path check under .squad/
 #   4. Staged inbox file check (.squad/decisions/inbox/ should be gitignored)
-#   5. Shellcheck on staged .sh files
+#   5. Refuse commits directly on develop/main/master
+#   6. Shellcheck on staged .sh files
 set -e
 
 # ---------------------------------------------------------------------------
@@ -149,7 +150,22 @@ if [ -n "$INBOX_STAGED" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Check 5: Shellcheck on staged .sh files (existing behavior)
+# Check 5: Refuse commits directly on develop / main / master
+# ---------------------------------------------------------------------------
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+case "$current_branch" in
+  develop|main|master)
+    echo ""
+    echo "ERROR: refusing to commit directly on '$current_branch'."
+    echo "       Create a feature branch first:"
+    echo "         git checkout -b squad/<issue>-<slug>"
+    echo ""
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Check 6: Shellcheck on staged .sh files (existing behavior)
 # ---------------------------------------------------------------------------
 if ! command -v shellcheck >/dev/null 2>&1; then
   exit 0

--- a/tests/test_precommit_hygiene.sh
+++ b/tests/test_precommit_hygiene.sh
@@ -7,6 +7,7 @@
 #   Check 2: ASCII-only on staged *.ps1 files
 #   Check 3: Rogue path check under .squad/
 #   Check 4: Staged inbox file check
+#   Check 5: Protected branch refuse (develop/main/master)
 #
 # Usage:
 #   bash tests/test_precommit_hygiene.sh
@@ -241,6 +242,80 @@ if sh "$HOOK" >/dev/null 2>&1; then
   pass "T4b: no inbox files staged passes"
 else
   fail "T4b: no inbox files staged passes"
+fi
+
+# ===========================================================================
+# Check 5 Tests: Refuse commits on protected branches
+# ===========================================================================
+echo ""
+echo "=== Check 5: Protected branch refuse ==="
+
+# Test 5a: FAIL - commit on develop should be refused
+T5A_DIR="${TMPDIR_BASE}/t5a"
+setup_test_repo "$T5A_DIR"
+# Already on develop after setup_test_repo
+echo "bad" > bad.txt
+git add bad.txt
+if sh "$HOOK" >/dev/null 2>&1; then
+  fail "T5a: commit on develop should be refused"
+else
+  pass "T5a: commit on develop is refused"
+fi
+
+# Test 5b: FAIL - commit on main should be refused
+T5B_DIR="${TMPDIR_BASE}/t5b"
+setup_test_repo "$T5B_DIR"
+git checkout -q -b main
+echo "bad" > bad.txt
+git add bad.txt
+if sh "$HOOK" >/dev/null 2>&1; then
+  fail "T5b: commit on main should be refused"
+else
+  pass "T5b: commit on main is refused"
+fi
+
+# Test 5c: FAIL - commit on master should be refused
+T5C_DIR="${TMPDIR_BASE}/t5c"
+mkdir -p "$T5C_DIR"
+cd "$T5C_DIR"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+echo "init" > README.md
+git add README.md
+git commit -q -m "chore: init"
+# Ensure we are on master (rename default branch if needed)
+git branch -m master 2>/dev/null || true
+echo "bad" > bad.txt
+git add bad.txt
+if sh "$HOOK" >/dev/null 2>&1; then
+  fail "T5c: commit on master should be refused"
+else
+  pass "T5c: commit on master is refused"
+fi
+
+# Test 5d: PASS - commit on squad/* branch is allowed
+T5D_DIR="${TMPDIR_BASE}/t5d"
+setup_test_repo "$T5D_DIR"
+git checkout -q -b squad/123-feature
+echo "good" > good.txt
+git add good.txt
+if sh "$HOOK" >/dev/null 2>&1; then
+  pass "T5d: commit on squad/* branch is allowed"
+else
+  fail "T5d: commit on squad/* branch is allowed"
+fi
+
+# Test 5e: PASS - commit on pluto/* branch is allowed
+T5E_DIR="${TMPDIR_BASE}/t5e"
+setup_test_repo "$T5E_DIR"
+git checkout -q -b pluto/249-fix
+echo "good" > good.txt
+git add good.txt
+if sh "$HOOK" >/dev/null 2>&1; then
+  pass "T5e: commit on pluto/* branch is allowed"
+else
+  fail "T5e: commit on pluto/* branch is allowed"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Pre-commit hook now refuses commits when HEAD is \develop\, \main\, or \master\. This closes a recurring incident class (3+ occurrences) where agents and humans commit directly to protected branches, bypassing review. Existing Check 1 catches ancestry bleed for squad/* branches but did NOT block commits ON develop/main itself.

## Changes

- \hooks/pre-commit\: Added Check 5 (protected branch guard) using \git rev-parse --abbrev-ref HEAD\ + case match. Exits 1 with actionable error message. Renumbered shellcheck from Check 5 to Check 6.
- \	ests/test_precommit_hygiene.sh\: Added 5 test cases (T5a-T5e) covering develop, main, master refuse and squad/*/pluto/* pass-through. Total: 18 tests, all passing.
- \CHANGELOG.md\: Added entry under [Unreleased] > Fixed.
- \.squad/agents/pluto/history.md\: Appended learnings entry for Issue #249.

## Test plan

- Ran \ash tests/test_precommit_hygiene.sh\ -- 18/18 pass (13 existing + 5 new).
- Confirmed Check 5 fires on develop, main, and master with clear error message.
- Confirmed Check 5 stays silent on squad/* and pluto/* branches.
- Confirmed Check 1-4 continue to work unchanged.
- Commit itself passed the pre-commit hook (including shellcheck on the test file).

## Related

Fixes #249

## Hygiene checklist

- [x] Updated \.squad/agents/pluto/history.md\ with a Learnings entry
- [x] Decisions inbox drained (N/A for this PR)
- [x] Skill captured for any new pattern (N/A -- tactical fix, no new pattern)
- [x] ASCII-only in all \.ps1\ / \	est_windows_setup.ps1\ / \.yml\ files (no .ps1/.yml files changed)
- [x] Conventional Commits format on all commits
- [x] Co-authored-by: Copilot trailer on all commits
- [x] Branch forked from develop (not from another squad/* branch)
- [x] No rogue files outside the canonical \.squad/\ paths