### PR TITLE
refactor(scripts): finish logging consolidation in setup.sh + uninstall.sh (#223)

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -445,3 +445,4 @@ both platform branches get the package to maintain the cross-platform parity doc
 - 2026-05-16 Hygiene retro complete -- 4 action items shipped (pre-spawn-checklist skill + squad-history-check CI gate + PR template + 6 standing rules). See .squad/log/2026-05-16-hygiene-retro-complete.md.
 
 - **2026-05-16 -- Reviewed PR #244 (Mickey's retroactive tags + 0.8.0 cut).** Verdict: APPROVE (posted as comment since GitHub single-owner repos cannot self-approve; --admin merge used). CHANGELOG cut is clean (empty Unreleased, all entries under 0.8.0, no drops). Spot-checked 3/7 SHAs (0.1.0, 0.5.0, 0.7.0) -- all point at release-shaped merge commits matching Mickey's rationale table. All 7 tags and GitHub releases confirmed present. Commit uses Conventional Commits format with Copilot co-author trailer.
+2026-05-16 -- #223 logging consolidation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/workflows/squad-triage.yml` and `sync-squad-labels.yml` add `slugify()` for label names (bugfix)
 - Dotfile backup strategy: `.bak` files are now timestamped (`.bak.YYYYMMDD-HHMMSS`) on both Linux (`config/dotfiles/install.sh`) and Windows (`scripts/windows/tools/dotfiles.ps1`). Keeps last 5 backups by default (override with `DOTFILE_BACKUP_KEEP` env var); previous versions of dotfiles are no longer lost on re-run (closes #227).
 - `.gitattributes` now pins `*.ps1`, `*.psm1`, and `*.psd1` files to explicit CRLF line endings, eliminating platform divergence when `core.autocrlf` is enabled (closes #231).
+- `setup.sh` and `scripts/linux/uninstall.sh` now source `scripts/linux/lib/log.sh` instead of defining their own logging helpers. Local `log_*` / `ok` / `info` / `skip` definitions removed; all call sites updated to the canonical `log_ok` / `log_info` / `log_warn` / `log_error` names (closes #223).
 
 ### Fixed
 - `.github/workflows/e2e-install.yml` -- adds a final `summary` job that fails the workflow if any platform job fails, preventing silent green-dashboard regressions. Per-platform jobs still use `continue-on-error: true` so full matrix telemetry is preserved (closes #253).

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -11,15 +11,10 @@
 
 set -euo pipefail
 
-# ── Colour helpers ───────────────────────────────────────────────────────────
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-RESET='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ok()   { printf "${GREEN}[OK] %s${RESET}\n" "$*"; }
-info() { printf "${CYAN}[INFO] %s${RESET}\n" "$*"; }
-skip() { printf "${YELLOW}[SKIP] %s${RESET}\n" "$*"; }
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/lib/log.sh"
 
 # ── Restore dotfile .bak files ───────────────────────────────────────────────
 # Restores the newest timestamped backup (.bak.YYYYMMDD-HHMMSS).
@@ -33,16 +28,16 @@ restore_backup() {
   newest=$(ls -t "${target}.bak."* 2>/dev/null | head -n 1) || newest=''
   if [[ -n "$newest" ]]; then
     mv "$newest" "$target"
-    ok "Restored $target from $(basename "$newest")"
+    log_ok "Restored $target from $(basename "$newest")"
   elif [[ -f "${target}.bak" ]]; then
     mv "${target}.bak" "$target"
-    ok "Restored $target from ${target}.bak (legacy)"
+    log_ok "Restored $target from ${target}.bak (legacy)"
   else
-    skip "No backup found for $target"
+    log_warn "No backup found for $target"
   fi
 }
 
-printf '\n%sdev-setup uninstaller%s\n\n' "$CYAN" "$RESET"
+printf '\ndev-setup uninstaller\n\n'
 
 # Dotfiles that install.sh may have backed up
 DOTFILES=(
@@ -64,12 +59,12 @@ remove_managed_block() {
   local end_marker="# --- end dev-setup managed block ---"
 
   if [[ ! -f "$file" ]]; then
-    skip "$file does not exist"
+    log_warn "$file does not exist"
     return
   fi
 
   if ! grep -qF "$begin_marker" "$file"; then
-    skip "No dev-setup block in $file"
+    log_warn "No dev-setup block in $file"
     return
   fi
 
@@ -78,11 +73,11 @@ remove_managed_block() {
   # Clean up the temp file sed creates with -i
   rm -f "${file}.tmp"
 
-  ok "Removed dev-setup block from $file"
+  log_ok "Removed dev-setup block from $file"
 }
 
 remove_managed_block "$HOME/.zshrc"
 remove_managed_block "$HOME/.bashrc"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
-printf '\n%s[OK] Uninstalled. Tools (uv, nvm, gh, etc.) remain. Remove them manually if you wish.%s\n\n' "$GREEN" "$RESET"
+printf '\n'; log_ok "Uninstalled. Tools (uv, nvm, gh, etc.) remain. Remove them manually if you wish."; printf '\n'

--- a/setup.sh
+++ b/setup.sh
@@ -19,12 +19,8 @@ exec 2>&1  # Merge stderr into stdout for ordered output in piped/Devcontainer e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# ── Logging helpers ──────────────────────────────────────────────────────────
-
-log_info()  { printf '\033[0;34m[INFO]\033[0m  %s\n' "$*"; }
-log_ok()    { printf '\033[0;32m[OK]\033[0m    %s\n' "$*"; }
-log_warn()  { printf '\033[0;33m[WARN]\033[0m  %s\n' "$*"; }
-log_error() { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/scripts/linux/lib/log.sh"
 
 # ── OS Detection ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #223.

## What changed

- **setup.sh**: Removed the 4-line local log_info/log_ok/log_warn/log_error block (lines 22-27). Now sources \scripts/linux/lib/log.sh\ via \\/scripts/linux/lib/log.sh\. All call sites unchanged (names were already canonical).
- **\scripts/linux/uninstall.sh\**: Removed colour vars (\GREEN\, \YELLOW\, \CYAN\, \RESET\) and local \ok()\/\info()\/\skip()\ helpers. Added \SCRIPT_DIR\ definition (was absent) and sources \lib/log.sh\. All call sites updated: \ok\ -> \log_ok\, \skip\ -> \log_warn\, bare \printf\ for the summary line replaced with \log_ok\.

## Verification

- \shellcheck setup.sh scripts/linux/uninstall.sh\ -- clean (pre-commit + pre-push hooks confirmed)
- No local log function defined outside \lib/log.sh\ in either file
- \pipefail\ guard on \ls | head -n 1\ in \estore_backup()\ already present (from PR #269)

## Notes

- Tests (\	est_shared_logging.sh\, \	est_precommit_hygiene.sh\) require WSL/bash, unavailable on the build machine. CI E2E will be the gate.
- ASCII-only: all changes are ASCII. Pre-commit check passed.