### PR TITLE
fix(scripts/windows): assert winget exit code (#226)

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -106,7 +106,47 @@ Set-Alias -Name <name> -Value <custom-function> -Force -Scope Global
 
 ---
 
-## [2026-05-04] Issue #185: Windows Setup Refactor — 451-line monolith → 9 per-tool files (PR #195)
+## [2026-05-16T18:30:00Z] Issue #226: Assert winget exit code after installs
+
+**Branch:** `squad/226-winget-exit-check`
+**Status:** PR open -- awaiting Doc review
+
+**Bug Pattern:** `winget install` (and `npm install -g`, powershell IEX installs) can return
+non-zero on real failures while the script silently continued. 7 install sites all lacked
+any exit-code check.
+
+**Fix Applied:**
+- Added `Assert-LastExit` helper to `scripts/windows/lib/logging.ps1`
+- `Assert-LastExit -ToolName <name> -AllowedExitCodes @(0, -1978335189)` called immediately
+  after each install command in all 7 sites
+- Winget ALREADY_INSTALLED code 0x8A15002B (= -1978335189 signed int32) treated as success
+- PS function mocks in tests P-2/P-3 updated to set `$global:LASTEXITCODE = 0` explicitly
+  (PS functions do not set LASTEXITCODE; leaving it unset would be racy)
+- 9 new Group X tests added (X-1 through X-9)
+
+**7 Install Sites Fixed:**
+1. `tools/git.ps1` -- winget Git.Git
+2. `tools/gh.ps1` -- winget GitHub.cli
+3. `tools/vim.ps1` -- winget vim.vim
+4. `tools/psmux.ps1` -- winget marlocarlo.psmux
+5. `tools/copilot.ps1` -- winget GitHub.Copilot
+6. `tools/uv.ps1` -- powershell IEX (astral.sh install script)
+7. `tools/squad-cli.ps1` -- npm install -g
+
+**Key Learnings:**
+- PowerShell functions do NOT set `$LASTEXITCODE`; only native external commands do.
+  Test mocks that override winget with a PS function MUST explicitly set
+  `$global:LASTEXITCODE = 0` to avoid racy behavior.
+- Winget ALREADY_INSTALLED = 0x8A15002B = -1978335189 (signed int32). Always include in
+  AllowedExitCodes for winget calls.
+- `Assert-LastExit` must be called BEFORE any subsequent PS commands that might change
+  `$LASTEXITCODE` (i.e., before `Refresh-SessionPath` even though PS functions don't
+  affect it -- defense in depth).
+- `[Parameter(Mandatory)]` on the helper's ToolName param satisfies PSUseSingularNouns
+  and PSReviewUnusedParameter rules without extra suppressions.
+
+---
+
 
 **Status:** ✅ APPROVED, MERGED to develop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `.github/workflows/e2e-install.yml` -- adds a final `summary` job that fails the workflow if any platform job fails, preventing silent green-dashboard regressions. Per-platform jobs still use `continue-on-error: true` so full matrix telemetry is preserved (closes #253).
+- `scripts/windows/tools/*.ps1` -- winget install calls now assert `$LASTEXITCODE` and surface failures to `setup.ps1` (closes #226). 7 install sites previously swallowed non-zero exits silently.
 
 ### Added
 - Doc (Fact Checker) joins the squad -- new agent addressing the verifier/validator gap from Sprint Q retro. Auto-triggers on `review`/`verify`/`fact-check`/`audit` tasks; produces verification reports with confidence ratings (Verified/Unverified/Contradicted/Needs Investigation). Charter: `.squad/agents/doc/charter.md`.

--- a/scripts/windows/lib/logging.ps1
+++ b/scripts/windows/lib/logging.ps1
@@ -7,3 +7,17 @@ function Write-Info  { param([string]$Msg) Write-Output "[INFO]  $Msg" }
 function Write-Ok    { param([string]$Msg) Write-Output "[OK]    $Msg" }
 function Write-Warn  { param([string]$Msg) Write-Output "[WARN]  $Msg" }
 function Write-Err   { param([string]$Msg) Write-Output "[ERROR] $Msg" }
+
+# Assert-LastExit: call immediately after any external install command.
+# Throws if $LASTEXITCODE is not in AllowedExitCodes.
+# Winget ALREADY_INSTALLED (0x8A15002B) = -1978335189 -- treat as success.
+function Assert-LastExit {
+    param(
+        [Parameter(Mandatory)][string]$ToolName,
+        [int[]]$AllowedExitCodes = @(0)
+    )
+    if ($AllowedExitCodes -notcontains $LASTEXITCODE) {
+        Write-Err "$ToolName install failed (exit code $LASTEXITCODE)"
+        throw "$ToolName install failed"
+    }
+}

--- a/scripts/windows/tools/copilot.ps1
+++ b/scripts/windows/tools/copilot.ps1
@@ -29,6 +29,7 @@ function Install-CopilotCli {
     # Mirrors the official install script (https://gh.io/copilot-install) on Windows:
     # on Windows it routes to `winget install GitHub.Copilot` (standalone binary).
     winget install --id GitHub.Copilot --silent --accept-source-agreements --accept-package-agreements
+    Assert-LastExit -ToolName "GitHub Copilot CLI" -AllowedExitCodes @(0, -1978335189)
     Refresh-SessionPath
     Write-Ok "Copilot CLI installed"
 }

--- a/scripts/windows/tools/gh.ps1
+++ b/scripts/windows/tools/gh.ps1
@@ -16,6 +16,7 @@ function Install-GhCli {
     }
     Write-Info "Installing GitHub CLI..."
     winget install --id GitHub.cli --silent --accept-source-agreements --accept-package-agreements
+    Assert-LastExit -ToolName "GitHub CLI" -AllowedExitCodes @(0, -1978335189)
     Refresh-SessionPath
     Write-Ok "gh CLI installed"
 }

--- a/scripts/windows/tools/git.ps1
+++ b/scripts/windows/tools/git.ps1
@@ -18,6 +18,7 @@ function Install-Git {
     }
     Write-Info "Installing Git for Windows (includes Git Bash)..."
     winget install --id Git.Git --silent --accept-source-agreements --accept-package-agreements
+    Assert-LastExit -ToolName "Git" -AllowedExitCodes @(0, -1978335189)
     Refresh-SessionPath
     Write-Ok "Git for Windows installed"
     Write-Info "Git Bash available at: C:\Program Files\Git\bin\bash.exe"

--- a/scripts/windows/tools/psmux.ps1
+++ b/scripts/windows/tools/psmux.ps1
@@ -17,6 +17,7 @@ function Install-Psmux {
     }
     Write-Info "Installing psmux..."
     winget install --id marlocarlo.psmux --accept-source-agreements --accept-package-agreements --silent
+    Assert-LastExit -ToolName "psmux" -AllowedExitCodes @(0, -1978335189)
     Refresh-SessionPath
     Write-Ok "psmux installed."
 }

--- a/scripts/windows/tools/squad-cli.ps1
+++ b/scripts/windows/tools/squad-cli.ps1
@@ -25,5 +25,6 @@ function Install-SquadCli {
     }
     Write-Info "Installing squad-cli..."
     npm install -g "@bradygaster/squad-cli"
+    Assert-LastExit -ToolName "squad-cli"
     Write-Ok "squad-cli installed"
 }

