### PR TITLE
test(hooks): behavioral coverage for pre-commit and pre-push (#224)

### DIFF
--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -363,3 +363,23 @@ Created `.github/workflows/e2e-install.yml` -- full end-to-end install smoke tes
 - Lesson: When a centralized version file like `.tool-versions` exists, version drift bugs are single-line fixes -- but only if e2e assertions actually check the installed version against downstream requirements. Always add version-gate assertions for tools with engine constraints.
 - v2 fix -- added `nvm alias default "$PINNED_NODE"` after `nvm use`. v1 missed it. CI exposed the gap via fresh-shell assertion: `nvm install` + `nvm use` only sets the version for the current shell, but a fresh `bash -lc` shell sources `~/.nvm/nvm.sh` with no default alias and falls back to the system Node (e.g., v20 on Ubuntu runners). This is the same root cause as the warning Linux was silently producing (#255). One-line fix closes both issues.
 - v3 fix -- test_tool_versions.sh was stale (expected nodejs 20.11.0). Bumped to match new pinned version.
+
+### Issue #224: Behavioral coverage for pre-commit + pre-push hooks
+
+- Gap identified: test_git_hooks.ps1 had only existence checks for pre-commit and pre-push; no behavioral scenarios.
+- Added Group X (6 scenarios) to tests/test_windows_setup.ps1:
+  - X-1: pre-commit rejects .ps1 containing an em-dash (UTF-8 0xE2 0x80 0x94) -- Check 2 coverage
+  - X-2: pre-commit allows ASCII-only .ps1 -- Check 2 negative case
+  - X-3: pre-commit rejects rogue .squad/random/notes.md path -- Check 3 coverage
+  - X-4: pre-push hard-rejects push whose REMOTE_REF is refs/heads/main
+  - X-5: pre-push allows push to refs/heads/develop
+  - X-6: pre-push exits 0 on feature branch push even with a .ps1 present (advisory block)
+- Extended tests/test_precommit_hygiene.sh with a pre-push section (5 scenarios):
+  - Tpp1: direct push to main hard-fails
+  - Tpp2: push to develop exits 0
+  - Tpp3: push to feature branch exits 0
+  - Tpp4: push targeting main from any local ref is rejected
+  - Tpp5: advisory PSScriptAnalyzer block does not fail CI (exits 0)
+- Decision: extended test_precommit_hygiene.sh instead of creating test_git_hooks.sh. Both pre-commit and pre-push are hook tests; keeping them in one bash file avoids fragmentation. Documented in .squad/decisions/inbox/.
+- Gotcha: sh not on PATH in local PowerShell session -- Group X skips correctly. In CI (GitHub Actions Windows runner), Git for Windows puts sh on PATH so tests execute. Pre-existing 3 failures in test_windows_setup.ps1 are unrelated to this work.
+- Byte-writing approach for em-dash test: used [System.IO.File]::WriteAllBytes with explicit UTF-8 bytes (0xE2 0x80 0x94) to avoid PS version compatibility issues with unicode escape sequences (\u{2014} is PS 6+ only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/windows/tools/*.ps1` -- winget install calls now assert `$LASTEXITCODE` and surface failures to `setup.ps1` (closes #226). 7 install sites previously swallowed non-zero exits silently.
 
 ### Added
+- `tests/test_windows_setup.ps1` Group X -- behavioral tests for pre-commit (ASCII check, rogue .squad/ path) and pre-push (main guard, feature-branch allow, advisory exit-code) hooks (closes #224)
+- `tests/test_precommit_hygiene.sh` extended with pre-push section -- 5 bash scenarios covering direct-to-main rejection and advisory exit-code (closes #224)
 - Doc (Fact Checker) joins the squad -- new agent addressing the verifier/validator gap from Sprint Q retro. Auto-triggers on `review`/`verify`/`fact-check`/`audit` tasks; produces verification reports with confidence ratings (Verified/Unverified/Contradicted/Needs Investigation). Charter: `.squad/agents/doc/charter.md`.
 - `.github/workflows/squad-label-enforce.yml` -- enforces mutual exclusivity for `go:`, `release:`, `type:`, `priority:` label groups
 - `.copilot/skills/error-recovery/SKILL.md` -- new generic error-recovery skill

--- a/tests/test_precommit_hygiene.sh
+++ b/tests/test_precommit_hygiene.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # tests/test_precommit_hygiene.sh
-# Tests for pre-commit hygiene checks (Issue #240)
+# Tests for pre-commit hygiene checks (Issue #240) and pre-push guard (Issue #224)
 #
 # Covers:
 #   Check 1: Branch ancestry (squad/* must descend from develop)
@@ -8,6 +8,7 @@
 #   Check 3: Rogue path check under .squad/
 #   Check 4: Staged inbox file check
 #   Check 5: Protected branch refuse (develop/main/master)
+#   pre-push: Main push guard + advisory PSScriptAnalyzer exit-code
 #
 # Usage:
 #   bash tests/test_precommit_hygiene.sh
@@ -316,6 +317,76 @@ if sh "$HOOK" >/dev/null 2>&1; then
   pass "T5e: commit on pluto/* branch is allowed"
 else
   fail "T5e: commit on pluto/* branch is allowed"
+fi
+
+# ===========================================================================
+# pre-push Tests: Main push guard + advisory exit-code
+# ===========================================================================
+echo ""
+echo "=== pre-push: main guard and advisory exit-code ==="
+
+PUSH_HOOK="${REPO_ROOT}/hooks/pre-push"
+
+# Helper: pipe a push-info line to the pre-push hook and return its exit code.
+# Usage: run_push_hook "LOCAL_REF SHA REMOTE_REF SHA"
+run_push_hook() {
+  printf '%s\n' "$1" | sh "$PUSH_HOOK" origin "https://github.com/test/repo" >/dev/null 2>&1
+}
+
+# Test PP1: FAIL -- push whose REMOTE_REF is refs/heads/main must hard-fail
+T_PP1_DIR="${TMPDIR_BASE}/tpp1"
+setup_test_repo "$T_PP1_DIR"
+cd "$T_PP1_DIR"
+if run_push_hook "refs/heads/develop abc1234 refs/heads/main def5678"; then
+  fail "Tpp1: direct push to main should hard-fail"
+else
+  pass "Tpp1: direct push to main is hard-rejected (exit non-zero)"
+fi
+
+# Test PP2: PASS -- push to develop is allowed
+T_PP2_DIR="${TMPDIR_BASE}/tpp2"
+setup_test_repo "$T_PP2_DIR"
+cd "$T_PP2_DIR"
+if run_push_hook "refs/heads/squad/224-test abc1234 refs/heads/develop def5678"; then
+  pass "Tpp2: push to develop exits 0"
+else
+  fail "Tpp2: push to develop exits 0"
+fi
+
+# Test PP3: PASS -- push to a squad/* feature branch is allowed
+T_PP3_DIR="${TMPDIR_BASE}/tpp3"
+setup_test_repo "$T_PP3_DIR"
+cd "$T_PP3_DIR"
+if run_push_hook "refs/heads/squad/224-test abc1234 refs/heads/squad/224-test def5678"; then
+  pass "Tpp3: push to feature branch exits 0"
+else
+  fail "Tpp3: push to feature branch exits 0"
+fi
+
+# Test PP4: FAIL -- any local ref pushing to refs/heads/main must be rejected
+T_PP4_DIR="${TMPDIR_BASE}/tpp4"
+setup_test_repo "$T_PP4_DIR"
+cd "$T_PP4_DIR"
+if run_push_hook "refs/heads/squad/hotfix abc1234 refs/heads/main def5678"; then
+  fail "Tpp4: push targeting main from feature branch should fail"
+else
+  pass "Tpp4: push targeting main from any local branch is rejected"
+fi
+
+# Test PP5: PASS -- advisory PSScriptAnalyzer block exits 0 even without pwsh
+# The hook uses `|| true` on all advisory commands so missing tools must not fail.
+T_PP5_DIR="${TMPDIR_BASE}/tpp5"
+setup_test_repo "$T_PP5_DIR"
+cd "$T_PP5_DIR"
+git checkout -q -b squad/224-advisory
+# Commit a .ps1 so the hook has content to attempt analysis
+echo 'Write-Host "advisory test"' > advisory.ps1
+git add advisory.ps1
+git commit -q -m "test: advisory ps1"
+if run_push_hook "refs/heads/squad/224-advisory abc1234 refs/heads/squad/224-advisory def5678"; then
+  pass "Tpp5: pre-push exits 0 on feature branch (advisory block does not fail CI)"
+else
+  fail "Tpp5: pre-push exits 0 on feature branch (advisory block does not fail CI)"
 fi
 
 # ===========================================================================

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1515,6 +1515,181 @@ if ($null -eq (Get-Command psmux -ErrorAction SilentlyContinue)) {
 }
 
 # ---------------------------------------------------------------------------
+# Group Y: pre-commit + pre-push behavioral tests (Issue #224)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group Y: pre-commit + pre-push behavioral tests (#224)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+$preCommitHook = Join-Path $RepoRoot "hooks\pre-commit"
+$prePushHook   = Join-Path $RepoRoot "hooks\pre-push"
+
+if (-not (Get-Command sh -ErrorAction SilentlyContinue)) {
+    Write-Skip "Y-1 pre-commit rejects .ps1 with em-dash"          "sh not available"
+    Write-Skip "Y-2 pre-commit allows ASCII-only .ps1"              "sh not available"
+    Write-Skip "Y-3 pre-commit rejects rogue .squad/ path"          "sh not available"
+    Write-Skip "Y-4 pre-push hard-rejects direct push to main"      "sh not available"
+    Write-Skip "Y-5 pre-push allows push to develop"                "sh not available"
+    Write-Skip "Y-6 pre-push exits 0 on feature branch (advisory)"  "sh not available"
+} else {
+    $yTmpBase = Join-Path $PSScriptRoot "tmp_grpy_$(Get-Random)"
+    New-Item -ItemType Directory -Path $yTmpBase -Force | Out-Null
+
+    # Helper: create a minimal git repo with a develop branch
+    function New-YTestRepo([string]$Path) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+        Push-Location $Path
+        & git init -q 2>&1 | Out-Null
+        & git config core.autocrlf false 2>&1 | Out-Null
+        & git config user.email "test@test.com" 2>&1 | Out-Null
+        & git config user.name "Test" 2>&1 | Out-Null
+        "init" | Set-Content README.md -Encoding ASCII
+        & git add README.md 2>&1 | Out-Null
+        & git commit -q -m "chore: init" 2>&1 | Out-Null
+        & git checkout -q -b develop 2>&1 | Out-Null
+        "develop" | Add-Content README.md -Encoding ASCII
+        & git add README.md 2>&1 | Out-Null
+        & git commit -q -m "chore: develop base" 2>&1 | Out-Null
+        Pop-Location
+    }
+
+    try {
+
+        # ------------------------------------------------------------------
+        # Y-1: pre-commit rejects .ps1 with a non-ASCII byte (em-dash)
+        # ------------------------------------------------------------------
+        Test-Scenario "Y-1 pre-commit rejects .ps1 with em-dash (non-ASCII)" {
+            $repoDir = Join-Path $yTmpBase "y1"
+            New-YTestRepo $repoDir
+            Push-Location $repoDir
+            try {
+                & git checkout -q -b pluto/ascii-fail 2>&1 | Out-Null
+                # Write a .ps1 containing a UTF-8 em-dash (bytes: 0xE2 0x80 0x94)
+                $before = [System.Text.Encoding]::ASCII.GetBytes('Write-Host "hello ')
+                $emDash = [byte[]](0xE2, 0x80, 0x94)
+                $after  = [System.Text.Encoding]::ASCII.GetBytes(' world"' + [char]10)
+                [System.IO.File]::WriteAllBytes(
+                    (Join-Path $repoDir "test.ps1"),
+                    ($before + $emDash + $after)
+                )
+                & git add "test.ps1" 2>&1 | Out-Null
+                & sh $preCommitHook 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    throw "pre-commit should have rejected .ps1 with em-dash but exited 0"
+                }
+            } finally { Pop-Location }
+        }
+
+        # ------------------------------------------------------------------
+        # Y-2: pre-commit allows a .ps1 that is pure ASCII
+        # ------------------------------------------------------------------
+        Test-Scenario "Y-2 pre-commit allows ASCII-only .ps1" {
+            $repoDir = Join-Path $yTmpBase "y2"
+            New-YTestRepo $repoDir
+            Push-Location $repoDir
+            try {
+                & git checkout -q -b pluto/ascii-pass 2>&1 | Out-Null
+                'Write-Host "hello -- world"' | Set-Content "test.ps1" -Encoding ASCII
+                & git add "test.ps1" 2>&1 | Out-Null
+                $out = & sh $preCommitHook 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    throw "pre-commit rejected ASCII-only .ps1 (exit $LASTEXITCODE): $out"
+                }
+            } finally { Pop-Location }
+        }
+
+        # ------------------------------------------------------------------
+        # Y-3: pre-commit rejects a newly staged .squad/ path not on allow-list
+        # ------------------------------------------------------------------
+        Test-Scenario "Y-3 pre-commit rejects rogue .squad/ path" {
+            $repoDir = Join-Path $yTmpBase "y3"
+            New-YTestRepo $repoDir
+            Push-Location $repoDir
+            try {
+                & git checkout -q -b pluto/rogue-squad 2>&1 | Out-Null
+                New-Item -ItemType Directory -Path ".squad\random" -Force | Out-Null
+                "rogue" | Set-Content ".squad\random\notes.md" -Encoding ASCII
+                & git add ".squad\random\notes.md" 2>&1 | Out-Null
+                & sh $preCommitHook 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    throw "pre-commit should have rejected rogue .squad/ path but exited 0"
+                }
+            } finally { Pop-Location }
+        }
+
+        # ------------------------------------------------------------------
+        # Y-4: pre-push hard-rejects a push whose remote ref is refs/heads/main
+        # ------------------------------------------------------------------
+        Test-Scenario "Y-4 pre-push hard-rejects direct push to main" {
+            $repoDir = Join-Path $yTmpBase "y4"
+            New-YTestRepo $repoDir
+            Push-Location $repoDir
+            try {
+                # Pipe push-info line as stdin: LOCAL_REF SHA REMOTE_REF SHA
+                $hookUnix   = $prePushHook.Replace('\', '/')
+                $stdinFile  = Join-Path $yTmpBase "push_stdin_y4.txt"
+                Set-Content $stdinFile "refs/heads/develop abc1234 refs/heads/main def5678" -Encoding ASCII
+                $stdinUnix  = $stdinFile.Replace('\', '/')
+                & sh -c "sh '$hookUnix' origin 'https://github.com/test/repo' < '$stdinUnix'" 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    throw "pre-push should have rejected push to main but exited 0"
+                }
+            } finally { Pop-Location }
+        }
+
+        # ------------------------------------------------------------------
+        # Y-5: pre-push allows a push whose remote ref is NOT main
+        # ------------------------------------------------------------------
+        Test-Scenario "Y-5 pre-push allows push to develop branch" {
+            $repoDir = Join-Path $yTmpBase "y5"
+            New-YTestRepo $repoDir
+            Push-Location $repoDir
+            try {
+                $hookUnix   = $prePushHook.Replace('\', '/')
+                $stdinFile  = Join-Path $yTmpBase "push_stdin_y5.txt"
+                Set-Content $stdinFile "refs/heads/squad/224-test abc1234 refs/heads/develop def5678" -Encoding ASCII
+                $stdinUnix  = $stdinFile.Replace('\', '/')
+                $out = & sh -c "sh '$hookUnix' origin 'https://github.com/test/repo' < '$stdinUnix'" 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    throw "pre-push should have allowed push to develop (exit $LASTEXITCODE): $out"
+                }
+            } finally { Pop-Location }
+        }
+
+        # ------------------------------------------------------------------
+        # Y-6: pre-push exits 0 on feature push regardless of PSScriptAnalyzer
+        # The advisory block always uses `|| true`, so warnings must not fail CI.
+        # ------------------------------------------------------------------
+        Test-Scenario "Y-6 pre-push exits 0 on feature branch (PSScriptAnalyzer advisory)" {
+            $repoDir = Join-Path $yTmpBase "y6"
+            New-YTestRepo $repoDir
+            Push-Location $repoDir
+            try {
+                & git checkout -q -b squad/224-advisory-test 2>&1 | Out-Null
+                # Commit a .ps1 so the hook has content to (optionally) analyze
+                'Write-Host "advisory test"' | Set-Content "advisory.ps1" -Encoding ASCII
+                & git add "advisory.ps1" 2>&1 | Out-Null
+                & git commit -q -m "test: advisory ps1" 2>&1 | Out-Null
+                $hookUnix   = $prePushHook.Replace('\', '/')
+                $stdinFile  = Join-Path $yTmpBase "push_stdin_y6.txt"
+                Set-Content $stdinFile "refs/heads/squad/224-advisory-test abc1234 refs/heads/squad/224-advisory-test def5678" -Encoding ASCII
+                $stdinUnix  = $stdinFile.Replace('\', '/')
+                $out = & sh -c "sh '$hookUnix' origin 'https://github.com/test/repo' < '$stdinUnix'" 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    throw "pre-push advisory path must exit 0 even with PSScriptAnalyzer warnings (exit $LASTEXITCODE): $out"
+                }
+            } finally { Pop-Location }
+        }
+
+    } finally {
+        if (Test-Path $yTmpBase) {
+            Remove-Item $yTmpBase -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds behavioral test coverage for hooks/pre-commit and hooks/pre-push -- the two hooks
that had zero runtime tests (only existence checks in Group A).

## Changes

### tests/test_windows_setup.ps1 -- Group X (6 scenarios)

Pre-commit behavioral tests (require sh on PATH -- skip gracefully when absent):
- **X-1** pre-commit rejects a staged .ps1 containing a UTF-8 em-dash (non-ASCII byte)
- **X-2** pre-commit allows a staged .ps1 that is pure ASCII
- **X-3** pre-commit rejects a newly staged .squad/random/notes.md (rogue path)

Pre-push behavioral tests:
- **X-4** pre-push hard-rejects a push whose REMOTE_REF is efs/heads/main (exit non-zero)
- **X-5** pre-push allows a push to efs/heads/develop (exit 0)
- **X-6** pre-push exits 0 on a feature-branch push even with a .ps1 present (advisory block)

### tests/test_precommit_hygiene.sh -- pre-push section (5 scenarios)

- **Tpp1** direct push to efs/heads/main hard-fails
- **Tpp2** push to efs/heads/develop exits 0
- **Tpp3** push to efs/heads/squad/224-test feature branch exits 0
- **Tpp4** push targeting main from any local ref is rejected
- **Tpp5** advisory PSScriptAnalyzer block exits 0 even without pwsh installed

## Design decision

Extended 	est_precommit_hygiene.sh rather than creating a new 	est_git_hooks.sh.
Rationale: that file already owns all pre-commit behavioral tests; adding pre-push there
keeps all hook tests co-located. Decision logged in .squad/decisions/inbox/chip-224-hook-tests.md.

## Acceptance criteria

- [x] pre-commit has at least 3 behavioral test scenarios (X-1, X-2, X-3 + T1a-T5e already in bash)
- [x] pre-push has at least 3 behavioral test scenarios (X-4, X-5, X-6 + Tpp1-Tpp5)
- [x] Tests work on both Linux (bash) and Windows (PS -- skip if sh absent, run in CI)

Closes #224.
