### PR TITLE
docs(retro): sprint Q + 0.8.0 release wrap + hooks fix

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -831,3 +831,22 @@ Reviewed PRs #243, #245, #246. Skipped #244 (self-authored).
 - 0.8.0 tag will be created AFTER PR merges to develop and develop merges to main (cannot tag unreleased code on a feature branch)
 
 - **2026-05-16 -- Re-reviewed PR #245 after Goofy revision.** Verdict: APPROVE. All 6 assertion adds confirmed (squad --version on Linux/macOS, squad/psmux/tmux on Windows, in both fresh-shell and post-idempotency phases). Hard-fail enforced, no || true softening. ASCII clean. Goofy history.md updated. Merged via --admin after CI settled.
+
+## Sprint Q Retro Authored -- 2026-05-16
+
+- **Scope:** Post-0.8.0 release retro covering Sprint Q P0 batch (#249, #251, #252) and the 9-round Goofy saga on #251.
+- **Output:** `.squad/retros/2026-05-16-sprint-q-retro.md`
+- **Key findings:**
+  - 8 of 9 rounds on #251 were reactive (patching symptoms surfaced by previous failure), not predictive (upfront failure-mode analysis)
+  - Branch ancestry bleed = 3rd occurrence -- needs prominent placement in CONTRIBUTING.md
+  - Stale branches keep accumulating despite `--delete-branch` on merge -- Ralph EOS sweep is now standing
+  - No verifier/validator role -- Earl had to double/triple-check claims of "done." Open question for Sprint R kickoff
+  - HYGIENE backlog underprioritized -- bumped to P0/P1 for next sprint
+- **Action items filed:**
+  - [Coordinator] "Two strikes" rule -- failure-mode analysis required before round 3 of any fix
+  - [Mickey] Make "branch from develop, never from another squad branch" prominent in CONTRIBUTING.md
+  - [Earl + Coordinator] Decide verifier/validator scope (extend Jiminy / new teammate / process change) before Sprint R
+  - [Mickey] Bump HYGIENE backlog (#224, #227, #228, branch hygiene automation)
+  - [Chip] Track E2E nightly flake rate -- flip `continue-on-error: false` after 2-3 green nightlies (#253)
+  - [Mickey] CHANGELOG conflict strategy doc
+- **Outcome:** Sprint Q closed. 0.8.0 shipped. Sprint R agenda has HYGIENE bumped, two-strikes rule, validator scope decision.

--- a/.squad/agents/ralph/history.md
+++ b/.squad/agents/ralph/history.md
@@ -212,3 +212,26 @@ Initial setup complete.
 - **gh auth:** ✓ logged in as primetimetank21
 - **CHANGELOG:** [Unreleased] section exists (queue for next release)
 - **Verdict:** READY FOR NEXT SESSION
+
+## Sprint Q + 0.8.0 Release Cleanup -- 2026-05-16
+
+- **Context:** After Sprint Q P0 fixes (#249, #251, #252) merged via #257/#256/#258, cut 0.8.0 release (PR #259 + #260) and shipped GH release. Final EOS sweep.
+- **Cleanup actions:**
+  - Deleted local `release/0.8.0` branch (after PR #259 merged)
+  - Auto-deleted remote `release/0.8.0` (via `--delete-branch` on merge)
+  - Pruned stale local tracking ref `origin/release/0.8.0`
+  - Verified `.squad/log/` and `.squad/orchestration-log/` files are intentionally gitignored (not strays)
+  - Confirmed `.squad/decisions/inbox/` empty (Scribe drained)
+  - Confirmed no rogue `.bak` / `.tmp` files anywhere
+- **Final repo state:**
+  - main: `7d9be7b` (PR #260 merge)
+  - develop: `df3a1cd` (synced with main + retro work pending)
+  - Tag: `0.8.0` pushed
+  - GH release: published at https://github.com/primetimetank21/dev-setup/releases/tag/0.8.0
+  - Local branches: develop, main (and current retro branch)
+  - Remote branches: develop, main
+  - Worktrees: 1 (primary)
+  - Open PRs: 0 (excluding upcoming retro PR)
+  - Open `go:yes` issues: 0
+- **Standing directive lock-in:** EOS sweep confirmed in charter. Every session ends with the 12-point sweep + branch reaping.
+- **Verdict:** CLEAN. Sprint Q + 0.8.0 wrap complete.

--- a/.squad/retros/2026-05-16-sprint-q-retro.md
+++ b/.squad/retros/2026-05-16-sprint-q-retro.md
@@ -1,0 +1,51 @@
+# Sprint Q Retro -- 2026-05-16 (0.8.0 Release)
+
+Sprint Q = the P0 emergency batch fixed AFTER Sprint 8 wrap revealed install regressions on a fresh box. Three bugs (#249, #251, #252) had to ship before 0.8.0 could go out. Goofy's #251 (Windows nvm PATH) took 9 rounds.
+
+## What Went Well
+
+- **All 3 P0s shipped and verified.** E2E green on all 3 platforms for the first time (Linux 39s, macOS 1m3s, Windows 2m34s). 0.8.0 cut from develop -> main with no rollbacks.
+- **Aggressive root-cause analysis from CI logs.** Goofy progressively identified each layer of the Windows install racy stack: timeout too low -> installer race vs winget return -> PATH unexpanded `%NVM_HOME%` literals -> fresh-shell registry blindness -> `$Args` PS automatic clash. Each round had data.
+- **Escalation call was correct.** When winget+nvm-setup.exe proved unreliable after 3 rounds, Coordinator+Earl chose portable `nvm-noinstall.zip`. Deterministic, no installer race. Right tradeoff.
+- **Surgical fixes over rewrites.** Once the root cause was found in a round, the fix was small and targeted. No "let me redesign the whole thing" thrashing.
+- **Earl's hard gate.** "All of these items that were 'shipped' -- there's ABSOLUTELY no reason for me to doubt they work properly?" stopped premature ship signals 2x.
+- **Jiminy hired.** New role: Hygiene Auditor. Audits squad's process compliance (history.md updates, branch hygiene, decision drains) after spawns. First session = stood up + charter shipped.
+- **CI gate for `agents/{name}/history.md`** caught at least one missing update mid-sprint.
+
+## What Could Be Better
+
+- **#251 took 9 rounds.** Pattern: each round patched the symptom uncovered by the previous failure. We never did an upfront "list every way this can fail" analysis. By round 5 we were chasing tail (workflow `$Args` shadowing) instead of fundamentals (registry PATH for fresh shells). **Cost:** ~4 days, ~9 CI runs, fatigue.
+- **Branch ancestry bleed (3rd occurrence).** Squad keeps forking branches off other squad branches instead of `develop`. Mickey flagged this twice prior. It happened again in Sprint Q. The CI gate in `pre-commit` checks this but only on commit-time -- after the fact.
+- **Stale branches kept accumulating.** Earl asked for branch cleanup TWICE this session. Despite `--delete-branch` on merge, stale tracking refs and remote orphans linger. Ralph's EOS sweep helps but is reactive.
+- **No verifier/validator role.** Earl had to double/triple-check claims of "done." Goofy claimed #251 was fixed 4+ times before E2E actually went green. Jiminy is process QA, not technical validation. **Open question:** is this a teammate gap or a process gap (e.g., "require green E2E artifact before claiming done")?
+- **HYGIENE backlog items underprioritized.** Earl explicitly bumped these for next sprint after seeing them cause real bugs (branch bleed, stale state, missing history updates).
+- **CHANGELOG conflicts predictable in multi-PR sprints.** Resolved by union each time, but a CHANGELOG strategy doc would save 15 minutes per PR.
+
+## Action Items
+
+- **[Coordinator] "Two strikes" rule.** When a fix fails CI twice on the same issue, REQUIRE a written failure-mode analysis before round 3. No more reactive patching. Track in coordinator's spawn checklist.
+- **[Mickey] Make "branch from develop" rule prominent.** Top of CONTRIBUTING.md, not buried. Add an example of the bleed pattern with concrete branch names. Reference the 3 occurrences.
+- **[Earl + Coordinator] Decide verifier/validator scope.** Options: (a) extend Jiminy to technical validation, (b) hire a new teammate (Validator), (c) make "green E2E artifact + manual smoke" mandatory before merge. Decide before Sprint R kickoff.
+- **[Mickey] Bump HYGIENE backlog to P0/P1.** #224 (hook tests), #227 (.bak rotation), #228 (docs core.hooksPath), branch hygiene automation. These keep causing P0s downstream.
+- **[Ralph] EOS sweep is now standing directive.** Document in charter. Confirm every session ends with the 12-point sweep -- already done this session, lock it in.
+- **[Chip] Track E2E nightly flake rate.** After 2-3 consecutive green nightlies, flip `continue-on-error: false` and make E2E a blocking check. #253 surfaces failures.
+- **[Mickey] Write CHANGELOG conflict strategy doc.** 5-line cheatsheet on union resolution for multi-PR sprints. Add to CONTRIBUTING.md.
+
+## Stats
+
+- **Issues filed/closed this session:** 6 filed (#249, #251, #252 P0s; #253, #254, #255 chores), 3 closed (#249, #251, #252)
+- **PRs merged this session:** ~10 (#244, #245, #248, #250, #256, #257, #258, #259, #260, + 0.8.0 tag)
+- **Rounds per P0:** Pluto #249: 1, Chip #252: 3, Goofy #251: 9
+- **Worktrees:** spun up 3, all cleaned
+- **Stale branches deleted:** 7 (sprint wrap) + 3 (Sprint Q wrap) + 1 (release/0.8.0)
+- **Memories stored:** 5+ (portable nvm-windows, CI Windows PATH refresh, PS `$Args` pitfall, U+2014 in PS strings, winget IDs)
+- **New teammate:** Jiminy (Hygiene Auditor) -- charter shipped, first audit complete
+- **Release:** 0.8.0 cut, tagged, GH release published
+
+## Reflection
+
+Sprint Q was a stress test of the squad's ability to ship when CI is the only feedback loop and the environment fights back. Goofy's 9-round saga proves we can iterate, but the cost was high -- 8 of 9 rounds were reactive, not predictive. The "two strikes" rule is the highest-leverage change from this retro: it forces a pause to think instead of yet another commit.
+
+The hygiene gap is the second theme. Branch ancestry bleed, stale branches, and missing history updates aren't bugs -- they're symptoms of process drift. They've now caused real P0s (the install audit only happened because Earl checked manually; the squad missed it). HYGIENE bump for Sprint R is mandatory.
+
+**Board status:** CLEAN. main = `7d9be7b`, develop synced, 0 worktrees beyond primary, 0 stray branches, 0 untracked. 0.8.0 shipped.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -84,6 +84,7 @@ if [ -n "$SQUAD_STAGED" ]; then
       .squad/decisions/inbox/*.md) VALID=1 ;;
       .squad/orchestration-log/*.md) VALID=1 ;;
       .squad/log/*.md) VALID=1 ;;
+      .squad/retros/*.md) VALID=1 ;;
       .squad/skills/*/SKILL.md) VALID=1 ;;
       .squad/templates/*.md) VALID=1 ;;
       .squad/casting/*.json) VALID=1 ;;
@@ -113,6 +114,7 @@ if [ -n "$SQUAD_STAGED" ]; then
     echo "    .squad/decisions/inbox/*.md (gitignored -- should not be staged)"
     echo "    .squad/orchestration-log/*.md"
     echo "    .squad/log/*.md"
+    echo "    .squad/retros/*.md"
     echo "    .squad/skills/{name}/SKILL.md"
     echo "    .squad/templates/*.md | .squad/casting/*.json"
     echo "    .squad/identity/*.md | .squad/plugins/*.json"


### PR DESCRIPTION
Sprint Q retro (0.8.0 release wrap-up) + hooks gap fix.

**Retro:** new file .squad/retros/2026-05-16-sprint-q-retro.md covers:
- 3 P0 fixes shipped (#249, #251, #252)
- Goofy's 9-round saga on #251 (Windows nvm PATH) -- 8 of 9 rounds reactive
- 0.8.0 cut + tagged + GH release published
- 6 action items for Sprint R kickoff

**Hooks fix:** add .squad/retros/*.md to pre-commit rogue-path allow-list. Path was already in use (existing 2026-04-12 retro) but new files were rejected.

**Ralph EOS cleanup logged** in ralph/history.md: release/0.8.0 reaped, stale refs pruned, .squad/log/* verified gitignored, repo clean.

**Mickey retro authorship logged** in mickey/history.md.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>