### PR TITLE
chore(squad): upgrade governance to 0.9.4

### DIFF
--- a/.copilot/skills/error-recovery/SKILL.md
+++ b/.copilot/skills/error-recovery/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: "error-recovery"
+description: "Standard recovery patterns for all squad agents. When something fails, adapt — don't just report the failure."
+domain: "reliability, agent-coordination"
+confidence: "high"
+license: MIT
+---
+
+# Error Recovery Patterns
+
+Standard recovery patterns for all squad agents. When something fails, **adapt** — don't just report the failure.
+
+---
+
+## 1. Retry with Backoff
+
+**When:** Transient failures — API timeouts, rate limits, network errors, temporary service unavailability.
+
+**Pattern:**
+1. Wait briefly, then retry (start at 2s, double each attempt)
+2. Maximum 3 retries before escalating
+3. Log each attempt with the error received
+
+**Example:** API call returns 429 Too Many Requests → wait 2s → retry → wait 4s → retry → wait 8s → retry → escalate if still failing.
+
+---
+
+## 2. Fallback Alternatives
+
+**When:** Primary tool or approach fails and an alternative exists.
+
+**Pattern:**
+1. Attempt primary approach
+2. On failure, identify alternative tool/method
+3. Try the alternative with the same intent
+4. Document which alternative was used and why
+
+**Example:** Primary CLI tool fails → fall back to direct API call for the same operation.
+
+---
+
+## 3. Diagnose-and-Fix
+
+**When:** Build failures, test failures, linting errors — structured errors with actionable output.
+
+**Pattern:**
+1. Read the full error output carefully
+2. Identify the root cause from error messages
+3. Attempt a targeted fix
+4. Re-run to verify the fix
+5. Maximum 3 fix-retry cycles before escalating
+
+**Example:** Build fails with a type error → check for missing import → add it → rebuild.
+
+---
+
+## 4. Escalate with Context
+
+**When:** Recovery attempts have been exhausted, or the failure requires human judgment.
+
+**Pattern:**
+1. Summarize what was attempted and what failed
+2. Include the exact error messages
+3. State what you believe the root cause is
+4. Suggest next steps or who might be able to help
+5. Hand off to the coordinator or the appropriate specialist
+
+**Example:** After 3 failed build attempts → "Build fails on line 42 with null reference. Tried X, Y, Z. Likely a design issue in the Foo module. Recommend the code owner review."
+
+---
+
+## 5. Graceful Degradation
+
+**When:** A non-critical step fails but the overall task can still deliver value.
+
+**Pattern:**
+1. Determine if the failed step is critical to the task outcome
+2. If non-critical, log the failure and continue
+3. Deliver partial results with a clear note of what was skipped
+4. Offer to retry the skipped step separately
+
+**Example:** Generating a report with 5 sections — section 3 data source is unavailable → produce the report with 4 sections, note that section 3 was skipped and why.
+
+---
+
+## Applying These Patterns
+
+Each agent should reference these patterns in their charter's `## Error Recovery` section, tailored to their domain. The charter should list the agent's most common failure modes and map each to the appropriate pattern above.
+
+**Selection guide:**
+
+| Failure Type | Primary Pattern | Fallback Pattern |
+|---|---|---|
+| Network/API transient | Retry with Backoff | Escalate with Context |
+| Tool/dependency missing | Fallback Alternatives | Escalate with Context |
+| Build/test error | Diagnose-and-Fix | Escalate with Context |
+| Auth/permissions | Retry with Backoff | Escalate with Context |
+| Non-critical data missing | Graceful Degradation | — |
+| Unknown/novel error | Escalate with Context | — |

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -7,10 +7,6 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
-
   # React to completed work or new squad work
   issues:
     types: [closed, labeled]

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -1,0 +1,181 @@
+name: Squad Label Enforce
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce mutual exclusivity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const appliedLabel = context.payload.label.name;
+
+            // Namespaces with mutual exclusivity rules
+            const EXCLUSIVE_PREFIXES = ['go:', 'release:', 'type:', 'priority:'];
+
+            // Skip if not a managed namespace label
+            if (!EXCLUSIVE_PREFIXES.some(p => appliedLabel.startsWith(p))) {
+              core.info(`Label ${appliedLabel} is not in a managed namespace — skipping`);
+              return;
+            }
+
+            const allLabels = issue.labels.map(l => l.name);
+
+            // Handle go: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('go:')) {
+              const otherGoLabels = allLabels.filter(l => 
+                l.startsWith('go:') && l !== appliedLabel
+              );
+
+              if (otherGoLabels.length > 0) {
+                // Remove conflicting go: labels
+                for (const label of otherGoLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                // Post update comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Triage verdict updated → \`${appliedLabel}\``
+                });
+              }
+
+              // Auto-apply release:backlog if go:yes and no release target
+              if (appliedLabel === 'go:yes') {
+                const hasReleaseLabel = allLabels.some(l => l.startsWith('release:'));
+                if (!hasReleaseLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['release:backlog']
+                  });
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `📋 Marked as \`release:backlog\` — assign a release target when ready.`
+                  });
+
+                  core.info('Applied release:backlog for go:yes issue');
+                }
+              }
+
+              // Remove release: labels if go:no
+              if (appliedLabel === 'go:no') {
+                const releaseLabels = allLabels.filter(l => l.startsWith('release:'));
+                if (releaseLabels.length > 0) {
+                  for (const label of releaseLabels) {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      name: label
+                    });
+                    core.info(`Removed release label from go:no issue: ${label}`);
+                  }
+                }
+              }
+            }
+
+            // Handle release: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('release:')) {
+              const otherReleaseLabels = allLabels.filter(l => 
+                l.startsWith('release:') && l !== appliedLabel
+              );
+
+              if (otherReleaseLabels.length > 0) {
+                // Remove conflicting release: labels
+                for (const label of otherReleaseLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                // Post update comment
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Release target updated → \`${appliedLabel}\``
+                });
+              }
+            }
+
+            // Handle type: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('type:')) {
+              const otherTypeLabels = allLabels.filter(l => 
+                l.startsWith('type:') && l !== appliedLabel
+              );
+
+              if (otherTypeLabels.length > 0) {
+                for (const label of otherTypeLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Issue type updated → \`${appliedLabel}\``
+                });
+              }
+            }
+
+            // Handle priority: namespace (mutual exclusivity)
+            if (appliedLabel.startsWith('priority:')) {
+              const otherPriorityLabels = allLabels.filter(l => 
+                l.startsWith('priority:') && l !== appliedLabel
+              );
+
+              if (otherPriorityLabels.length > 0) {
+                for (const label of otherPriorityLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                  core.info(`Removed conflicting label: ${label}`);
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🏷️ Priority updated → \`${appliedLabel}\``
+                });
+              }
+            }
+
+            core.info(`Label enforcement complete for ${appliedLabel}`);

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -110,9 +110,11 @@ jobs:
               return;
             }
 
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+
             // Build triage context
             const memberList = members.map(m =>
-              `- **${m.name}** (${m.role}) → label: \`squad:${m.name.toLowerCase()}\``
+              `- **${m.name}** (${m.role}) → label: \`squad:${slugify(m.name)}\``
             ).join('\n');
 
             // Determine best assignee based on issue content and routing
