### PR TITLE
chore(scripts/windows): apply -Encoding ASCII (#234)

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -343,3 +343,4 @@ Fixed three regressions introduced by PR #130:
 - Group letter coordination: This PR also created Group X, but collision with #267 Group X
   was resolved by merging #268 first and having #267 rebase to Group Y.
   Lesson: Coordinator should pre-assign group letters in spawn prompts.
+2026-05-16 -- #234 ASCII encoding hygiene

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,26 @@
 
 ## Decision Records
 
+## # Decision: Always use -Encoding ASCII for Set-Content/Add-Content/Out-File in Windows scripts
+
+**Issue:** #234
+**PR:** TBD
+**Agent:** Goofy (Cross-Platform)
+**Date:** 2026-05-16
+
+## Context
+
+PowerShell 5.1 defaults Set-Content/Add-Content to UTF-16LE BOM; PS 7 defaults to UTF-8 BOM.
+Both encodings break cross-tool compatibility (git, external editors, shell parsers).
+Profile and config files written by dev-setup must be readable by all tooling without BOM corruption.
+
+## Decision
+
+All Set-Content, Add-Content, and Out-File calls in Windows PowerShell scripts in this repo
+MUST include `-Encoding ASCII` unless the content is explicitly non-ASCII (in which case
+`-Encoding utf8NoBOM` is acceptable on PS7-only paths).
+ASCII is the safe default for all profile blocks and config snippets written by this repo.
+
 ## # Decision: CI PS 5.1 Validation Path
 
 **Issue:** #109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `scripts/windows/tools/profile.ps1` and `scripts/windows/uninstall.ps1`: added `-Encoding ASCII` to all `Set-Content` and `Add-Content` calls. Prevents encoding mismatch between PS 5.1 (UTF-16LE BOM default) and PS 7 (UTF-8 BOM default) (closes #234).
 - Documentation: README + CONTRIBUTING now document the automatic `core.hooksPath` setup performed by `setup.sh` and `setup.ps1`. Replaced stale "install hooks manually" instruction. Added branch-from-develop validation note per Sprint Q retro (closes #228).
 - Squad governance upgraded from 0.9.1 to 0.9.4 (dispatch mechanism, `CURRENT_DATETIME` requirement, `name` param in spawn prompts, default models bumped to `claude-sonnet-4.6` / `gpt-5.3-codex`, tier-based agent timeout policy)
 - `.github/workflows/squad-heartbeat.yml` removes noisy cron trigger; Ralph now fires on issue events only

--- a/scripts/windows/tools/profile.ps1
+++ b/scripts/windows/tools/profile.ps1
@@ -25,7 +25,7 @@ function Write-PowerShellProfile {
             $raw = Get-Content $profilePath -Raw
             # Strip the managed block (handles both LF and CRLF)
             $raw = $raw -replace "(?s)\r?\n$([regex]::Escape($beginMarker)).*?$([regex]::Escape($endMarker))\r?\n?", ''
-            Set-Content $profilePath $raw -NoNewline
+            Set-Content $profilePath $raw -NoNewline -Encoding ASCII
         }
     }
 
@@ -291,9 +291,9 @@ Set-Alias -Name cancel_tsdn -Value Invoke-CancelTimedShutdown -Force -Scope Glob
         # Always prepend a blank line so we don't concatenate onto any existing last line.
         try {
             if (Test-Path $profilePath) {
-                Add-Content -Path $profilePath -Value ""
+                Add-Content -Path $profilePath -Value "" -Encoding ASCII
             }
-            Add-Content -Path $profilePath -Value $profileContent
+            Add-Content -Path $profilePath -Value $profileContent -Encoding ASCII
         } catch {
             Write-Err "Failed to write profile to '$profilePath': $_"
             continue

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -97,7 +97,7 @@ function Remove-DevSetupProfileBlock {
         Remove-Item $ProfilePath -Force
         Write-Ok "Removed profile (was only dev-setup block): $ProfilePath"
     } else {
-        Set-Content $ProfilePath $cleaned -NoNewline
+        Set-Content $ProfilePath $cleaned -NoNewline -Encoding ASCII
         Write-Ok "Removed dev-setup block from $ProfilePath"
     }
 }

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1722,6 +1722,54 @@ if (-not (Get-Command sh -ErrorAction SilentlyContinue)) {
 }
 
 # ---------------------------------------------------------------------------
+# Group Z: Set-Content encoding hygiene (Issue #234)
+# ---------------------------------------------------------------------------
+
+Write-Host "`n========================================================" -ForegroundColor Cyan
+Write-Host " Group Z: Set-Content encoding hygiene (#234)" -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Test-Scenario "Z-1: profile.ps1 - every Set-Content call has -Encoding" {
+    $content = Get-Content (Join-Path $RepoRoot 'scripts\windows\tools\profile.ps1') -Raw
+    $matches = [regex]::Matches($content, 'Set-Content\b[^`\n]*')
+    foreach ($m in $matches) {
+        if ($m.Value -notmatch '-Encoding') {
+            throw "Set-Content without -Encoding found in profile.ps1: $($m.Value.Trim())"
+        }
+    }
+}
+
+Test-Scenario "Z-2: profile.ps1 - every Add-Content call has -Encoding" {
+    $content = Get-Content (Join-Path $RepoRoot 'scripts\windows\tools\profile.ps1') -Raw
+    $matches = [regex]::Matches($content, 'Add-Content\b[^`\n]*')
+    foreach ($m in $matches) {
+        if ($m.Value -notmatch '-Encoding') {
+            throw "Add-Content without -Encoding found in profile.ps1: $($m.Value.Trim())"
+        }
+    }
+}
+
+Test-Scenario "Z-3: uninstall.ps1 - every Set-Content call has -Encoding" {
+    $content = Get-Content (Join-Path $RepoRoot 'scripts\windows\uninstall.ps1') -Raw
+    $matches = [regex]::Matches($content, 'Set-Content\b[^`\n]*')
+    foreach ($m in $matches) {
+        if ($m.Value -notmatch '-Encoding') {
+            throw "Set-Content without -Encoding found in uninstall.ps1: $($m.Value.Trim())"
+        }
+    }
+}
+
+Test-Scenario "Z-4: uninstall.ps1 - every Out-File call has -Encoding (future-proof)" {
+    $content = Get-Content (Join-Path $RepoRoot 'scripts\windows\uninstall.ps1') -Raw
+    $matches = [regex]::Matches($content, 'Out-File\b[^`\n]*')
+    foreach ($m in $matches) {
+        if ($m.Value -notmatch '-Encoding') {
+            throw "Out-File without -Encoding found in uninstall.ps1: $($m.Value.Trim())"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #234.

## Changes

- \scripts/windows/tools/profile.ps1\: Added \-Encoding ASCII\ to \Set-Content\ (strip+re-inject path) and both \Add-Content\ calls (blank-line prepend + profile block write).
- \scripts/windows/uninstall.ps1\: Added \-Encoding ASCII\ to \Set-Content\ in \Remove-DevSetupProfileBlock\.
- \	ests/test_windows_setup.ps1\: Group Z (Z-1 through Z-4) - regex assertions that every \Set-Content\/\Add-Content\/\Out-File\ call in both target files has an explicit \-Encoding\ argument.
- \CHANGELOG.md\: Updated \[Unreleased] ### Changed\.
- \.squad/decisions.md\: Recorded decision to always use \-Encoding ASCII\ for write cmdlets in Windows PS scripts.

## Why

PowerShell 5.1 defaults to UTF-16LE BOM; PS 7 defaults to UTF-8 BOM. Both break cross-tool compatibility for profile files read by git, editors, and shell parsers. ASCII is the safe default for all plain-text content written by this repo.