### PR TITLE
ci(e2e): add summary job to surface platform failures (#253)

### DIFF
--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -493,3 +493,21 @@ jobs:
             }
             Write-Host "`nUninstall verification passed"
           }
+
+  summary:
+    name: E2E Summary
+    runs-on: ubuntu-latest
+    needs: [e2e-linux, e2e-macos, e2e-windows]
+    if: always()
+    steps:
+      - name: Check platform results
+        run: |
+          echo "Linux:   ${{ needs.e2e-linux.result }}"
+          echo "macOS:   ${{ needs.e2e-macos.result }}"
+          echo "Windows: ${{ needs.e2e-windows.result }}"
+          if [[ "${{ needs.e2e-linux.result }}" != "success" ]] || \
+            [[ "${{ needs.e2e-macos.result }}" != "success" ]] || \
+            [[ "${{ needs.e2e-windows.result }}" != "success" ]]; then
+           echo "::error::One or more platform jobs failed"
+           exit 1
+          fi

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -61,6 +61,22 @@ Established CI/CD validation framework and cross-platform test coverage infrastr
 
 ## Recent Work
 
+## [2026-05-16T18:30:00-04:00] Issue #253: e2e-install failure-summary step
+
+**Branch:** `squad/253-e2e-summary`
+**PR:** #265
+**Status:** PR opened
+
+Added a final `summary` job to `.github/workflows/e2e-install.yml` that surfaces silent platform failures. The summary job:
+- Runs on ubuntu-latest with `needs: [e2e-linux, e2e-macos, e2e-windows]` and `if: always()`
+- Inspects each platform job's `result` field
+- Fails with `exit 1` if ANY platform failed
+- Preserves per-platform `continue-on-error: true` for full-matrix telemetry
+
+**Key insight:** Per-platform jobs retain `continue-on-error: true` so nightly crons get complete diagnostics before the summary job reports overall success/failure. This prevents the fail-fast that would lose second/third platform diagnostics.
+
+Updated CHANGELOG.md with [Unreleased] > ### Fixed section.
+
 ## [2026-05-22T00:00:00Z] Issue #181: macOS CI validation job
 
 **Branch:** `squad/181-macos-ci`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/workflows/squad-heartbeat.yml` removes noisy cron trigger; Ralph now fires on issue events only
 - `.github/workflows/squad-triage.yml` and `sync-squad-labels.yml` add `slugify()` for label names (bugfix)
 
+### Fixed
+- `.github/workflows/e2e-install.yml` -- adds a final `summary` job that fails the workflow if any platform job fails, preventing silent green-dashboard regressions. Per-platform jobs still use `continue-on-error: true` so full matrix telemetry is preserved (closes #253).
+
 ### Added
 - Doc (Fact Checker) joins the squad -- new agent addressing the verifier/validator gap from Sprint Q retro. Auto-triggers on `review`/`verify`/`fact-check`/`audit` tasks; produces verification reports with confidence ratings (Verified/Unverified/Contradicted/Needs Investigation). Charter: `.squad/agents/doc/charter.md`.
 - `.github/workflows/squad-label-enforce.yml` -- enforces mutual exclusivity for `go:`, `release:`, `type:`, `priority:` label groups


### PR DESCRIPTION
## Summary

Adds a final `summary` job to `.github/workflows/e2e-install.yml` that surfaces platform failures by making the overall workflow fail if any platform (Linux, macOS, Windows) fails.

## Problem

The e2e-install workflow uses `continue-on-error: true` on all 3 platform jobs. When one or more platforms fail (e.g., run #25969269951 with macOS + Windows failures), the overall workflow still reports `success` — silent failure while the dashboard turns green.

## Solution

Added a `summary` job that:
- Depends on all 3 platform jobs (`needs: [e2e-linux, e2e-macos, e2e-windows]`)
- Inspects each job's `result` field
- Fails the workflow with `exit 1` if ANY platform failed
- Uses `if: always()` to run even when a needed job fails
- Preserves per-platform `continue-on-error: true` so full-matrix telemetry and diagnostics are retained

## Testing

### Before merge:
- Run `gh workflow run e2e-install.yml --ref squad/253-e2e-summary` manually to verify summary job works
- Break one platform deliberately (e.g., add `exit 1` to one test) and confirm overall workflow turns RED

### After merge (nightly cron):
- Verify all 3 platforms complete before summary job runs
- Confirm summary job displays platform statuses clearly in logs

## Checklist
- [x] `.github/workflows/e2e-install.yml` updated
- [x] `CHANGELOG.md` updated
- [x] Branch: `squad/253-e2e-summary`
- [x] Closes #253