@@ -189,7 +191,7 @@ jobs:
             }
 
             const isCopilot = assignedMember.name === '@copilot';
-            const assignLabel = isCopilot ? 'squad:copilot' : `squad:${assignedMember.name.toLowerCase()}`;
+            const assignLabel = isCopilot ? 'squad:copilot' : `squad:${slugify(assignedMember.name)}`;
 
             // Add the member-specific label
             await github.rest.issues.addLabels({

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -103,6 +103,8 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+
             // Ensure the base "squad" triage label exists
             const labels = [
               { name: 'squad', color: SQUAD_COLOR, description: 'Squad triage inbox — Lead will assign to a member' }
@@ -110,7 +112,7 @@ jobs:
 
             for (const member of members) {
               labels.push({
-                name: `squad:${member.name.toLowerCase()}`,
+                name: `squad:${slugify(member.name)}`,
                 color: MEMBER_COLOR,
                 description: `Assigned to ${member.name} (${member.role})`
               });

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -51,6 +51,10 @@ Lead architect; established foundational team process, architecture, and Windows
 
 ⚠️ **TEAM REQUIREMENT:** Read `.squad/skills/ps51-ascii-safety/SKILL.md` before touching any `.ps1` file. This skill captures the CP1252 encoding trap, detection scripts, and fix patterns.
 
+- **squad upgrade rogue-file bug (0.9.4):** `squad upgrade` dumps template files at `.squad/` root that should only live in `.squad/templates/`. Compare root files against templates — if identical or older, delete. The pre-commit hook allow-list catches these, but clean up before committing.
+- **git-workflow SKILL.md overwrite risk:** Upgrade overwrites customized skills with the built-in generic version. The 0.9.4 version assumes a 3-branch model (dev/insiders/main) and removes our project-specific rules (merge gates, branch protection, Mickey approval requirement). Always diff after upgrade.
+- **New workflows from upgrade may target the squad CLI's own release pipeline** (squad-promote, squad-release, squad-insider-release, squad-preview, squad-docs) — these assume package.json publishing and branches that don't exist in consumer repos. Delete or don't ship unless the repo actually uses that pipeline.
+
 - `git add --renormalize` updates INDEX only, not working tree
 - `script -q /dev/null -c 'command'` for isatty()-gated CLIs (general pattern, deprecated for Copilot CLI)
 - Branch protection write via `gh api` blocked by Codespace token scope — manual UI required

--- a/.squad/skills/squad-upgrade-hygiene/SKILL.md
+++ b/.squad/skills/squad-upgrade-hygiene/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "squad-upgrade-hygiene"
+description: "Post-upgrade audit checklist for squad CLI upgrades. Catches rogue files, overwritten skills, and irrelevant workflows."
+domain: "squad-cli, maintenance"
+confidence: "high"
+license: MIT
+---
+
+# Squad Upgrade Hygiene
+
+After running `squad upgrade`, always audit before committing.
+
+---
+
+## 1. Rogue Files at `.squad/` Root
+
+**Problem:** The upgrade may dump template files directly into `.squad/` root instead of `.squad/templates/`. These are duplicates or older versions of canonical files.
+
+**Detection:**
+```bash
+git status --short .squad/ | grep "^??" | grep -v "templates/"
+```
+
+**Validation:** Compare each rogue file against:
+1. `.squad/templates/{same-name}` — if identical, delete the root copy
+2. The canonical subdirectory location (e.g., `.squad/casting/policy.json` vs `.squad/casting-policy.json`) — if the canonical is newer/richer, delete the root copy
+
+**Fix:** Delete all rogue files before committing. The pre-commit hook's allow-list will reject them anyway.
+
+---
+
+## 2. Overwritten Customized Skills
+
+**Problem:** `squad upgrade` overwrites `.copilot/skills/` with built-in versions, even if customized. It warns but proceeds.
+
+**Detection:**
+```bash
+git diff --stat -- .copilot/skills/
+```
+
+**Validation:** Check if lost content was project-specific (branch names, approval rules, repo-specific commands). If yes, revert.
+
+**Fix:** `git checkout HEAD -- .copilot/skills/{name}/SKILL.md` to restore, then reconcile manually if the new version adds useful content.
+
+---
+
+## 3. Irrelevant New Workflows
+
+**Problem:** Upgrade may add workflows designed for the squad CLI's own release pipeline (npm publish, preview/insiders branches) that don't apply to consumer repos.
+
+**Red flags:**
+- Targets branches that don't exist (`preview`, `insider`, `insiders`)
+- Contains `npm publish` or package.json version reads
+- Has "Project type was not detected" placeholder comments
+- Duplicates existing CI (e.g., `squad-ci.yml` vs your own `validate.yml`)
+
+**Fix:** Delete irrelevant workflows. Keep only those that add value to your repo's actual workflow.
+
+---
+
+## 4. Workflow Diffs — Are They Pure Upstream?
+
+For modified workflows, check `git diff` for:
+- Removed project-specific customizations (secrets, custom labels, branch names)
+- Added generic logic that conflicts with your setup
+
+If diffs are pure upstream improvements (bugfixes, new features), ship. If they remove customizations, investigate.
+
+---
+
+## Checklist
+
+- [ ] Delete rogue `.squad/` root files
+- [ ] Verify `.copilot/skills/` overwrites — revert if customized
+- [ ] Audit new workflows — delete those targeting non-existent branches
+- [ ] Diff modified workflows — confirm no lost customizations
+- [ ] Check `squad.agent.md` for new spawn requirements
+- [ ] Run pre-commit hook to validate
+- [ ] Commit in logical groups (governance, workflows, skills separately)

--- a/.squad/templates/ceremonies.md
+++ b/.squad/templates/ceremonies.md
@@ -39,3 +39,31 @@
 2. Root cause analysis
 3. What should change?
 4. Action items for next iteration
+
+
+---
+
+## Retrospective with Enforcement
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | auto |
+| **When** | weekly |
+| **Condition** | No *retrospective* log in .squad/log/ within the last 7 days |
+| **Facilitator** | lead |
+| **Participants** | all |
+| **Time budget** | focused |
+| **Enabled** | yes |
+| **Enforcement skill** | retro-enforcement |
+
+**Agenda:**
+1. What shipped this week? (closed issues, merged PRs)
+2. What did not ship? (open issues, blockers)
+3. Root cause on any failures
+4. Action items -- each MUST become a GitHub Issue labeled retro-action
+
+**Coordinator integration:**
+At round start, call Test-RetroOverdue (see skill retro-enforcement). If overdue, run this ceremony before the work queue.
+
+**Why GitHub Issues, not markdown:**
+Production data: 0% completion across 6 retros using markdown checklists, 100% after switching to GitHub Issues.

--- a/.squad/templates/fact-checker-charter.md
+++ b/.squad/templates/fact-checker-charter.md
@@ -1,0 +1,83 @@
+# Fact Checker
+
+> Trust, but verify. Every claim gets a source check.
+
+## Identity
+
+- **Name:** Fact Checker
+- **Role:** Devil's Advocate & Verification Agent
+- **Style:** Rigorous but constructive. Flags issues clearly without being abrasive.
+- **Casting:** Gets a universe name like any other agent (not exempt like Scribe/Ralph).
+
+## What I Do
+
+Validate claims, detect hallucinations, and run counter-hypotheses on team output before it ships.
+
+## Verification Methodology
+
+For every claim or assertion I review:
+
+1. **Source Check:** What evidence supports this? Can I verify it?
+2. **Counter-Hypothesis:** What would disprove this? Is there an alternative explanation?
+3. **Existence Check:** Do the URLs, package names, API endpoints, file paths, and version numbers actually exist?
+4. **Consistency Check:** Does this contradict anything in `.squad/decisions.md` or prior team output?
+
+## Confidence Ratings
+
+Every verified item gets one of:
+
+| Rating | Meaning |
+|--------|---------|
+| ✅ Verified | Confirmed via source, test, or direct observation |
+| ⚠️ Unverified | Plausible but could not confirm — needs human review |
+| ❌ Contradicted | Found evidence that contradicts the claim |
+| 🔍 Needs Investigation | Requires deeper analysis beyond current scope |
+
+## When I'm Triggered
+
+- **Auto-trigger (via routing):** Tasks tagged with `review`, `verify`, `fact-check`, `audit`
+- **Pre-publish gate:** Before any artifact is delivered to the user, if configured
+- **Manual:** User says "fact-check this", "verify these claims", "double-check"
+- **Post-research:** After any agent produces research output or external references
+
+## How I Work
+
+1. **Read the artifact** — understand what's being claimed
+2. **Extract claims** — list every factual assertion (package versions, API behavior, file existence, etc.)
+3. **Verify each claim** — use available tools (grep, glob, web search, gh CLI) to check
+4. **Run counter-hypotheses** — for key assumptions, ask "what if this is wrong?"
+5. **Produce a verification report:**
+
+```markdown
+## Verification Report — {artifact name}
+
+### Claims Verified
+- ✅ {claim} — confirmed via {source}
+- ⚠️ {claim} — could not verify, {reason}
+- ❌ {claim} — contradicted by {evidence}
+
+### Counter-Hypotheses
+- {assumption} → Alternative: {counter}
+
+### Recommendation
+{proceed / revise / block with reasons}
+```
+
+6. **Write decision** if I found issues: `.squad/decisions/inbox/fact-checker-{slug}.md`
+
+## Boundaries
+
+**I handle:** Verification, fact-checking, counter-hypotheses, hallucination detection.
+
+**I don't handle:** Implementation, design, testing, or docs. I review, not create.
+
+**I am not a blocker by default.** My verification report is advisory unless the coordinator or a reviewer escalates it to a gate.
+
+## Project Context
+
+**Project:** {project_name}
+{project_description}
+
+## Learnings
+
+Initial setup complete. Ready for verification work.

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -231,7 +231,8 @@ Working as {member} ({role})
 **Update workflow:**
 ```bash
 # Make changes
-git add .
+# ⚠️ NEVER use `git add .` or `git add -A` — only stage files you intentionally changed
+git add -- {specific files you modified}
 git commit -m "fix: address review feedback"
 git push
 ```
@@ -254,11 +255,8 @@ gh pr merge {pr-number} --merge --delete-branch
 
 **GitHub (squash):**
 ```bash
-# ⚠️ NEVER use for sprint wrap PRs (develop → main)
 gh pr merge {pr-number} --squash --delete-branch
 ```
-
-**Sprint Wrap PRs (develop → main):** Always use `--merge` (regular merge commits). Squash merges cause permanent history divergence on protected branches. See `.squad/decisions.md` for rationale.
 
 **Azure DevOps:**
 ```bash

--- a/.squad/templates/loop.md
+++ b/.squad/templates/loop.md
@@ -1,0 +1,46 @@
+---
+configured: false
+interval: 10
+timeout: 30
+description: "My squad work loop"
+---
+
+# Squad Work Loop
+
+> ⚠️ Set `configured: true` in the frontmatter above to activate this loop.
+> Run with: `squad loop`
+
+## What to do each cycle
+
+Describe what your squad should do every time the loop wakes up. Be specific —
+the more context you give, the better your squad performs.
+
+Examples:
+- Check for new messages in a Teams channel and summarize action items
+- Review recent pull requests and flag anything needing attention
+- Run a health check on staging and report anomalies
+- Scan the inbox for anything that needs a response today
+
+<!-- Replace this section with your actual loop instructions. -->
+
+## Monitoring (optional)
+
+If you want your squad to watch external channels, enable monitor capabilities:
+
+```bash
+squad loop --monitor-email --monitor-teams
+```
+
+## Personality (optional)
+
+If your squad has a specific voice or style, describe it here so each cycle
+stays consistent.
+
+Example: "Be concise. Use bullet points. Flag blockers clearly."
+
+## Tips
+
+- **Be specific.** Vague prompts produce vague results.
+- **Set boundaries.** Tell the squad what NOT to do (e.g., "Don't send messages to anyone but me").
+- **Start small.** Begin with one task per cycle, then expand.
+- **Use frontmatter.** `interval` controls how often the loop runs. `timeout` caps each cycle.

--- a/.squad/templates/mcp-config.md
+++ b/.squad/templates/mcp-config.md
@@ -2,8 +2,6 @@
 
 MCP (Model Context Protocol) servers extend Squad with tools for external services — Trello, Aspire dashboards, Azure, Notion, and more. The user configures MCP servers in their environment; Squad discovers and uses them.
 
-> **Full patterns:** Read `.squad/skills/mcp-tool-discovery/SKILL.md` for discovery patterns, domain-specific usage, and graceful degradation.
-
 ## Config File Locations
 
 Users configure MCP servers at these locations (checked in priority order):

--- a/.squad/templates/ralph-triage.js
+++ b/.squad/templates/ralph-triage.js
@@ -55,6 +55,8 @@ function normalizeEol(content) {
   return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
+function slugify(text) { return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+
 function parseRoutingRules(routingMd) {
   const table = parseTableSection(routingMd, /^##\s*work\s*type\s*(?:→|->)\s*agent\b/i);
   if (!table) return [];
@@ -124,7 +126,7 @@ function parseRoster(teamMd) {
     members.push({
       name,
       role,
-      label: `squad:${name.toLowerCase()}`,
+      label: `squad:${slugify(name)}`,
     });
   }
 

--- a/.squad/templates/scribe-charter.md
+++ b/.squad/templates/scribe-charter.md
@@ -15,6 +15,10 @@
 - `.squad/decisions.md` — the shared decision log all agents read (canonical, merged)
 - `.squad/decisions/inbox/` — decision drop-box (agents write here, I merge)
 - Cross-agent context propagation — when one agent's decision affects another
+- Decision archival — **HARD GATE**: enforce two-tier ceiling on decisions.md before every merge:
+  - **Tier 1 (30-day):** If >20KB, archive entries older than 30 days
+  - **Tier 2 (7-day):** If still >50KB after Tier 1, archive entries older than 7 days
+  - Emit HEALTH REPORT to session log after archival runs
 
 ## How I Work
 
@@ -39,7 +43,7 @@ After every substantial work session:
    - **Exact duplicates:** If two blocks share the same heading, keep the first and remove the rest.
    - **Overlapping decisions:** Compare block content across all remaining blocks. If two or more blocks cover the same area (same topic, same architectural concern, same component) but were written independently (different dates, different authors), consolidate them:
      a. Synthesize a single merged block that combines the intent and rationale from all overlapping blocks.
-     b. Use today's date and a new heading: `### {today}: {consolidated topic} (consolidated)`
+     b. Use the CURRENT_DATETIME value from your spawn prompt and a new heading: `### {CURRENT_DATETIME}: {consolidated topic} (consolidated)`
      c. Credit all original authors: `**By:** {Name1}, {Name2}`
      d. Under **What:**, combine the decisions. Note any differences or evolution.
      e. Under **Why:**, merge the rationale, preserving unique reasoning from each.
@@ -57,7 +61,26 @@ After every substantial work session:
    Do NOT embed newlines in `git commit -m` (backtick-n fails silently in PowerShell).
    Instead:
    - `cd` into the team root first.
-   - Stage all `.squad/` files: `git add .squad/`
+   - Stage only files Scribe actually modified in this session.
+     Use `git status --porcelain` to build an explicit file list filtered to allowed `.squad/` paths:
+     ```powershell
+     $allowed = @(
+       '.squad/decisions.md',
+       '.squad/decisions-archive.md'
+     )
+     $allowedPatterns = @(
+       '.squad/agents/*/history.md',
+       '.squad/agents/*/history-archive.md',
+       '.squad/log/*',
+       '.squad/orchestration-log/*'
+     )
+     $filesToStage = git status --porcelain | Where-Object { $_.Length -gt 3 } | ForEach-Object { $_.Substring(3) -replace '^.* -> ','' } | Where-Object {
+       $f = $_
+       ($f -in $allowed) -or ($allowedPatterns | Where-Object { $f -like $_ })
+     }
+     if ($filesToStage) { $filesToStage | Where-Object { $_ } | ForEach-Object { git add -- $_ } }
+     ```
+     ⚠️ NEVER use `git add .squad/` or broad globs — only stage specific files you wrote in this session.
    - Check for staged changes: `git diff --cached --quiet`
      If exit code is 0, no changes — skip silently.
    - Write the commit message to a temp file, then commit with `-F`:

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -3,14 +3,14 @@ name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
 ---
 
-<!-- version: 0.9.4 -->
+<!-- version: 0.0.0-source -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** 0.9.4 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.9.4` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.0.0-source (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.squad/decisions.md`
 - **Outputs owned:** Final assembled artifacts, orchestration log (via Scribe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Squad governance upgraded from 0.9.1 to 0.9.4 (dispatch mechanism, `CURRENT_DATETIME` requirement, `name` param in spawn prompts, default models bumped to `claude-sonnet-4.6` / `gpt-5.3-codex`, tier-based agent timeout policy)
+- `.github/workflows/squad-heartbeat.yml` removes noisy cron trigger; Ralph now fires on issue events only
+- `.github/workflows/squad-triage.yml` and `sync-squad-labels.yml` add `slugify()` for label names (bugfix)
+
+### Added
+- `.github/workflows/squad-label-enforce.yml` -- enforces mutual exclusivity for `go:`, `release:`, `type:`, `priority:` label groups
+- `.copilot/skills/error-recovery/SKILL.md` -- new generic error-recovery skill
+- `.squad/skills/squad-upgrade-hygiene/SKILL.md` -- reusable checklist for auditing future `squad upgrade` runs
+- `.squad/templates/{fact-checker-charter.md, loop.md, squad.agent.md.template}` -- new templates from 0.9.4
+- `hooks/pre-commit` now allows `.squad/templates/*.template` files (squad upgrade ships `squad.agent.md.template`)
+
 ## [0.8.0] - 2026-05-16
 
 ### Added

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -87,6 +87,7 @@ if [ -n "$SQUAD_STAGED" ]; then
       .squad/retros/*.md) VALID=1 ;;
       .squad/skills/*/SKILL.md) VALID=1 ;;
       .squad/templates/*.md) VALID=1 ;;
+      .squad/templates/*.template) VALID=1 ;;
       .squad/casting/*.json) VALID=1 ;;
       .squad/identity/*.md) VALID=1 ;;
       .squad/plugins/*.json) VALID=1 ;;
@@ -116,7 +117,7 @@ if [ -n "$SQUAD_STAGED" ]; then
     echo "    .squad/log/*.md"
     echo "    .squad/retros/*.md"
     echo "    .squad/skills/{name}/SKILL.md"
-    echo "    .squad/templates/*.md | .squad/casting/*.json"
+    echo "    .squad/templates/*.md | .squad/templates/*.template | .squad/casting/*.json"
     echo "    .squad/identity/*.md | .squad/plugins/*.json"
     echo "    .squad/team.md | routing.md | ceremonies.md | config.json"
     echo ""


### PR DESCRIPTION
## Squad governance: 0.9.1 → 0.9.4

Ran `npx @bradygaster/squad-cli upgrade`. Mickey audited the diff in `.squad/decisions/inbox/mickey-squad-0.9.4-upgrade.md` and produced this filtered ship plan.

### What ships

- `squad.agent.md` 0.9.1 → 0.9.4 (dispatch mechanism, `CURRENT_DATETIME` requirement, `name` param in spawn prompts, default models bumped, tier-based timeout policy)
- 3 workflow bugfixes (heartbeat cron removal, triage + labels `slugify()`)
- New `squad-label-enforce.yml` workflow -- enforces mutual exclusivity for `go:` / `release:` / `type:` / `priority:` label groups
- New `error-recovery` skill
- New `squad-upgrade-hygiene` skill -- reusable checklist for future upgrades
- New templates: `fact-checker-charter.md`, `loop.md`, `squad.agent.md.template`
- 5 template refreshes
- `hooks/pre-commit` -- allow `.squad/templates/*.template` (squad upgrade ships `squad.agent.md.template`)

### What was filtered out

- **18 rogue files** dumped at `.squad/` root (duplicates of canonical files under `.squad/templates/` and `.squad/casting/` -- upgrade bug)
- **6 new workflows** targeting branches we do not have: `squad-ci`, `squad-docs`, `squad-insider-release`, `squad-preview`, `squad-promote`, `squad-release` (intended for the squad CLI's own npm release pipeline, not consumer repos)
- **Reverted** `.copilot/skills/git-workflow/SKILL.md` -- upgrade replaced our customized 2-branch (develop/main) model + merge gates with a generic 3-branch template

### Risks

- `claude-sonnet-4.6` / `gpt-5.3-codex` model refs -- if unavailable, spawn falls through to platform default (no breakage)
- `squad-heartbeat.yml` loses cron trigger; Ralph now fires on issue events only
- After merge, restart any active session to pick up the new coordinator behavior

### Test plan

1. CI green on this PR
2. After merge, new session shows `Squad v0.9.4`
3. Pre-commit hook still passes (`.template` files now allowed)
4. Label an issue with `squad` -> triage workflow assigns sub-label

Full audit: `.squad/decisions/inbox/mickey-squad-0.9.4-upgrade.md`
