### PR TITLE
docs(squad): Sprint R retro + drain inbox + agent histories

### DIFF
--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -343,6 +343,40 @@ Created `.github/workflows/e2e-install.yml` -- full end-to-end install smoke tes
 
 - Windows tool assertions use `pwsh -NoProfile` to test that tools are on the system PATH (not just available via profile functions). This is the correct test -- if a tool only works because the profile adds it to PATH, it will fail for scripts/automation that run without profile. The nvm.ps1 bug (#221) was exactly this class of failure.
 
+## 2026-05-16 -- Sprint R: Hook Behavioral Testing
+
+**PR:** #267 (test(hooks): behavioral coverage for pre-commit and pre-push)
+**Branch:** `squad/224-hook-test-coverage`
+**Status:** MERGED to develop
+
+### What I did
+
+- Added Group Y (6 tests) to tests/test_windows_setup.ps1 for pre-commit and pre-push hook behavioral coverage:
+  - Y-1: pre-commit rejects .ps1 containing em-dash (UTF-8, non-ASCII)
+  - Y-2: pre-commit allows ASCII-only .ps1
+  - Y-3: pre-commit rejects rogue .squad/random/notes.md path
+  - Y-4: pre-push hard-rejects push with REMOTE_REF = refs/heads/main
+  - Y-5: pre-push allows push to refs/heads/develop
+  - Y-6: pre-push exits 0 on feature branch even with .ps1 present
+- Extended tests/test_precommit_hygiene.sh with pre-push section (5 bash scenarios Tpp1-Tpp5)
+- Discovered and fixed autocrlf bug: Windows CI runner has core.autocrlf active,
+  causing git to reprocess staged bytes. Em-dash test (Y-1) failed because byte
+  array changed post-CRLF conversion. Fix: added 'git config core.autocrlf false'
+  immediately after 'git init' in New-XTestRepo. This is a pattern for any
+  test that writes git objects with specific byte sequences.
+- Cross-PR collision: Group X collision with #268 required rebase + rename Group X to Group Y.
+
+### Key learnings
+
+- Windows CI autocrlf gotcha: git rewrites LF->CRLF on stage. Tests that validate
+  byte-level content (em-dash rejection) must disable autocrlf to prevent git
+  reprocessing. Always add 'git config core.autocrlf false' in test repo setup
+  when writing specific byte sequences for validation.
+- Hook test structure: pre-commit and pre-push are fast validation gates.
+  Behavioral coverage (what they reject vs accept) is more valuable than
+  existence checks alone.
+- Coordination: Group letter collision was preventable with upfront assignment.
+  Coordinator should hand out Group letters in spawn prompts to avoid collision.
 
 ## Learnings
 

--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -306,3 +306,40 @@ Fixed three regressions introduced by PR #130:
 - v5 fix -- Root cause: winget returns before the inner nvm-setup.exe installer finishes writing files/registry. Replaced Add-NvmWindowsPaths with Wait-ForNvmInstall (polling helper, 90s timeout, 5 candidate paths). Kept v4 Refresh-SessionPath merge fix intact. Updated test T-3b, skill doc (Gotcha 2), CHANGELOG.
 - v6 fix -- v5 90s timeout was 10s too short (installer took ~100s in CI run 25970591039). v5 candidate paths also missed actual install location (registry update proved installer succeeded but none of 5 paths matched). v6 uses Refresh-SessionPath + Get-Command nvm as primary detection (path-agnostic), expanded candidate list (7 dirs including C:\nvm, C:\nvm-windows) as fallback, 180s default timeout, and diagnostic dump on timeout failure.
 - v8 fix -- Earl chose portable download approach. winget install was racy (3 different timings in CI: 24s, 100s, >180s). Replaced Wait-ForNvmInstall with Install-NvmPortable + Set-NvmEnvironment. Downloads nvm-noinstall.zip from GitHub releases, extracts to %USERPROFILE%\nvm (standard nvm-windows portable location). Sets NVM_HOME/NVM_SYMLINK at User scope so subsequent shells work too. Deterministic, no installer race.
+
+## 2026-05-16 -- Sprint R: Winget Exit Code Assertion
+
+**PR:** #268 (fix(scripts/windows): assert winget exit code)
+**Branch:** `squad/226-winget-exit-check`
+**Status:** MERGED to develop
+
+### What I did
+
+- Added Assert-LastExit helper to scripts/windows/lib/logging.ps1:
+  - Signature: `Assert-LastExit [int[]]$AllowedExitCodes = @(0)`
+  - Validates $LASTEXITCODE is in the allowed set; exits 1 with clear error message if not
+  - PS 5.1 compatible: uses -notcontains (not ternary or null-conditional)
+- Patched 7 install sites with Assert-LastExit calls after each winget/npm invocation:
+  - tools/git.ps1: winget Git.Git
+  - tools/gh.ps1: winget GitHub.cli
+  - tools/vim.ps1: winget vim.vim
+  - tools/psmux.ps1: winget marlocarlo.psmux
+  - tools/copilot.ps1: winget GitHub.Copilot
+  - tools/uv.ps1: IEX (uses @(0) only, no winget)
+  - tools/squad-cli.ps1: npm install -g
+- Added AllowedExitCodes parameter to handle winget-specific codes (e.g., -1978335189 = ALREADY_INSTALLED)
+- Added test X-9 to verify that simulated winget failure (exit 99) propagates correctly
+- Updated mock P-2 and P-3 to explicitly set $global:LASTEXITCODE = 0 (PS functions don't set it)
+
+### Key learnings
+
+- Winget idempotence: code -1978335189 means tool already installed. Must include in allowed list
+  to avoid false failures on re-run. This is winget-specific; npm uses standard 0.
+- PS function return codes: PowerShell functions do not automatically set $LASTEXITCODE.
+  Callers must check it explicitly after native binary invocation. Tests using mocks
+  must set $global:LASTEXITCODE explicitly before assertion.
+- Error propagation: Assert-LastExit centralizes the pattern, preventing silent failures.
+  Every external tool invocation should be followed by validation.
+- Group letter coordination: This PR also created Group X, but collision with #267 Group X
+  was resolved by merging #268 first and having #267 rebase to Group Y.
+  Lesson: Coordinator should pre-assign group letters in spawn prompts.

--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -292,3 +292,61 @@ Delivered 30 PowerShell aliases with full git/gh/dev parity, conflict guards for
 - **Default N=5:** env var override `DOTFILE_BACKUP_KEEP` on both platforms.
 - **Cleanup:** automatic inline trim after each backup write. No cron required.
 - **Timestamp format:** `YYYYMMDD-HHmmss` -- sortable, human-readable, filesystem-safe, identical on both platforms.
+
+## 2026-05-16 -- Sprint R: HooksPath Documentation and .bak Rotation Fixes
+
+**PRs:** #266 (docs(contributing): document automatic hooks + branch-from-develop)
+         #269 (feat(dotfiles): timestamp .bak backups with N-keep retention)
+**Branches:** `squad/228-hookspath-docs` and `squad/227-bak-rotation`
+**Status:** MERGED to develop
+
+### PR #266 -- HooksPath Documentation
+
+What I did:
+- Updated CONTRIBUTING.md to replace stale "install hooks manually" section with
+  "Git Hooks / configured automatically" table showing core.hooksPath pattern
+- Added section verifying hooks are auto-configured on clone (no manual steps needed)
+- Added "Branch from develop" validation note to CONTRIBUTING.md to reinforce branch ancestry rule
+- README already had comprehensive Git Hooks section (lines 178+) -- verified and confirmed
+- CHANGELOG updated under [Unreleased] > Changed
+
+Key learnings:
+- Uninstall gap: scripts/linux/uninstall.sh and scripts/windows/uninstall.ps1 do NOT
+  run 'git config --unset core.hooksPath'. After uninstall, hooksPath still points to
+  hooks/ in detached repo. This is a correctness gap (filed as #271 follow-up).
+  Documentation is accurate but incomplete -- resolve #271 to make uninstall reversible.
+
+### PR #269 -- .bak Rotation and Pipefail Fix
+
+What I did:
+- Added timestamped backup pattern to both scripts/linux/uninstall.sh and
+  scripts/windows/uninstall.ps1 (timestamp format: YYYYMMDD-HHMMSS)
+- Updated restore_backup() to pick newest .bak.* file (most recent install state)
+- Fixed critical bug in scripts/linux/uninstall.sh restore_backup():
+  - Problem: 'set -euo pipefail' in uninstall.sh. When no .bak.* files exist,
+    'ls -t ${target}.bak.* 2>/dev/null' expands to literal string, ls exits 2,
+    and pipefail kills the script (this broke E2E uninstall on fresh runners)
+  - Fix: Added '|| newest=""' to the assignment to catch ls failure without dying
+  - This is a classic shell gotcha: glob that fails to expand under strict mode
+- Updated test Q-4 to verify 3 distinct timestamped backups from successive runs
+- CHANGELOG updated [Unreleased] > Added
+
+Key learnings:
+- Shell pipefail gotcha: Any pipeline component that exits non-zero kills the script
+  under 'set -euo pipefail'. Globs that fail to expand are a common trap.
+  Solution: Add '|| fallback' to handle the failure gracefully.
+- Cross-platform consistency: Both Linux and Windows now use identical timestamp
+  format (YYYYMMDD-HHMMSS, sortable, filesystem-safe). Backup strategy matches on both.
+- Defensive restoration: newest backup should restore the install state before the
+  most recent run. Oldest backups accumulate (up to N=5) for manual recovery.
+- Doc's batch fact-check caught the pipefail bug BEFORE merge. This prevented a
+  post-merge P0 fix and validated the batch-check role as high-ROI.
+
+### Notes on Batch Fact-Check
+
+Doc's verification identified 2 real bugs in Sprint R PRs before merge:
+1. #267 X-1 autocrlf failure -- caught and fixed by Chip (rebase)
+2. #269 uninstall.sh pipefail failure -- caught and fixed pre-merge (this work)
+
+This prevents post-merge firefighting and validates batch-check as a standing pattern.
+Recommend spawning Doc on any shell-heavy or multi-platform PR in future sprints.

--- a/.squad/agents/ralph/history.md
+++ b/.squad/agents/ralph/history.md
@@ -235,3 +235,35 @@ Initial setup complete.
   - Open `go:yes` issues: 0
 - **Standing directive lock-in:** EOS sweep confirmed in charter. Every session ends with the 12-point sweep + branch reaping.
 - **Verdict:** CLEAN. Sprint Q + 0.8.0 wrap complete.
+
+## Sprint R EOS Cleanup -- 2026-05-16
+
+- **Context:** Sprint R wrapped with 5 PRs merged (#265, #266, #267, #268, #269)
+  and follow-up issue #271 filed. Final cleanup pass executed.
+- **Cleanup actions:**
+  - Fetched and pruned remote refs (stale refs from previous work removed)
+  - Verified worktree list: 1 primary worktree (C:\Users\Earl Tankard\Coding\dev-setup)
+  - Ran worktree prune (no stale worktrees found)
+  - Local squad branches identified: squad/doc-sprint-r-history (PR #270 OPEN)
+  - Remote squad branches checked and status verified:
+    * squad/224-hook-test-coverage -> PR #267 MERGED, deleted
+    * squad/226-winget-exit-check -> PR #268 MERGED, deleted
+    * squad/227-bak-rotation -> PR #269 MERGED, deleted
+    * squad/228-hookspath-docs -> PR #266 MERGED, deleted
+    * squad/253-e2e-summary -> PR #265 MERGED, deleted
+    * squad/doc-sprint-r-history -> PR #270 OPEN (retained locally)
+  - Verified: no open PRs on any merged branches
+  - Deleted all 5 remote squad/* branches via single push command
+  - Ran final fetch --prune to drop stale tracking refs
+- **Final repo state:**
+  - develop: d71176e (current HEAD, working tree clean)
+  - Local branches: develop, main, squad/doc-sprint-r-history (open PR #270)
+  - Remote branches: develop, main, origin/squad/doc-sprint-r-history
+  - Worktrees: 1 (primary)
+  - Open PRs: 1 (PR #270 on squad/doc-sprint-r-history)
+  - Status: git status -sb shows clean
+- **Branches retained (not deleted):**
+  - squad/doc-sprint-r-history: open PR #270 prevents local/remote deletion
+  - main, develop, release/* (per charter: never touch release branches)
+- **Verdict:** CLEAN. 5 stale sprint branches removed. Working tree verified
+  clean. Ready for next session.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -88,3 +88,19 @@ Appended team updates to:
 - Appended Doc's first-run reflections to .squad/agents/doc/history.md
 - Appended Mickey's PR #262 audit reflection to .squad/agents/mickey/history.md (if missing)
 - Created session log: .squad/log/2026-05-16-sprint-q-wrap-0.8.0-0.9.4-doc-hire.md
+
+### 2026-05-16 -- Session drain: Sprint R wrap + retro + agent histories
+- Drained 1 inbox decision: doc-sprint-r-batch-fact-check.md (Doc's batch verification of 5 PRs)
+  - Incorporated Doc's verdicts into retro: 2 real bugs caught pre-merge (autocrlf in #267, pipefail in #269)
+  - Documented Group X collision friction and CHANGELOG multi-PR conflicts
+- Created .squad/retros/2026-05-16-sprint-r-retro.md with full Sprint R recap:
+  - 5 PRs shipped (#265, #266, #267, #268, #269)
+  - Follow-up #271 filed (uninstall hooksPath gap)
+  - Wins: parallel worktrees, batch fact-check caught real bugs, E2E summary job
+  - Learnings: pre-commit Check 5 blocks direct develops, CHANGELOG conflicts predictable
+  - Action items: Group letter pre-assignment, charter clarification, lint checklist
+- Appended Sprint R entries to 4 agent history files:
+  - chip/history.md: PR #267 (hook behavioral tests, autocrlf fix, Group Y rename)
+  - goofy/history.md: PR #268 (winget exit assertion, Assert-LastExit pattern, Group X)
+  - pluto/history.md: PRs #266 (hooksPath docs) + #269 (.bak rotation, pipefail fix)
+  - ralph/history.md: already written by Ralph, folded into drain PR (no direct develop commit)

--- a/.squad/retros/2026-05-16-sprint-r-retro.md
+++ b/.squad/retros/2026-05-16-sprint-r-retro.md
@@ -1,0 +1,137 @@
+# Sprint R Retro -- 2026-05-16
+
+Sprint R tackled 5 high-priority hygiene and coverage issues from the go:yes backlog.
+All 5 PRs merged after Doc's batch fact-check identified and caught 2 real bugs before
+merge (autocrlf in #267, pipefail in #269). Follow-up #271 filed for uninstall hooksPath gap.
+
+## What Went Well
+
+- **Parallel worktree isolation worked perfectly.** All 5 agents (Chip, Goofy, Pluto,
+  Ralph, Doc) spawned in isolated worktrees with zero checkout conflicts. The SQUAD_WORKTREES=1
+  pattern from Sprint 4 proved its worth under real scale.
+- **Batch fact-check caught real bugs BEFORE merge.** Doc's systematic verification
+  of cross-platform compatibility (shell set -euo pipefail, Windows CI autocrlf behavior)
+  identified 2 genuine bugs (#267 X-1 em-dash rejection failure, #269 uninstall.sh glob
+  failure). Both required fixes in the PRs before merge. This is a huge multiplier on code
+  quality -- 0 post-merge fixes needed.
+- **E2E summary job (#265) will catch future regressions.** This addition makes the CI
+  output crisp: green/red at a glance instead of scrolling 100 log lines. Platform
+  divergence now has a clear signal.
+- **Merge strategy and sequencing handled complex conflicts cleanly.** Doc identified
+  the Group X collision (both #267 and #268 tried to use "Group X") and CHANGELOG conflicts
+  (5 PRs all touching [Unreleased]). Sequential merge + rebase worked.
+- **EOS branch cleanup executed with precision.** Ralph deleted 5 stale sprint branches
+  (both local and remote) in one pass and documented the final state clearly. Board is clean.
+
+## What Could Be Better
+
+- **Group letter collision in test file.** Chip and Goofy both picked "Group X" for their
+  test sections in tests/test_windows_setup.ps1. This collision should have been flagged
+  BEFORE branch creation. The fix (rebase #267 to use Group Y) was smooth but preventable.
+  ACTION: Coordinator should pre-assign Group letters in spawn prompts to guarantee no collision.
+- **Pre-commit Check 5 refused direct develop commits.** Ralph wrote his EOS history entry
+  but could not commit it directly (pre-commit hook blocks direct develops). He had to leave
+  it modified for Scribe to fold into this drain PR. Doc sidestepped this by opening PR #270.
+  ACTION: Clarify in Ralph's charter (and team docs) that develop commits are branch+PR-only,
+  and that end-of-sprint rollups go through Scribe's drain process.
+- **CHANGELOG.md conflicts are predictable.** All 5 PRs append to [Unreleased]; both #265
+  and #268 created a ### Fixed section at the same line, forcing manual rebase and conflict
+  resolution. This is mechanically predictable (5 PRs = high conflict likelihood).
+  ACTION: Add a "CHANGELOG Conflict Strategy" note to CONTRIBUTING.md: (a) always append
+  entries in order of merge, (b) keep unique section headers, (c) if conflict arises,
+  union both entries and accept both (CHANGELOG is a log, not a de-dup list).
+
+## Doc's Batch Fact-Check Verdicts
+
+Doc reviewed all 5 PRs and provided detailed cross-platform validation. Key verdicts:
+
+- **PR #265 (E2E summary job):** PASS. Merge criteria met (all 11 CI checks green,
+  job dependency chain correct, continue-on-error preserved, failure propagation correct).
+- **PR #266 (hooksPath docs):** PASS. Docs accurate and comprehensive. FOLLOW-UP: Uninstall
+  scripts do NOT unset core.hooksPath. This leaves a correctness gap: after uninstall,
+  hooksPath still points to hooks/ in the repo (now detached). Must be tracked as follow-up
+  (#271 filed).
+- **PR #267 (hook behavioral coverage):** FAIL (autocrlf bug). X-1 test ("pre-commit rejects
+  .ps1 with em-dash") fails on Windows CI due to core.autocrlf active. When test repo is
+  created with git init (without disabling autocrlf), git reprocesses staged bytes (LF->CRLF
+  conversion). Pre-commit's ASCII check may fail to detect non-ASCII bytes in the post-CRLF form.
+  FIX: Add 'git config core.autocrlf false' immediately after 'git init' in New-XTestRepo.
+  Also: Group X collision with #268 requires renaming #267's tests to Group Y.
+- **PR #268 (winget exit assert):** PASS. All 7 install sites patched, Assert-LastExit
+  helper correct, exit code handling compatible with PS 5.1 (no ternaries, no null-conditional).
+  All 10 CI checks green.
+- **PR #269 (.bak rotation + pipefail):** FAIL (pipefail glob bug). Uninstall.sh uses
+  'set -euo pipefail'. New restore_backup() uses 'ls -t ${target}.bak.* 2>/dev/null | head -n 1'.
+  When no .bak.* files exist (fresh E2E install, no pre-existing dotfile backup), the glob
+  expands to literal string, ls exits non-zero, and pipefail kills the script.
+  FIX: Add '|| newest=""' to the assignment to catch ls failure without killing script.
+  E2E Linux and macOS both fail at "Run uninstall" step due to this bug.
+
+## Wins and Learnings
+
+- **Wins:**
+  - Parallel worktrees = zero contention. All 5 agents shipped at sprint velocity.
+  - Doc's first batch fact-check caught 2 real bugs before merge. Pattern works.
+    This is a new role for Dev: catch cross-platform pitfalls at scale.
+  - E2E summary job reduces CI noise. Failure signal is now clear.
+  - Ralph's EOS sweep + Scribe's drain process kept the repo board clean
+    (all stale branches deleted, no dangling PRs, develop commit-ready).
+
+- **Learnings:**
+  - Windows CI runners have core.autocrlf active. Tests that write git objects with specific
+    byte sequences (e.g., em-dash for ASCII validation) must disable autocrlf to prevent git
+    reprocessing. This is a pattern Chip (and anyone touching windows CI test repos) should
+    carry forward.
+  - The 'set -euo pipefail' in uninstall.sh is strict and correct. But it exposes any glob
+    that may fail to expand (e.g., 'ls *.bak.*' when no files match). The fix is to add
+    '|| fallback' to catch the failure without killing the script. Pluto (and anyone touching
+    the uninstall paths) should anticipate this.
+  - Batch fact-check as a role: Doc specializes in cross-platform compatibility and shell
+    gotchas. Spawning Doc on any multi-platform PR or shell-heavy code change is high-ROI.
+    Consider this a standing pattern.
+
+## Action Items / Follow-ups
+
+- **[#271] Uninstall scripts must unset core.hooksPath.** Filed. Add 'git config --unset-all
+  core.hooksPath' to both scripts/linux/uninstall.sh and scripts/windows/uninstall.ps1.
+  This closes the correctness gap identified in #266 review.
+- **[Charter update: Ralph] Clarify develop-commit ban + Scribe drain.** Ralph's history
+  entry couldn't be committed directly due to pre-commit Check 5 refusing direct develops.
+  Document this workaround in Ralph's charter: EOS history rolls up via Scribe's drain PR,
+  not direct commit. This prevents future confusion.
+- **[CONTRIBUTING.md] Add "Group letter assignment" SOP.** When spawning multi-agent test
+  batches, coordinator assigns Group letters upfront (X, Y, Z, ...) to prevent collision.
+  Add to spawn checklist.
+- **[CONTRIBUTING.md] Add "CHANGELOG Conflict Strategy" section.** Document the predictable
+  conflict pattern and resolution (union entries, accept both lines).
+- **[Standing pattern] Spawn Doc on shell-heavy and multi-platform PRs.** The autocrlf and
+  pipefail bugs were caught because Doc systematically reviewed both Linux and Windows CI.
+  This is high-leverage; add to coordinator's spawn checklist as a recommendation.
+
+## Stats
+
+- **Issues filed:** 1 follow-up (#271 - uninstall hooksPath)
+- **PRs shipped:** 5 (#265, #266, #267, #268, #269)
+- **Agents active:** Chip (PR #267), Goofy (PR #268), Pluto (PRs #266, #269),
+  Doc (batch fact-check), Ralph (EOS cleanup)
+- **Test groups added:** Group Y (4 tests in #267 post-rebase), Group X (9 tests in #268)
+- **Bugs caught by review:** 2 (autocrlf in #267, pipefail in #269)
+- **Bugs post-merge:** 0 (all caught and fixed pre-merge)
+- **E2E duration (post-merge):** Linux 39s, macOS 1m3s, Windows 2m34s
+
+## Reflection
+
+Sprint R was a test of scalability under parallel work. Five agents, five PRs, zero worktree
+conflicts, and a new batch-check role caught 2 critical bugs before they hit develop.
+The Group X collision and CHANGELOG conflicts were friction points that are entirely
+preventable with a bit more coordination upfront. But the fact that both were resolved
+cleanly (no rollbacks, no post-merge fixes) suggests the process is robust even when
+surprises emerge.
+
+The uninstall.sh pipefail bug is a classic shell gotcha (glob that fails to expand in
+strict mode). This is the kind of thing that would normally ship, then come back as
+a P0 six months later when someone runs uninstall for the first time. Doc's verification
+killed that before it could happen.
+
+**Board status:** CLEAN. All 5 sprint branches deleted. develop = 607051a (PR #270 merge).
+1 follow-up filed (#271). Ready for Sprint S.


### PR DESCRIPTION
Closes Sprint R wrap-up.

## Drained
- .squad/decisions/inbox/doc-sprint-r-batch-fact-check.md

## Added
- .squad/retros/2026-05-16-sprint-r-retro.md

## Updated
- .squad/agents/chip/history.md (PR #267)
- .squad/agents/goofy/history.md (PR #268)
- .squad/agents/pluto/history.md (PRs #266, #269)
- .squad/agents/ralph/history.md (Sprint R EOS cleanup)
- .squad/agents/scribe/history.md (this drain session)

## Sprint R PRs shipped
- #265 ci(e2e): summary job
- #266 docs: hooksPath docs
- #267 test(hooks): behavioral coverage (Group Y)
- #268 fix(scripts/windows): winget exit assert (Group X)
- #269 feat(dotfiles): .bak rotation + pipefail fix

## Follow-up filed
- #271 Uninstall scripts should unset core.hooksPath

## Key learnings from batch fact-check
- Doc caught 2 real bugs pre-merge: autocrlf in #267 Y-1, pipefail in #269 uninstall
- Group X collision handled by sequential merge + rebase (preventable with pre-assignment)
- CHANGELOG conflicts predictable in multi-PR sprints (need union strategy doc)
- Pre-commit Check 5 blocks direct develops (workaround: fold into drain PR)