### PR TITLE
docs(squad): add pwsh-lastexitcode skill (closes #288)

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -894,3 +894,38 @@ Reviewed PRs #243, #245, #246. Skipped #244 (self-authored).
   confirmed they work in practice -- Group letter SOP held through Z, AA, BB, CC, DD,
   T6-T11 reservations; CHANGELOG strategy held through 4 separate `[Unreleased]`
   conflict resolutions; Ralph develop-commit ban was honored throughout.
+## Sprint T -- pwsh-lastexitcode Skill Authored (2026-05-17, PR for #288)
+
+- **Scope:** Closes #288. Skill-only PR -- no script behavior changes.
+- **Branch:** `squad/288-pwsh-lastexitcode` (forked from `develop` @ `ce53853`,
+  immediately post-0.9.0).
+- **Output (3 files):**
+  1. `.squad/skills/pwsh-lastexitcode/SKILL.md` -- documents the
+     `0`-propagates-across-pwsh-`&`-boundary anti-pattern,
+     why `try/catch` and `Continue = 'Stop'` do **not** catch
+     native non-zero exits, the canonical `0 = 0` reset
+     (and the local-vs-global scope trap), a detection checklist, and a
+     full call-site audit of `scripts/windows/` + `.github/workflows/`.
+  2. `CONTRIBUTING.md` -- new "PowerShell Exit Code Discipline" section
+     directly after "Tool Version Pin Enforcement". Mirrors the
+     #282 structure: problem statement, canonical sites bullet list,
+     one-paragraph fix, link to skill, link to discovery PR #277.
+  3. `CHANGELOG.md` -- two entries under `[Unreleased]`/Added (skill +
+     CONTRIBUTING section).
+- **Audit findings:** 3 workflow `&` script-call boundaries (e2e-install.yml
+  lines 350, 432, 475); only line 475 had a known leak, fixed by PR #277.
+  Inside `scripts/windows/`, found 1 mitigated site (uninstall.ps1:117 +
+  reset at 125) and 5 unmitigated-but-currently-benign sites: setup.ps1:38
+  (`git rev-parse` outside a repo) and four `gh auth status` / `gh api`
+  calls in auth.ps1. Flagged for follow-up issue but **scope-locked** out of
+  this PR per Coordinator dispatch.
+- **Key design choice:** kept the SKILL.md "Known sites" table descriptive
+  rather than prescriptive -- the audit lists what's there and what's at
+  risk, but the actual hardening is deferred to a follow-up issue routed
+  to Goofy. This keeps the documentation PR atomic and reviewable.
+- **Decision note:** `.squad/decisions/inbox/mickey-pwsh-lastexitcode-decision.md`
+  (local-only, inbox is gitignored).
+- **Outcome:** #288 closed. Skill catalog now has tool-version-pin (#255 origin)
+  + pwsh-lastexitcode (#277 origin). Pattern established: every bug that
+  recurs across a class of similar sites gets a SKILL.md so the next agent
+  spots it in review instead of re-discovering it in CI.

--- a/.squad/skills/pwsh-lastexitcode/SKILL.md
+++ b/.squad/skills/pwsh-lastexitcode/SKILL.md
@@ -1,0 +1,231 @@
+# Skill: PowerShell Exit Code Discipline
+
+**Confidence:** high (confirmed by PR #277 post-mortem)
+**Owner:** Mickey (Lead)
+**Issue:** #288 (surfaced by #277)
+
+---
+
+## What
+
+PowerShell tracks the exit code of the most recent native command in the
+automatic variable `$LASTEXITCODE`. That value **persists across `&` script-call
+boundaries** -- when a script ends with a failed-but-expected native command,
+the caller (or the GitHub Actions `pwsh` step wrapper) sees the non-zero code
+and fails, even though the script logically succeeded.
+
+Every Windows script invoked via `& .\script.ps1` from a workflow `shell: pwsh`
+step must end with `$LASTEXITCODE == 0`, or reset it explicitly after any
+expected-failure native command.
+
+## Why: the anti-pattern
+
+```powershell
+# scripts/windows/uninstall.ps1
+& git config --unset-all core.hooksPath 2>&1 | Out-Null
+# $LASTEXITCODE == 5 when key was never set -- this is the expected case
+# script body ends here
+```
+
+Called from a workflow:
+
+```yaml
+- shell: pwsh
+  run: |
+    & .\scripts\windows\uninstall.ps1
+```
+
+The GitHub Actions `pwsh` wrapper inspects `$LASTEXITCODE` after the step body
+runs. It sees `5` and **fails the step** with no useful diagnostic -- the
+script printed `[SKIP] core.hooksPath was not set`, then exited "cleanly", and
+yet the step is red.
+
+This is the exact failure mode that bit PR #277. The fix was mechanical:
+`$global:LASTEXITCODE = 0` after the call.
+
+### Why `$ErrorActionPreference = 'Stop'` does not save you
+
+Native-command non-zero exits do **not** raise terminating errors in
+PowerShell, even under `Set-StrictMode -Version Latest` +
+`$ErrorActionPreference = 'Stop'`. `$LASTEXITCODE` is set silently. You must
+inspect and reset it manually for any command whose non-zero exit is part of
+its contract.
+
+### Why `try/catch` does not save you either
+
+`catch` blocks only fire on terminating PowerShell errors. Native binaries
+exiting non-zero produce no terminating error, so the `try` block completes,
+the `catch` is skipped, and `$LASTEXITCODE` leaks past the function/script
+boundary unchanged.
+
+## The canonical pattern
+
+### 1. Inspect, classify, reset
+
+```powershell
+& git config --unset-all core.hooksPath 2>&1 | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    Write-Ok "core.hooksPath unset"
+} elseif ($LASTEXITCODE -in @(1, 5)) {
+    Write-Skip "core.hooksPath was not set (nothing to unset)"
+} else {
+    Write-Warn "git config --unset-all exited $LASTEXITCODE (unexpected; proceeding)"
+}
+$global:LASTEXITCODE = 0
+```
+
+Three rules:
+
+1. **Inspect immediately.** Read `$LASTEXITCODE` on the next line after the
+   native call. Any intervening cmdlet (`Write-Host`, `Out-Null`, etc.) leaves
+   it intact -- but readability suffers if the inspection drifts.
+2. **Classify the exit codes you expect.** Document them inline. `git
+   config --unset-all` returns `5` for "key not present" and `1` for some
+   older git builds; treat both as the expected no-op.
+3. **Reset `$global:LASTEXITCODE = 0`** after the conditional. Local `$LASTEXITCODE
+   = 0` does NOT work -- `$LASTEXITCODE` is an automatic variable in the
+   global scope, so a local assignment shadows it without resetting the value
+   the parent shell will read.
+
+### 2. Reset at the script's last line if the body might end on a non-zero
+
+When a script's last meaningful native command can fail expectedly (e.g.,
+`& git rev-parse --git-dir` guarding "are we in a repo?"), add a trailing
+`$global:LASTEXITCODE = 0` immediately before the script's final newline.
+That guarantees the `&`-caller and the GH Actions pwsh wrapper see a clean
+boundary regardless of which control-flow branch ran.
+
+### 3. Swallow stderr only when the message is noise
+
+```powershell
+& git config core.hooksPath 2>$null
+```
+
+Use `2>$null` (or `2>&1 | Out-Null`) only when the stderr is a user-facing
+distraction (e.g., `fatal: not in a git directory`). Do **not** rely on
+stderr redirection to mask exit codes -- the exit code is still set.
+
+## Detection
+
+In code review, flag the following patterns:
+
+1. **Workflow `shell: pwsh` step calling a project script with `&`.**
+   ```yaml
+   - shell: pwsh
+     run: |
+       & .\scripts\windows\foo.ps1
+   ```
+   The called script must end with `$LASTEXITCODE == 0`. Verify the script's
+   last native call is either guaranteed-success or followed by an explicit
+   reset.
+
+2. **Inside any `.ps1` invoked from such a step**, search for expected-failure
+   native commands:
+   - `git config --unset` / `git config --unset-all` (exits 5 when key absent)
+   - `git config <key>` reading an unset key (exits 1)
+   - `git rev-parse` outside a repo (exits 128)
+   - `npm uninstall -g <pkg>` for an uninstalled package (exits 1)
+   - `winget uninstall <id>` for a missing package (exits non-zero)
+   - `gh api <path>` for a 404 resource (exits 1)
+   - `gh auth status` for the not-authed case (exits 1)
+
+   Each must be followed (eventually, before script exit) by `$global:LASTEXITCODE = 0`
+   on every code path where the non-zero exit was the expected outcome.
+
+3. **Use of `try/catch` to "guard" native commands.** A reviewer comment is
+   warranted: `catch` does not fire on native non-zero. The author probably
+   wants an `if ($LASTEXITCODE -ne 0)` check + explicit reset.
+
+## Known sites in this repo
+
+Audit performed against `develop` @ `ce53853` for issue #288.
+
+### Script-call boundaries (workflow -> script)
+
+| File:Line | Call | Risk | Mitigation status |
+|---|---|---|---|
+| `.github/workflows/e2e-install.yml:350` | `& .\setup.ps1` (first run) | Inherits `$LASTEXITCODE` from setup.ps1's last native call | Implicit OK in CI: `actions/checkout@v4` runs before, so `Install-GitHook`'s final native call (`git config core.hooksPath hooks`) exits 0. **No explicit reset.** |
+| `.github/workflows/e2e-install.yml:432` | `& .\setup.ps1` (idempotency second run) | Same as above | Same. |
+| `.github/workflows/e2e-install.yml:475` | `& .\scripts\windows\uninstall.ps1` | Was leaking `5` from `git config --unset-all` | **Fixed in PR #277** by `$global:LASTEXITCODE = 0` at `uninstall.ps1:125`. |
+
+### Expected-failure native commands inside `scripts/windows/`
+
+| File:Line | Command | Expected non-zero exit | Mitigation status |
+|---|---|---|---|
+| `scripts/windows/uninstall.ps1:117` | `& git config --unset-all core.hooksPath 2>&1 \| Out-Null` | `5` (key unset) or `1` (older git) | **Mitigated** at line 125: `$global:LASTEXITCODE = 0`. Canonical example for this skill. |
+| `scripts/windows/setup.ps1:38` | `& git rev-parse --git-dir 2>$null \| Out-Null` | `128` if not in a git repo | Read by `if ($LASTEXITCODE -eq 0)` on line 39, but `$LASTEXITCODE` is **not reset** on the warn branch. Benign in CI (always in a repo after checkout) but a latent leak for local users running setup outside a repo. **TODO** -- track via follow-up issue. |
+| `scripts/windows/auth.ps1:28` | `& gh auth status 2>&1 \| Out-String` | `1` when not authenticated | Read locally (line 29) but **not reset**. Followed by additional installers in `Main` that issue their own native calls, so the leak is masked in practice. **TODO** -- track via follow-up issue. |
+| `scripts/windows/auth.ps1:36` | `& gh api user --jq '.login' 2>&1 \| Out-String` | `1` on 404 / auth failure | Read locally (line 37) but **not reset**. Same containment as above. |
+| `scripts/windows/auth.ps1:73` | `& gh auth status 2>&1 \| Out-String` (post-login verify) | `1` if login failed | Read locally (line 74) but **not reset**. |
+| `scripts/windows/auth.ps1:81` | `& gh api user --jq '.login' 2>&1 \| Out-String` (post-login verify) | `1` on 404 / auth failure | Read locally (line 82) but **not reset**. |
+
+There are **no** `npm uninstall`, `winget uninstall`, or other listed
+expected-failure call sites currently in `scripts/windows/`. If those are
+added in the future, they must follow the canonical pattern above.
+
+### Follow-up TODOs (not in scope for #288)
+
+This is a documentation-only PR; the audit surfaced four latent leak sites
+that are benign in CI today but should be hardened defensively:
+
+- `scripts/windows/setup.ps1:38` -- add `$global:LASTEXITCODE = 0` in the
+  `Install-GitHook` "not in a git repo" warn branch.
+- `scripts/windows/auth.ps1` -- after each of the four `& gh ...` blocks,
+  reset `$global:LASTEXITCODE = 0` once the local conditional has read the
+  value.
+
+Both should be filed as a single follow-up issue (`scripts/windows: harden
+expected-failure call sites against $LASTEXITCODE leak`) and routed to Goofy.
+
+## Examples
+
+### From PR #277 -- the bug that triggered this skill
+
+Before (`scripts/windows/uninstall.ps1` pre-fix):
+
+```powershell
+# (no unset call -- core.hooksPath was leaking from install)
+```
+
+After (`scripts/windows/uninstall.ps1` lines 117-125):
+
+```powershell
+& git config --unset-all core.hooksPath 2>&1 | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    Write-Ok "core.hooksPath unset (git falls back to per-repo .git/hooks)"
+} elseif ($LASTEXITCODE -in @(1, 5)) {
+    Write-Skip "core.hooksPath was not set (nothing to unset)"
+} else {
+    Write-Warn "git config --unset-all exited $LASTEXITCODE (unexpected; proceeding)"
+}
+$global:LASTEXITCODE = 0
+```
+
+The trailing `$global:LASTEXITCODE = 0` is the load-bearing line: without
+it, the GH Actions `pwsh` wrapper sees exit `5` from the very common
+"hookspath was never set" path and fails the uninstall step.
+
+### Counter-example -- the trap to avoid
+
+```powershell
+# WRONG -- local assignment shadows but doesn't reset the global automatic.
+& git config --unset-all core.hooksPath 2>$null
+$LASTEXITCODE = 0   # creates a local; the global is still 5
+
+# Also WRONG -- catch never fires on native non-zero exit.
+try {
+    & git config --unset-all core.hooksPath
+} catch {
+    # this block is dead code for native command failures
+}
+```
+
+## References
+
+- Issue #288 -- this skill's origin
+- PR #277 -- the bug that surfaced the pattern (`fix(uninstall): unset
+  core.hooksPath`)
+- CONTRIBUTING.md section "PowerShell Exit Code Discipline"
+- `.squad/skills/tool-version-pin/SKILL.md` -- structural template
+- PowerShell docs: [`$LASTEXITCODE` automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables)
+- GitHub Actions docs: [`pwsh` shell wrapper exit semantics](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `.squad/skills/pwsh-lastexitcode/SKILL.md`: documents the `$LASTEXITCODE` propagation gotcha across pwsh `&` script-call boundaries; canonical fix is `$global:LASTEXITCODE = 0` after expected-failure commands (closes #288, surfaced by #277)
+- CONTRIBUTING.md "PowerShell Exit Code Discipline" section referencing the new skill
+
 ## [0.9.0] - 2026-05-17
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,3 +327,36 @@ Homebrew does not publish versioned formulae for tools like `gh`. On macOS, acce
 the latest brew version, compare against the pin, and log a WARN if they differ.
 macOS is a secondary target; version drift is tolerated with visibility.
 
+---
+
+## PowerShell Exit Code Discipline
+
+`$LASTEXITCODE` leaks across PowerShell `&` script-call boundaries. When a
+Windows script ends with an *expected-failure* native command (e.g.,
+`git config --unset-all <key>` exiting `5` because the key was never set), the
+caller -- including the GitHub Actions `pwsh` step wrapper -- sees the non-zero
+code and fails the step even though the script logically succeeded.
+
+### Canonical expected-failure sites
+
+- `git config --unset` / `--unset-all <key>` (exits `5` when key absent)
+- `git rev-parse --git-dir` outside a git repo (exits `128`)
+- `gh auth status` when not authenticated (exits `1`)
+- `gh api <path>` for a missing resource (exits `1` on 404)
+- `npm uninstall -g <pkg>` for an uninstalled package (exits `1`)
+- `winget uninstall <id>` for a missing package (non-zero)
+
+### Fix
+
+After every expected-failure native command, read `$LASTEXITCODE`, classify
+the cases you intend to swallow, then reset with **`$global:LASTEXITCODE = 0`**
+(the local `$LASTEXITCODE = 0` shadows but does not clear the automatic
+variable). Optionally pair with `2>$null` or `2>&1 | Out-Null` to silence
+stderr noise. The trailing reset is load-bearing for any script invoked from
+a workflow `shell: pwsh` step via `& .\path\to\script.ps1` -- without it the
+GH Actions wrapper fails the step on the next inspection of `$LASTEXITCODE`.
+
+See `.squad/skills/pwsh-lastexitcode/SKILL.md` for the full pattern, a
+detection checklist, and the call-site audit. The discovery PR is #277
+(`fix(uninstall): unset core.hooksPath`); the skill closes #288.
+


### PR DESCRIPTION
Closes #288.

## What changed

Documentation-only PR. Authors the `pwsh-lastexitcode` skill capturing the
`\0`-leaks-across-pwsh-`&`-script-boundary anti-pattern that
bit PR #277 (the `core.hooksPath` uninstall fix), plus a CONTRIBUTING.md
section linking to it. No script behavior changes.

### Files (4)

- `.squad/skills/pwsh-lastexitcode/SKILL.md` (new) -- mirrors the structure
  of `.squad/skills/tool-version-pin/SKILL.md` (added in #282): What / Why
  the anti-pattern / Canonical pattern / Detection / Known sites in this
  repo / Examples / Counter-examples / References.
- `CONTRIBUTING.md` -- new "PowerShell Exit Code Discipline" section
  inserted directly after "Tool Version Pin Enforcement".
- `CHANGELOG.md` -- two entries under `[Unreleased]`/Added.
- `.squad/agents/mickey/history.md` -- Sprint T entry per Coordinator
  dispatch SOP.

## Audit findings

Searched `scripts/windows/` and `.github/workflows/` per dispatch.

### Workflow `&` script-call boundaries

| Site | Status |
|---|---|
| `.github/workflows/e2e-install.yml:350` `& .\setup.ps1` | Implicit OK (CI checkout puts us in a git repo; final native call exits 0) |
| `.github/workflows/e2e-install.yml:432` `& .\setup.ps1` (idempotency) | Same |
| `.github/workflows/e2e-install.yml:475` `& .\scripts\windows\uninstall.ps1` | **Fixed in PR #277** via `\0 = 0` reset |

### Expected-failure native commands

| Site | Mitigation |
|---|---|
| `scripts/windows/uninstall.ps1:117` `& git config --unset-all core.hooksPath` | **Mitigated** at line 125 (canonical example) |
| `scripts/windows/setup.ps1:38` `& git rev-parse --git-dir` | Not reset on the "not in a repo" warn branch; benign in CI; **TODO** follow-up |
| `scripts/windows/auth.ps1:28,36,73,81` (four `gh auth status`/`gh api user`) | Read locally but not reset; benign in current `Main` ordering; **TODO** follow-up |

No `npm uninstall`, `winget uninstall`, or `gh api` 404-path call sites
exist in `scripts/windows/` beyond the four above. The audit is fully
captured in the "Known sites in this repo" section of the SKILL doc with
file:line citations.

## Follow-up issue (not in scope)

The 5 unmitigated-but-benign sites should be hardened in a separate PR.
Suggested title: `scripts/windows: harden expected-failure call sites
against \0 leak`. Suggested owner: Goofy. Labels: `area:windows`,
`type:chore`, `priority:p2`, `squad:goofy`, `go:yes`, `release:backlog`.
I'll hand this to Coordinator on PR handoff.

## Tests

None. Docs-only PR. The skill itself is the artifact; no behavioral change to test.

## Hygiene

- Sprint T entry appended to `.squad/agents/mickey/history.md`.
- Decision note at `.squad/decisions/inbox/mickey-pwsh-lastexitcode-decision.md`
  (local-only; inbox is gitignored).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