--- a/scripts/windows/tools/uv.ps1
+++ b/scripts/windows/tools/uv.ps1
@@ -15,5 +15,6 @@ function Install-Uv {
     }
     Write-Info "Installing uv..."
     powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    Assert-LastExit -ToolName "uv"
     Write-Ok "uv installed"
 }

--- a/scripts/windows/tools/vim.ps1
+++ b/scripts/windows/tools/vim.ps1
@@ -17,6 +17,7 @@ function Install-Vim {
     }
     Write-Info "Installing vim..."
     winget install --id vim.vim --silent --accept-source-agreements --accept-package-agreements
+    Assert-LastExit -ToolName "vim" -AllowedExitCodes @(0, -1978335189)
     # winget does not reliably add vim to PATH -- find and register it manually
     $vimExe = Get-ChildItem 'C:\Program Files*\Vim\*\vim.exe' -ErrorAction SilentlyContinue |
               Sort-Object -Property FullName -Descending |

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1007,6 +1007,7 @@ if ($null -ne (Get-Command psmux -ErrorAction SilentlyContinue)) {
         function global:winget {
             $script:WingetCalled = $true
             $script:WingetArgs = $args
+            $global:LASTEXITCODE = 0
         }
         try {
             $output = Install-Psmux 2>&1 | Out-String
@@ -1023,7 +1024,7 @@ if ($null -ne (Get-Command psmux -ErrorAction SilentlyContinue)) {
 }
 
 Test-Scenario "P-3: Install-Psmux is idempotent (second call does not throw)" {
-    function global:winget { }
+    function global:winget { $global:LASTEXITCODE = 0 }
     try {
         Install-Psmux | Out-Null
         Install-Psmux | Out-Null
@@ -1410,6 +1411,107 @@ Test-Scenario "W-3 nvm.ps1 uses two-level Split-Path (not one)" {
     if ($nvmContent -notmatch 'Split-Path\s*\(\s*Split-Path\s+\$PSScriptRoot\s+-Parent\s*\)\s+-Parent') {
         throw "nvm.ps1 does not use two-level Split-Path for lib resolution"
     }
+}
+
+# ---------------------------------------------------------------------------
+# Group X: winget / npm exit code assertion (Issue #226)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group X: winget/npm exit code assertion (Issue #226)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+. (Join-Path $RepoRoot 'scripts\windows\lib\logging.ps1')
+
+Test-Scenario "X-1: Assert-LastExit is defined in logging.ps1" {
+    $cmd = Get-Command Assert-LastExit -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw "Assert-LastExit not defined after dot-sourcing logging.ps1"
+    }
+}
+
+Test-Scenario "X-2: Assert-LastExit does not throw for exit code 0" {
+    $global:LASTEXITCODE = 0
+    Assert-LastExit -ToolName "test-tool"
+}
+
+Test-Scenario "X-3: Assert-LastExit does not throw for ALREADY_INSTALLED (-1978335189)" {
+    $global:LASTEXITCODE = -1978335189
+    Assert-LastExit -ToolName "test-tool" -AllowedExitCodes @(0, -1978335189)
+}
+
+Test-Scenario "X-4: Assert-LastExit throws for unexpected non-zero exit code" {
+    $global:LASTEXITCODE = 2
+    $threw = $false
+    try {
+        Assert-LastExit -ToolName "test-tool" -AllowedExitCodes @(0, -1978335189)
+    } catch {
+        $threw = $true
+    }
+    $global:LASTEXITCODE = 0
+    if (-not $threw) {
+        throw "Assert-LastExit did not throw for exit code 2"
+    }
+}
+
+Test-Scenario "X-5: All 5 winget install scripts call Assert-LastExit" {
+    $wingetScripts = @('git', 'gh', 'vim', 'psmux', 'copilot')
+    foreach ($s in $wingetScripts) {
+        $path = Join-Path $RepoRoot "scripts\windows\tools\$s.ps1"
+        $content = Get-Content $path -Raw
+        if ($content -notmatch 'Assert-LastExit') {
+            throw "$s.ps1 does not call Assert-LastExit after winget install"
+        }
+    }
+}
+
+Test-Scenario "X-6: squad-cli.ps1 calls Assert-LastExit after npm install" {
+    $content = Get-Content (Join-Path $RepoRoot 'scripts\windows\tools\squad-cli.ps1') -Raw
+    if ($content -notmatch 'Assert-LastExit') {
+        throw "squad-cli.ps1 does not call Assert-LastExit after npm install"
+    }
+}
+
+Test-Scenario "X-7: uv.ps1 calls Assert-LastExit after install command" {
+    $content = Get-Content (Join-Path $RepoRoot 'scripts\windows\tools\uv.ps1') -Raw
+    if ($content -notmatch 'Assert-LastExit') {
+        throw "uv.ps1 does not call Assert-LastExit after install command"
+    }
+}
+
+Test-Scenario "X-8: Assert-LastExit allowed codes include winget ALREADY_INSTALLED in all winget scripts" {
+    $wingetScripts = @('git', 'gh', 'vim', 'psmux', 'copilot')
+    foreach ($s in $wingetScripts) {
+        $path = Join-Path $RepoRoot "scripts\windows\tools\$s.ps1"
+        $content = Get-Content $path -Raw
+        if ($content -notmatch '\-1978335189') {
+            throw "$s.ps1 does not include ALREADY_INSTALLED (-1978335189) in AllowedExitCodes"
+        }
+    }
+}
+
+if ($null -eq (Get-Command psmux -ErrorAction SilentlyContinue)) {
+    Test-Scenario "X-9: Simulated winget failure propagates from Install-Psmux" {
+        $psmuxContent = Get-Content (Join-Path $RepoRoot 'scripts\windows\tools\psmux.ps1') -Raw
+        $psmuxExec = $psmuxContent -replace '\.\s+"?\$PSScriptRoot[^"]*(logging|path)\.ps1"?', '# lib loaded by test harness'
+        Invoke-Expression $psmuxExec
+        function global:winget { $global:LASTEXITCODE = 99 }
+        $threw = $false
+        try {
+            Install-Psmux 2>&1 | Out-Null
+        } catch {
+            $threw = $true
+        } finally {
+            Remove-Item -Force Function:winget -ErrorAction SilentlyContinue
+            $global:LASTEXITCODE = 0
+        }
+        if (-not $threw) {
+            throw "Install-Psmux did not propagate the simulated winget failure"
+        }
+    }
+} else {
+    Write-Skip "X-9: Simulated winget failure propagates from Install-Psmux" `
+        "psmux is installed -- early-return path taken, winget not called"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #226 -- `winget install` (and `npm install -g`, powershell IEX installs) in
`scripts/windows/tools/*.ps1` did not check `$LASTEXITCODE`. A network blip or
unavailable source could fail silently and let setup proceed as if everything was fine.

## Changes

### New helper: `Assert-LastExit` (logging.ps1)

```powershell
function Assert-LastExit {
    param(
        [Parameter(Mandatory)][string]$ToolName,
        [int[]]$AllowedExitCodes = @(0)
    )
    if ($AllowedExitCodes -notcontains $LASTEXITCODE) {
        Write-Err "$ToolName install failed (exit code $LASTEXITCODE)"
        throw "$ToolName install failed"
    }
}
```

### 7 install sites patched

| File | Command | Allowed codes |
|------|---------|---------------|
| tools/git.ps1 | winget Git.Git | 0, -1978335189 |
| tools/gh.ps1 | winget GitHub.cli | 0, -1978335189 |
| tools/vim.ps1 | winget vim.vim | 0, -1978335189 |
| tools/psmux.ps1 | winget marlocarlo.psmux | 0, -1978335189 |
| tools/copilot.ps1 | winget GitHub.Copilot | 0, -1978335189 |
| tools/uv.ps1 | powershell IEX | 0 |
| tools/squad-cli.ps1 | npm install -g | 0 |

`-1978335189` (0x8A15002B) is winget's `ALREADY_INSTALLED` -- benign, treated as success.

### Tests

- 9 new Group X tests (`X-1` through `X-9`) covering:
  - Helper definition and non-throw for allowed codes (X-1 to X-3)
  - Throw for unexpected non-zero (X-4)
  - Static call-site verification for all 7 sites (X-5 to X-7)
  - ALREADY_INSTALLED in AllowedExitCodes for all winget scripts (X-8)
  - Simulated winget failure propagates (X-9, conditional)
- P-2/P-3 mocks updated to set `$global:LASTEXITCODE = 0` explicitly

## Acceptance Criteria

- [x] All 7 install sites verify exit code
- [x] A forced failure (mock, exit code 99) bubbles up to caller (X-9)
- [x] ALREADY_INSTALLED (-1978335189) treated as success (X-3, X-8)
- [ ] CI green (pending)

## PS 5.1 Compatibility

- No ternaries, no null-conditional operators
- ASCII-only in all .ps1 files
- `$AllowedExitCodes -notcontains $LASTEXITCODE` works on PS 5.1 and PS 7+
