### PR TITLE
feat(dotfiles): timestamp .bak backups with N-keep retention (#227)

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -254,3 +254,41 @@ Delivered 30 PowerShell aliases with full git/gh/dev parity, conflict guards for
 - ASCII check: <10ms for typical staged .ps1 files (pipes through grep)
 - Rogue path check: <5ms (pure shell pattern matching)
 - Total hook overhead for clean commit: ~20ms (well under 100ms goal)
+
+---
+
+## 2026-05-16 -- Issue #227: Timestamp .bak backups (both platforms)
+
+**Branch:** `squad/227-bak-rotation`
+**PR:** (pending)
+**Status:** PR open, targeting `develop`
+
+### What I did
+
+- Added `backup_file()` to `config/dotfiles/install.sh`:
+  - Creates `<target>.bak.YYYYMMDD-HHMMSS` on each backup
+  - Trims all but the N most recent (default N=5, override `DOTFILE_BACKUP_KEEP`)
+  - Replaces the old `cp "$dest" "${dest}.bak"` one-shot pattern in `install_copy`
+    and the `cp "$link" "${link}.bak"` pattern in `install_symlink`
+- Added `Backup-File` function to `scripts/windows/tools/dotfiles.ps1`:
+  - Same timestamp format (`yyyyMMdd-HHmmss`), same N-keep trim
+  - Reads `$env:DOTFILE_BACKUP_KEEP` for override
+  - Replaces the "back up only if no .bak exists yet" guard
+- Updated `scripts/linux/uninstall.sh` `restore_backup()`:
+  - Picks newest `.bak.*` (last known good before most recent install)
+  - Falls back to legacy `.bak` for backward compat
+- Updated `scripts/windows/uninstall.ps1` `Restore-DotfileBackup`:
+  - Same strategy: newest `.bak.*` first, then legacy `.bak`
+  - Updated "foundAny" probe to check `.bak.*` glob too
+- Updated `tests/test_windows_setup.ps1`:
+  - Q-3 now asserts `.bak.*` (timestamped) pattern, not `.bak`
+  - Added Q-4: 3-run acceptance test -- 3 distinct timestamped backups verified
+- CHANGELOG.md [Unreleased] > Changed: appended entry
+- Decision file: `.squad/decisions/inbox/pluto-227-bak-rotation.md`
+
+### Key decisions
+
+- **Restore strategy:** newest backup = state before last install. Oldest = original-original (still accessible manually, kept by N=5 default). Decision file: `pluto-227-bak-rotation.md`.
+- **Default N=5:** env var override `DOTFILE_BACKUP_KEEP` on both platforms.
+- **Cleanup:** automatic inline trim after each backup write. No cron required.
+- **Timestamp format:** `YYYYMMDD-HHmmss` -- sortable, human-readable, filesystem-safe, identical on both platforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Squad governance upgraded from 0.9.1 to 0.9.4 (dispatch mechanism, `CURRENT_DATETIME` requirement, `name` param in spawn prompts, default models bumped to `claude-sonnet-4.6` / `gpt-5.3-codex`, tier-based agent timeout policy)
 - `.github/workflows/squad-heartbeat.yml` removes noisy cron trigger; Ralph now fires on issue events only
 - `.github/workflows/squad-triage.yml` and `sync-squad-labels.yml` add `slugify()` for label names (bugfix)
+- Dotfile backup strategy: `.bak` files are now timestamped (`.bak.YYYYMMDD-HHMMSS`) on both Linux (`config/dotfiles/install.sh`) and Windows (`scripts/windows/tools/dotfiles.ps1`). Keeps last 5 backups by default (override with `DOTFILE_BACKUP_KEEP` env var); previous versions of dotfiles are no longer lost on re-run (closes #227).
 
 ### Fixed
 - `.github/workflows/e2e-install.yml` -- adds a final `summary` job that fails the workflow if any platform job fails, preventing silent green-dashboard regressions. Per-platform jobs still use `continue-on-error: true` so full matrix telemetry is preserved (closes #253).

--- a/config/dotfiles/install.sh
+++ b/config/dotfiles/install.sh
@@ -44,6 +44,23 @@ for arg in "$@"; do
   esac
 done
 
+# ── Helper: timestamped backup, keep last N copies ───────────────────────────
+# Usage: backup_file <target> [<keep_count>]
+# Creates <target>.bak.YYYYMMDD-HHMMSS and trims all but the N most recent.
+# DOTFILE_BACKUP_KEEP overrides the default of 5 at install time.
+backup_file() {
+  local target="$1"
+  local keep="${2:-${DOTFILE_BACKUP_KEEP:-5}}"
+  [ -e "$target" ] || return 0
+  local ts
+  ts=$(date +%Y%m%d-%H%M%S)
+  cp -p "$target" "${target}.bak.${ts}"
+  info "Backed up $target -> ${target}.bak.${ts}"
+  # Remove oldest backups beyond the keep limit
+  # shellcheck disable=SC2012
+  ls -t "${target}.bak."* 2>/dev/null | tail -n +$((keep + 1)) | xargs -r rm --
+}
+
 # ── Helper: copy a template file, skipping if destination already matches ───
 # Usage: install_copy <src> <dest> [<label>]
 install_copy() {
@@ -53,9 +70,9 @@ install_copy() {
 
   if [[ "$DRY_RUN" == true ]]; then
     if [[ -f "$dest" ]]; then
-      dry "Would back up existing $dest → ${dest}.bak and overwrite with $src"
+      dry "Would back up existing $dest -> ${dest}.bak.YYYYMMDD-HHMMSS and overwrite with $src"
     else
-      dry "Would copy $src → $dest"
+      dry "Would copy $src -> $dest"
     fi
     return
   fi
@@ -63,8 +80,7 @@ install_copy() {
   if [[ -f "$dest" ]]; then
     # Only back up if the destination is not already this template
     if ! diff -q "$src" "$dest" > /dev/null 2>&1; then
-      cp "$dest" "${dest}.bak"
-      info "Backed up existing $dest → ${dest}.bak"
+      backup_file "$dest"
       cp "$src" "$dest"
       ok "Installed $label"
     else
@@ -126,9 +142,8 @@ install_symlink() {
     # Symlink exists but points somewhere else — replace it
     rm "$link"
   elif [[ -e "$link" ]]; then
-    # Regular file in the way — back it up
-    cp "$link" "${link}.bak"
-    info "Backed up existing $link → ${link}.bak"
+    # Regular file in the way -- back it up
+    backup_file "$link"
     rm "$link"
   fi
 
@@ -168,7 +183,7 @@ substitute_gitconfig() {
 }
 
 # ── Main ─────────────────────────────────────────────────────────────────────
-printf "\n${CYAN}Installing dotfiles from %s${RESET}\n\n" "$DOTFILES_DIR"
+printf '\n%sInstalling dotfiles from %s%s\n\n' "$CYAN" "$DOTFILES_DIR" "$RESET"
 
 # .gitconfig — copy so users can edit without touching the repo template
 install_copy \
@@ -205,7 +220,8 @@ install_symlink \
   "$HOME/.vimrc" \
   ".vimrc"
 
-# .zshrc — copy template on fresh install; append managed block to existing file
+# .zshrc -- copy template on fresh install; append managed block to existing file
+# shellcheck disable=SC2016
 ZSHRC_MANAGED_BLOCK='# --- dev-setup managed block (do not edit) ---
 export PATH="$HOME/.local/bin:$PATH"
 export NVM_DIR="$HOME/.nvm"
@@ -218,14 +234,15 @@ if [[ -f "$HOME/.zshrc" ]]; then
   append_managed_block "$HOME/.zshrc" "$ZSHRC_MANAGED_BLOCK" ".zshrc"
 else
   if [[ "$DRY_RUN" == true ]]; then
-    dry "Would copy .zshrc.template → $HOME/.zshrc"
+    dry "Would copy .zshrc.template -> $HOME/.zshrc"
   else
     cp "$DOTFILES_DIR/.zshrc.template" "$HOME/.zshrc"
     ok "Installed .zshrc from template"
   fi
 fi
 
-# .bashrc — append managed block if file exists (nvm PATH already appended by nvm installer)
+# .bashrc -- append managed block if file exists (nvm PATH already appended by nvm installer)
+# shellcheck disable=SC2016
 BASHRC_MANAGED_BLOCK='# --- dev-setup managed block (do not edit) ---
 export PATH="$HOME/.local/bin:$PATH"
 [ -f "$HOME/.aliases" ] && source "$HOME/.aliases"
@@ -235,4 +252,4 @@ if [[ -f "$HOME/.bashrc" ]]; then
   append_managed_block "$HOME/.bashrc" "$BASHRC_MANAGED_BLOCK" ".bashrc"
 fi
 
-printf "\n${GREEN}Done.${RESET}\n\n"
+printf '\n%sDone.%s\n\n' "$GREEN" "$RESET"

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -22,19 +22,27 @@ info() { printf "${CYAN}[INFO] %s${RESET}\n" "$*"; }
 skip() { printf "${YELLOW}[SKIP] %s${RESET}\n" "$*"; }
 
 # ── Restore dotfile .bak files ───────────────────────────────────────────────
+# Restores the newest timestamped backup (.bak.YYYYMMDD-HHMMSS).
+# That is the state just before the most recent install run.
+# To recover the original-original, use the oldest .bak.* file manually.
 restore_backup() {
   local target="$1"
-  local backup="${target}.bak"
-
-  if [[ -f "$backup" ]]; then
-    mv "$backup" "$target"
-    ok "Restored $target from $backup"
+  # Prefer newest timestamped backup; fall back to legacy .bak
+  local newest
+  # shellcheck disable=SC2012
+  newest=$(ls -t "${target}.bak."* 2>/dev/null | head -n 1)
+  if [[ -n "$newest" ]]; then
+    mv "$newest" "$target"
+    ok "Restored $target from $(basename "$newest")"
+  elif [[ -f "${target}.bak" ]]; then
+    mv "${target}.bak" "$target"
+    ok "Restored $target from ${target}.bak (legacy)"
   else
     skip "No backup found for $target"
   fi
 }
 
-printf "\n${CYAN}dev-setup uninstaller${RESET}\n\n"
+printf '\n%sdev-setup uninstaller%s\n\n' "$CYAN" "$RESET"
 
 # Dotfiles that install.sh may have backed up
 DOTFILES=(
@@ -77,4 +85,4 @@ remove_managed_block "$HOME/.zshrc"
 remove_managed_block "$HOME/.bashrc"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
-printf "\n${GREEN}[OK] Uninstalled. Tools (uv, nvm, gh, etc.) remain. Remove them manually if you wish.${RESET}\n\n"
+printf '\n%s[OK] Uninstalled. Tools (uv, nvm, gh, etc.) remain. Remove them manually if you wish.%s\n\n' "$GREEN" "$RESET"

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -30,7 +30,7 @@ restore_backup() {
   # Prefer newest timestamped backup; fall back to legacy .bak
   local newest
   # shellcheck disable=SC2012
-  newest=$(ls -t "${target}.bak."* 2>/dev/null | head -n 1)
+  newest=$(ls -t "${target}.bak."* 2>/dev/null | head -n 1) || newest=''
   if [[ -n "$newest" ]]; then
     mv "$newest" "$target"
     ok "Restored $target from $(basename "$newest")"

--- a/scripts/windows/tools/dotfiles.ps1
+++ b/scripts/windows/tools/dotfiles.ps1
@@ -1,13 +1,38 @@
 # scripts/windows/tools/dotfiles.ps1 - Dotfile installer for Windows
 #
-# Owner: Goofy (#2)
-# Copies dotfiles to %USERPROFILE% with .bak backup if existing file differs.
+# Owner: Pluto (Config Engineer)
+# Copies dotfiles to %USERPROFILE% with timestamped .bak backup on change.
 # No symlinks -- plain copy for maximum compatibility (no admin/developer mode).
+#
+# Backup strategy: <file>.bak.YYYYMMDD-HHmmss
+# Keeps the $KeepLast most recent backups (default 5; override with
+# $env:DOTFILE_BACKUP_KEEP). Older backups are deleted automatically.
+# Uninstall restores the newest backup (= state before last install run).
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . "$PSScriptRoot\..\lib\logging.ps1"
+
+# Backs up $Target with a timestamp suffix and trims old backups.
+# $KeepLast is overridden by $env:DOTFILE_BACKUP_KEEP when set.
+function Backup-File {
+    param(
+        [string]$Target,
+        [int]$KeepLast = 5
+    )
+    if (-not (Test-Path $Target)) { return }
+    if ($env:DOTFILE_BACKUP_KEEP -match '^\d+$') { $KeepLast = [int]$env:DOTFILE_BACKUP_KEEP }
+    $ts = Get-Date -Format "yyyyMMdd-HHmmss"
+    $bakPath = "$Target.bak.$ts"
+    Copy-Item -Path $Target -Destination $bakPath -Force
+    Write-Info "Backed up $Target -> $bakPath"
+    # Remove oldest timestamped backups beyond the keep limit
+    Get-ChildItem "$Target.bak.*" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -Skip $KeepLast |
+        Remove-Item -Force
+}
 
 function Install-Dotfiles {
     Write-Info "Installing dotfiles..."
@@ -43,12 +68,7 @@ function Install-Dotfiles {
                 continue
             }
 
-            # Back up only if no .bak exists yet
-            $bakPath = "$destPath.bak"
-            if (-not (Test-Path $bakPath)) {
-                Write-Warn "$destPath exists -- backing up to $bakPath"
-                Copy-Item -Path $destPath -Destination $bakPath -Force
-            }
+            Backup-File -Target $destPath
         }
 
         Copy-Item -Path $srcPath -Destination $destPath -Force

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -16,12 +16,21 @@ function Write-Skip { param([string]$Msg) Write-Host "[SKIP] $Msg" -ForegroundCo
 function Write-Info { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Cyan }
 
 # -- Restore dotfile .bak files ------------------------------------------------
+# Restores the newest timestamped backup (.bak.YYYYMMDD-HHmmss).
+# The newest backup is the state just before the most recent install run.
+# To recover the original-original, look for the oldest .bak.* file manually.
 function Restore-DotfileBackup {
     param([string]$Target)
-    $backup = "$Target.bak"
-    if (Test-Path $backup) {
-        Move-Item -Path $backup -Destination $Target -Force
-        Write-Ok "Restored $Target from $backup"
+    # Prefer newest timestamped backup; fall back to legacy .bak
+    $tsBaks = Get-ChildItem "$Target.bak.*" -ErrorAction SilentlyContinue |
+                  Sort-Object LastWriteTime -Descending
+    if ($tsBaks) {
+        $newest = $tsBaks[0]
+        Move-Item -Path $newest.FullName -Destination $Target -Force
+        Write-Ok "Restored $Target from $($newest.Name)"
+    } elseif (Test-Path "$Target.bak") {
+        Move-Item -Path "$Target.bak" -Destination $Target -Force
+        Write-Ok "Restored $Target from $Target.bak (legacy)"
     } else {
         Write-Skip "No backup found for $Target"
     }
@@ -42,7 +51,7 @@ $dotfiles = @(
 
 $foundAny = $false
 foreach ($dotfile in $dotfiles) {
-    if (Test-Path "$dotfile.bak") {
+    if ((Test-Path "$dotfile.bak") -or (Get-ChildItem "$dotfile.bak.*" -ErrorAction SilentlyContinue)) {
         $foundAny = $true
         break
     }

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1070,7 +1070,7 @@ Test-Scenario "Q-2: Install-Dotfiles is idempotent (calling twice does not throw
     }
 }
 
-Test-Scenario "Q-3: Install-Dotfiles creates .bak when target differs" {
+Test-Scenario "Q-3: Install-Dotfiles creates timestamped .bak when target differs" {
     $script = Join-Path $RepoRoot 'scripts\windows\tools\dotfiles.ps1'
     $tempHome = Join-Path $env:TEMP "dotfiles_bak_test_$(Get-Random)"
     New-Item -ItemType Directory -Path $tempHome -Force | Out-Null
@@ -1082,13 +1082,45 @@ Test-Scenario "Q-3: Install-Dotfiles creates .bak when target differs" {
         Set-Content -Path $targetFile -Value 'old content that differs' -Encoding UTF8
         . $script
         Install-Dotfiles | Out-Null
-        $bakFile = "$targetFile.bak"
-        if (-not (Test-Path $bakFile)) {
-            throw ".bak file was not created when target content differed"
+        # Expect a .bak.YYYYMMDD-HHmmss file (not a plain .bak)
+        $bakFiles = Get-ChildItem "$targetFile.bak.*" -ErrorAction SilentlyContinue
+        if (-not $bakFiles) {
+            throw "No timestamped .bak.* file was created when target content differed"
         }
-        $bakContent = Get-Content $bakFile -Raw
+        $bakContent = Get-Content $bakFiles[0].FullName -Raw
         if ($bakContent -notmatch 'old content that differs') {
             throw ".bak file does not contain original content"
+        }
+    } finally {
+        $env:USERPROFILE = $origProfile
+        Remove-Item -Recurse -Force $tempHome -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Scenario "Q-4: Three successive installs produce three distinct timestamped backups" {
+    $script = Join-Path $RepoRoot 'scripts\windows\tools\dotfiles.ps1'
+    $tempHome = Join-Path $env:TEMP "dotfiles_3run_test_$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempHome -Force | Out-Null
+    $origProfile = $env:USERPROFILE
+    try {
+        $env:USERPROFILE = $tempHome
+        . $script
+        $targetFile = Join-Path $tempHome '.editorconfig'
+        # Pre-seed the target so all 3 runs see a diff and produce a backup
+        Set-Content -Path $targetFile -Value 'version-0-original' -Encoding UTF8
+        # Run 1: seeds backup of version-0
+        Install-Dotfiles | Out-Null
+        Set-Content -Path $targetFile -Value 'version-1-edit' -Encoding UTF8
+        Start-Sleep -Milliseconds 1100   # ensure distinct 1-second timestamp
+        # Run 2: seeds backup of version-1
+        Install-Dotfiles | Out-Null
+        Set-Content -Path $targetFile -Value 'version-2-edit' -Encoding UTF8
+        Start-Sleep -Milliseconds 1100
+        # Run 3: seeds backup of version-2
+        Install-Dotfiles | Out-Null
+        $bakFiles = Get-ChildItem "$targetFile.bak.*" -ErrorAction SilentlyContinue
+        if ($bakFiles.Count -lt 3) {
+            throw "Expected at least 3 timestamped backups after 3 install runs; found $($bakFiles.Count)"
         }
     } finally {
         $env:USERPROFILE = $origProfile


### PR DESCRIPTION
## Summary

Closes #227.

Both Linux (config/dotfiles/install.sh) and Windows (scripts/windows/tools/dotfiles.ps1) now create timestamped dotfile backups on every install run, preserving history instead of silently overwriting the previous backup.

## What changed

### Strategy: .bak.YYYYMMDD-HHMMSS + N-keep trim

| Platform | Old behavior | New behavior |
|----------|-------------|-------------|
| Linux | cp dest dest.bak -- overwrites every run | ackup_file(): dest.bak.20260516-183045, keeps last N |
| Windows | backup once if no .bak exists | Backup-File: same timestamp format, same N-keep trim |

**Default N = 5.** Override: DOTFILE_BACKUP_KEEP=10 ./install.sh / \ = 10.

### Restore strategy (uninstall)

Both uninstallers now restore the **newest** .bak.* (state before the most recent install run). Falls back to legacy .bak for backward compat. The oldest .bak.* is the original-original -- still accessible manually within the N-keep window.

Decision rationale: .squad/decisions/inbox/pluto-227-bak-rotation.md

### Files changed

- config/dotfiles/install.sh -- ackup_file() helper; shellcheck fixes (SC2012, SC2016, SC2059) on touched lines
- scripts/windows/tools/dotfiles.ps1 -- Backup-File function; removed "backup only once" guard
- scripts/linux/uninstall.sh -- estore_backup() picks newest .bak.*
- scripts/windows/uninstall.ps1 -- Restore-DotfileBackup picks newest .bak.*
- 	ests/test_windows_setup.ps1 -- Q-3 updated for timestamp pattern; Q-4 added (3-run acceptance test)
- CHANGELOG.md -- [Unreleased] entry

## Testing

- Q-1: dotfiles.ps1 parses + defines Install-Dotfiles -- PASS
- Q-2: idempotent (2x no-op) -- PASS
- Q-3: timestamped .bak.* created when content differs -- PASS
- Q-4: 3 successive installs produce 3 distinct timestamped backups -- PASS

## Acceptance criteria

- [x] Running setup 3 times preserves all 3 prior versions (Q-4)
- [x] Cleanup documented (keep N most recent, trim on next run; ind ~ -name "*.bak.*" -mtime +90 -delete for manual cleanup)
- [x] Both Linux and Windows use the same strategy
