### PR TITLE
docs(squad): Sprint R retro action items (#273)

### DIFF
--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -20,6 +20,19 @@ Sequence before any merge:
 
 Violation history: Sprint 2 (PRs #17-#27), Sprint 3 (PRs #33-#36). Branch protection on `develop` now enforces this at the GitHub level (Sprint 4).
 
+## Develop Commit Ban
+
+The `hooks/pre-commit` Check 5 refuses ALL direct commits to `develop`, `main`, and `master`.
+This applies to Ralph too. End-of-sprint history.md entries must use one of:
+1. **Short-lived branch + PR pattern** (recommended for Ralph's standalone logs). See PR #270
+   (Doc Sprint R history) for the canonical example: create `squad/<agent>-<sprint>-history`,
+   commit + push, open PR, merge.
+2. **Scribe drain fold-in** (when Ralph runs as part of an EOS sweep). Leave `history.md`
+   modified (not staged) and Scribe will fold it into her drain PR. See PR #272 (Sprint R
+   retro drain) for the canonical example.
+
+Do NOT attempt to bypass the hook with `--no-verify`.
+
 ## Agent Stall Detection
 
 Ralph monitors running agents for signs of stalling. A stall is when an agent exceeds its wall-clock budget without producing useful output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.squad/skills/squad-upgrade-hygiene/SKILL.md` -- reusable checklist for auditing future `squad upgrade` runs
 - `.squad/templates/{fact-checker-charter.md, loop.md, squad.agent.md.template}` -- new templates from 0.9.4
 - `hooks/pre-commit` now allows `.squad/templates/*.template` files (squad upgrade ships `squad.agent.md.template`)
+- `.squad/agents/ralph/charter.md` "Develop Commit Ban" section -- documents that Ralph (and all agents) cannot commit directly to `develop`/`main`/`master`; EOS history entries flow through short-lived branch+PR or Scribe drain process (closes #273)
+- CONTRIBUTING.md "Group Letter Assignment" section -- coordinator pre-assigns test group letters to prevent parallel-agent collisions; Sprint R example documented (closes #273)
+- CONTRIBUTING.md "CHANGELOG Conflict Strategy" section -- documents mechanical resolution for predictable [Unreleased] conflicts when multiple PRs land in one sprint: merge order, unique headers, union entries (closes #273)
 
 ## [0.8.0] - 2026-05-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,20 @@ Keep the summary under 72 characters. Add a body if the change needs more contex
 
 ---
 
+## CHANGELOG Conflict Strategy
+
+When multiple PRs land in a single sprint, `CHANGELOG.md` `[Unreleased]` is a predictable
+conflict zone (multiple PRs append to the same `### Added` / `### Changed` / `### Fixed`
+section). Resolution is mechanical, not semantic:
+1. Entries land in **merge order** (the later PR rebases on top of the earlier one's entry).
+2. Keep **unique section headers** (`### Added`, `### Changed`, `### Fixed`, `### Removed`).
+3. On conflict: **union both entries - keep ALL lines from both sides, no deduplication**.
+   `CHANGELOG.md` is an append-only log, not a deduped list. Both agents intended their entry.
+4. Add `CHANGELOG.md merge=union` to `.gitattributes` is NOT recommended here - manual review
+   catches accidentally inverted entries.
+
+---
+
 ## PowerShell 5.x Compatibility
 
 All `.ps1` scripts in this repo must run on **PowerShell 5.1** (the version shipped with Windows 10/11). PS 7+ runs on Linux Codespaces; PS 5.1 is what end users actually have.
@@ -231,6 +245,18 @@ git worktree remove /workspaces/dev-setup-56
 ```
 
 Or list all active worktrees with `git worktree list`.
+
+---
+
+## Group Letter Assignment (parallel test work)
+
+Behavioral tests in `tests/test_windows_setup.ps1` are organized by alphabetic groups
+(Group A, B, ..., V, W, X, Y, Z, AA, BB, ...). When 2+ parallel agents may extend this
+file in the same sprint, the **coordinator pre-assigns Group letters in each spawn prompt**
+to prevent collisions. Sprint R example: Chip #267 picked "Group X" independently while
+Goofy #268 also picked "Group X" - required a manual rename to Group Y during rebase.
+Going forward, the coordinator's spawn checklist includes Group letter assignment for any
+agent that may add tests to this file.
 
 ---
 


### PR DESCRIPTION
Closes #273. Implements three Sprint R retro action items:

1. **Ralph Develop Commit Ban** (.squad/agents/ralph/charter.md) - Documents that direct commits to develop/main/master are blocked by pre-commit hook; EOS history entries flow through short-lived branch+PR or Scribe drain process.

2. **CONTRIBUTING Group Letter Assignment SOP** - When multiple agents add tests to tests/test_windows_setup.ps1 in parallel, coordinator pre-assigns Group letters to prevent collisions (avoids Sprint R Group X collision).

3. **CONTRIBUTING CHANGELOG Conflict Strategy SOP** - Documents mechanical resolution for predictable [Unreleased] conflicts when multiple PRs land: merge order, unique headers, union entries.