### PR TITLE
docs(squad): codify Doc worktree pattern + Jiminy auto-dispatch SOP (closes #289, #290)

### DIFF
--- a/.squad/agents/doc/charter.md
+++ b/.squad/agents/doc/charter.md
@@ -99,6 +99,32 @@ Rationale: Verification-heavy work -- tracing claims, running counter-hypotheses
 - Always branch from `develop` before any commit: `git checkout -b squad/{slug}`
 - Never commit directly to `develop` or `main`
 - Standard squad branch naming: `squad/{slug}`
+- **Sprint-scoped history.md branch:** All `.squad/agents/doc/history.md` edits commit + push to `squad/doc-history-sprint-<N>` from the `..\dev-setup-doc` worktree (see "Where Doc writes history.md" below). NEVER commit history.md edits to a per-fact-check squad branch -- one fold PR per sprint, not one per fact-check.
+
+## Where Doc writes history.md
+
+> Source: `.squad/decisions/doc-and-jiminy-automation.md` (closes #289).
+
+Doc runs as a `general-purpose` subagent and inherits the Coordinator's CWD by default. Without an explicit CWD override, every `.squad/agents/doc/history.md` write lands as `M` on `develop` in the Coordinator's primary worktree, which is illegal (no agent commits directly to develop). The fix is a per-sprint dedicated worktree.
+
+**Sprint kickoff (one-time per sprint, owned by Coordinator):**
+
+```
+git worktree add ../dev-setup-doc -b squad/doc-history-sprint-<N>
+```
+
+**Every Doc spawn prompt (owned by Coordinator):** MUST begin with an explicit CWD directive pointing at `..\dev-setup-doc`. Doc's first action in every fact-check is to `Set-Location` (or `cd`) into that worktree before reading any files.
+
+**Every fact-check tail (owned by Doc):**
+
+1. Append the verification entry to `.squad/agents/doc/history.md` from inside the doc worktree.
+2. `git add .squad/agents/doc/history.md`
+3. `git commit -m "docs(doc): fact-check log for <artifact>"` (Conventional Commits; the commit-msg hook enforces format)
+4. `git push origin squad/doc-history-sprint-<N>`
+
+**Sprint wrap (owned by Coordinator, see `ceremonies.md` -> Sprint Wrap):** Open ONE fold PR from `squad/doc-history-sprint-<N>` into `develop`. Mickey reviews + approves. One fold PR per sprint, not per fact-check.
+
+**If the kickoff worktree is missing:** Doc reports the gap and stops. The Coordinator MUST create the worktree before re-spawning. Falling back to "write to develop in the primary worktree" is the Sprint S anti-pattern and is no longer permitted.
 
 ## Collaboration
 

--- a/.squad/agents/jiminy/charter.md
+++ b/.squad/agents/jiminy/charter.md
@@ -54,9 +54,11 @@ What Jiminy checks, by lane:
 | When | What Jiminy does |
 |------|------------------|
 | **Before coordinator returns control to user** | Quick sweep (under 10s). Clean -> one-line `Jiminy clear`. Dirty -> list issues + offer to fix. |
-| **After multi-agent batches (3+ spawns)** | Verify each agent's AFTER-work block was honored. Flag any agent who skipped history append or decisions inbox. |
-| **Session-end (user signals done)** | Full sweep + stale branch cleanup gate. BLOCKS session close on dirty state. |
+| **After multi-agent batches (3+ spawns)** | Verify each agent's AFTER-work block was honored. Flag any agent who skipped history append or decisions inbox. Auto-dispatch is enforced at `.squad/templates/loop.md` -> Gate 1 (post-batch audit) and reinforced in `.squad/templates/ceremonies.md` -> Sprint Wrap. |
+| **Session-end (user signals done)** | Full sweep + stale branch cleanup gate. BLOCKS session close on dirty state. Enforced at `.squad/templates/loop.md` -> Gate 2 (session-end audit) and `ceremonies.md` -> Sprint Wrap step 1. |
 | **Manual** | "Jiminy, check" / "Jiminy, audit" -> on-demand full sweep |
+
+> The post-batch and session-end triggers are codified at three independent surfaces (this charter, `loop.md`, `ceremonies.md`). If the Coordinator forgets one surface, the other two should catch the miss. See `.squad/decisions/doc-and-jiminy-automation.md` (closes #290) for rationale.
 
 ## How Jiminy reports
 

--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -929,3 +929,75 @@ Reviewed PRs #243, #245, #246. Skipped #244 (self-authored).
   + pwsh-lastexitcode (#277 origin). Pattern established: every bug that
   recurs across a class of similar sites gets a SKILL.md so the next agent
   spots it in review instead of re-discovering it in CI.
+
+
+## 2026-05-19 -- Sprint T design pass: PR for #289 + #290 (Doc worktree pattern + Jiminy auto-dispatch)
+
+**Issues closed:** #289 (Doc subagent worktree pattern), #290 (auto-enforce Jiminy post-batch dispatch).
+**PR:** opened as a single PR per Coordinator's dispatch reasoning -- both issues
+touch the same surface (`.squad/templates/loop.md`, `.squad/templates/ceremonies.md`,
+and the Doc/Jiminy charters), and both are about operational SOPs that are
+currently manual and should be either automated or enforced by checklist.
+Resolving them in a single design pass avoids template churn and ensures
+the chosen patterns are coherent.
+
+**Rationale for ONE PR (not two):**
+- Same files modified. Splitting would create artificial seams in `loop.md`
+  and `ceremonies.md` where the two SOPs share a "Squad Operational Gates"
+  section.
+- The decision document is a single coherent record (Options A-D for Doc,
+  Options A-D for Jiminy, both Consequences sections). Splitting forces
+  duplicated context.
+- Sprint T verification for both issues happens at the same dispatch
+  trigger (first multi-agent batch of Sprint T), so the AC checklists are
+  intertwined.
+
+**Decisions:**
+- **#289 -> Option B (dedicated worktree).** `..\dev-setup-doc` worktree on
+  `squad/doc-history-sprint-<N>` branch, created at sprint kickoff. Doc's
+  spawn prompt MUST begin with an explicit CWD directive. ONE fold PR per
+  sprint at sprint wrap (down from 2 in Sprint S: #281 + #283). Option A
+  rejected because Doc cannot safely switch branches in the primary worktree
+  without disrupting sibling agents.
+- **#290 -> Option A (loop.md + ceremonies.md checklist).** Two-source
+  enforcement at zero infrastructure cost. Charter `Triggers` table already
+  named the moments; the amendment is to make it cross-reference the new
+  template surfaces so the SOP is loud at three surfaces instead of one.
+  Options B (GH Action) + C (pre-push hook) + D (runtime reminder) rejected
+  per the issue's own analysis.
+
+**Files modified (8):**
+1. `.squad/decisions/doc-and-jiminy-automation.md` (new) -- canonical decision record.
+2. `.squad/templates/loop.md` -- "Squad Operational Gates" section (3 gates).
+3. `.squad/templates/ceremonies.md` -- `Sprint Kickoff` + `Sprint Wrap` ceremonies.
+4. `.squad/agents/doc/charter.md` -- "Where Doc writes history.md" section + amended `Git Rules`.
+5. `.squad/agents/jiminy/charter.md` -- `Triggers` table cross-references new templates.
+6. `CONTRIBUTING.md` -- "Squad Operational Gates (Coordinator dispatch)" section.
+7. `CHANGELOG.md` -- `[Unreleased]` `### Changed` entry.
+8. `.squad/agents/mickey/history.md` -- this entry.
+
+**Skill extraction candidate:** the workflow of "amend three template surfaces
+in coordination + write decision record + cross-link" is now a repeatable
+pattern (Jiminy dispatch SOP from #280 followed the same shape, and #289/#290
+follow it again). Suggest a future `.squad/skills/squad-template-amendment/SKILL.md`
+that captures: which surfaces to amend together, how to cross-link via the
+decision doc, and the "three-surface enforcement" check. Filing as a separate
+follow-up rather than authoring inline -- separate scope.
+
+**Test changes:** none. Considered a `tests/test_squad_sops.sh` grep test
+verifying SOP phrase presence in the templates, rejected because the SOPs
+are purely human-facing (Coordinator behavior, not script behavior) and
+phrase-pinning tests turn template edits into test churn. The triple-surface
+enforcement IS the audit signal. Rationale documented in the decision doc.
+
+**Sprint T verification (pre-conditions for Coordinator):**
+1. `git worktree list` should show `..\dev-setup-doc` on
+   `squad/doc-history-sprint-T` before the first Doc spawn. If absent,
+   create it.
+2. First >= 3-agent batch of Sprint T MUST end with a Jiminy run before
+   results return to user.
+3. Sprint T wrap MUST open one fold PR (or zero if Doc never ran).
+
+**Hygiene tail:** decision record IS the decision (no separate
+`decisions/inbox/` drop). History entry done. No further Scribe action
+needed for this design-pass PR until merge.

--- a/.squad/decisions/doc-and-jiminy-automation.md
+++ b/.squad/decisions/doc-and-jiminy-automation.md
@@ -1,0 +1,133 @@
+# Decision: Doc subagent worktree pattern + Jiminy auto-dispatch SOP
+
+- **Date:** 2026-05-19
+- **Status:** Accepted
+- **Decided-by:** Mickey (Squad Lead)
+- **Closes:** #289, #290
+- **Source:** Sprint S retro (#284); follow-on to PR #280 (Jiminy charter dispatch SOP) and PRs #281/#283 (Doc fact-check fold PRs).
+
+---
+
+## Context
+
+Two operational SOPs surfaced as fragile during Sprint S, and both are about *Coordinator behavior at dispatch time* rather than agent code. They share the same surface area (`.squad/templates/loop.md`, `.squad/templates/ceremonies.md`, and the Doc/Jiminy charters), so they are resolved in a single design pass to avoid template churn and keep the new patterns coherent.
+
+**#289 (Doc fold-PR overhead):** Doc (Fact Checker) is spawned as a `general-purpose` subagent in the Coordinator's primary worktree. Every time Doc appends to `.squad/agents/doc/history.md`, the edit lands as `M` on `develop` in the primary worktree. Because no agent (including the Coordinator) may commit directly to `develop`, the only safe way to land those edits is a short-lived "fold" PR. Sprint S produced two of these (PR #281 for the 6-PR batch fact-check, PR #283 for the PR #282 single-PR fact-check). The cost compounds: each fold is review overhead + merge ceremony + risk that the next agent dispatched from the primary worktree stages the dirty file accidentally.
+
+**#290 (Manual Jiminy invocation):** PR #280 codified the Jiminy dispatch SOP ("Coordinator MUST invoke Jiminy after every 3+ agent batch and at session-end"), but the SOP is enforced by Coordinator instruction-following alone. Sprint S already produced one regression: the Coordinator forgot the post-batch dispatch after the first 3-agent batch, which is precisely why the rogue `bradygaster-squad-sdk-0.9.4.tgz` artifact survived long enough to require PR #280 in the first place. Manual SOPs decay; we need a checklist-driven gate that two independent template surfaces reinforce.
+
+---
+
+## Options considered
+
+### Doc worktree pattern (#289)
+
+| Option | Description | Trade-offs |
+|--------|-------------|------------|
+| **A. Pre-created sprint branch** | At sprint kickoff, create `squad/doc-history-<sprint>`. Doc dispatches with explicit instructions to commit + push to that branch only. | Cheap to set up, but Doc still runs in the Coordinator's primary worktree CWD. Switching branches mid-session corrupts any sibling agent that thinks it is on `develop`. Forces git plumbing gymnastics (`update-ref`, detached HEAD writes) that are brittle. |
+| **B. Dedicated worktree (chosen)** | At sprint kickoff, `git worktree add ../dev-setup-doc -b squad/doc-history-sprint-<N>`. Doc's spawn prompt prefixes a `Set-Location` to that worktree. All Doc writes land there. One fold PR at sprint end. | One additional worktree on disk per active sprint. Coordinator must remember to create it at kickoff (mitigated by the new ceremony checklist). Cleanly isolates Doc's `M` edits from the primary worktree's index. Matches the existing "Parallel Agent Work" pattern in CONTRIBUTING.md. |
+| **C. Inline fact-checks (no history.md)** | Amend Doc charter so fact-check reports are written only to PR bodies / comments, never to `.squad/agents/doc/history.md`. | Eliminates the fold-PR problem entirely but loses cross-sprint searchability. Doc's history.md is one of his highest-value artifacts: it captures recurring fact-check patterns (e.g., "`set -euo pipefail` + bare glob expansion"), and we keep referring back to it in subsequent sprints. Permanently throwing that away to dodge a fold-PR is the wrong trade. |
+| **D. Coordinator manual fold (status quo)** | Keep doing exactly what Sprint S did. | Two fold PRs per sprint, growing with batch count. Already proven fragile. Rejected. |
+
+### Jiminy dispatch automation (#290)
+
+| Option | Description | Trade-offs |
+|--------|-------------|------------|
+| **A. Loop.md + ceremonies.md checklist (chosen)** | Extend `.squad/templates/loop.md` with a "Squad Operational Gates" section that the Coordinator consults on every dispatch tick. Extend `.squad/templates/ceremonies.md` with explicit sprint-kickoff + sprint-wrap ceremonies referencing those gates. Two-source enforcement. | Zero infrastructure cost. Relies on Coordinator instruction-following, but the cost of forgetting is now visible at TWO checklist surfaces, not zero. Cheap to evolve as we learn. |
+| **B. GitHub Action** | Workflow that triggers on develop changes and checks for Jiminy commits. | Rejected by the issue author: GH only sees pushed state; uncommitted-by-design squad activity is invisible to Actions. Not viable. |
+| **C. Local pre-push hook** | Extend `hooks/pre-push` to refuse pushes from `squad/*` branches if recent `develop` commits include 3+ squad-authored merges without a Jiminy audit commit. | Heavy and brittle: requires the hook to inspect commit authorship + recency + audit-log presence; would block legitimate work when the Coordinator chooses to defer the audit to session-end (already an allowed pattern). False-positive risk too high. |
+| **D. Coordinator runtime reminder** | Out-of-repo system reminder ("you have N agents dispatched, last Jiminy run was at T"). | Requires runtime support outside the repo. Not portable across Coordinator implementations. Out of scope for a docs PR. |
+
+---
+
+## Decision
+
+**Doc (#289): Option B - Dedicated worktree at `..\dev-setup-doc` with a per-sprint branch.**
+
+At each sprint kickoff, the Coordinator creates one Doc worktree:
+
+```bash
+git worktree add ../dev-setup-doc -b squad/doc-history-sprint-<N>
+```
+
+Every Doc spawn prompt MUST begin with an explicit CWD directive pointing the agent at that worktree. Doc commits + pushes after every fact-check. At sprint wrap, the Coordinator opens ONE fold PR from `squad/doc-history-sprint-<N>` into `develop`. This collapses N fold-PRs per sprint into exactly one and eliminates the "dirty file on develop in the primary worktree" failure mode entirely.
+
+**Jiminy (#290): Option A - Loop.md + ceremonies.md two-source checklist.**
+
+Codify the existing PR #280 SOP at two checklist surfaces:
+
+1. `.squad/templates/loop.md` gains a "Squad Operational Gates" section that lists the post-batch and session-end Jiminy triggers with their exact conditions ("after >= 3 spawns in the same Coordinator turn" and "before returning final control to the user at session-end").
+2. `.squad/templates/ceremonies.md` gains explicit `Sprint Kickoff` and `Sprint Wrap` ceremony entries that reference those gates (kickoff = create Doc worktree + remind about Jiminy gate; wrap = Jiminy session-end audit + fold Doc PR).
+
+The Jiminy charter's existing `Triggers` table already names these moments. The amendment is to make the table point at the new checklist surfaces so the SOP is reinforced at three locations (charter, loop, ceremonies) instead of one.
+
+---
+
+## Consequences
+
+**Positive**
+
+- Sprint S's dual fold-PR pattern (#281 + #283) collapses to a single fold-PR per sprint.
+- Doc's `history.md` edits never appear as `M` in the primary worktree's index, removing the "sibling agent stages the dirty file" failure mode.
+- Jiminy auto-dispatch is now reinforced at three independent surfaces (charter `Triggers` table + loop.md gates + ceremonies.md kickoff/wrap), making "Coordinator forgot to invoke Jiminy" a multi-surface miss rather than a single-line miss.
+- Sprint kickoff and sprint wrap are now first-class ceremonies in `ceremonies.md`. Previously they were implicit.
+
+**Negative / cost**
+
+- Coordinator must remember to `git worktree add` at sprint kickoff. Mitigated by the new `Sprint Kickoff` ceremony checklist. If the kickoff step is skipped, Doc falls back to the Option D path (write to primary worktree, fold via PR), which is no worse than current.
+- One additional on-disk worktree per active sprint (`..\dev-setup-doc`). Disk cost is negligible (same `.git` object store).
+- Sprint T is the first sprint to run under this pattern. Coordinator MUST verify the worktree exists before the first Doc spawn; if missed, the next Jiminy audit will flag the missed kickoff step.
+
+**Migration cost**
+
+- Existing Sprint S Doc fold PRs (#281, #283) stay merged as-is. No retroactive cleanup.
+- No agent code changes. No CI changes. No hook changes.
+- Charter diffs are surgical: Doc gets a new "Where Doc writes history.md" section; Jiminy's `Triggers` table gains pointer text to the new templates. No deletions.
+
+**What existing docs change**
+
+- `.squad/templates/loop.md` - new "Squad Operational Gates" section appended.
+- `.squad/templates/ceremonies.md` - two new ceremonies (`Sprint Kickoff`, `Sprint Wrap`).
+- `.squad/agents/doc/charter.md` - new "Where Doc writes history.md" section + amended `Git Rules`.
+- `.squad/agents/jiminy/charter.md` - `Triggers` table cross-references the new templates.
+- `CONTRIBUTING.md` - new "Squad Operational Gates (Coordinator dispatch)" section so human contributors see the pattern.
+- `CHANGELOG.md` `[Unreleased]` - one `### Changed` entry covering both issues.
+
+---
+
+## Implementation
+
+Files modified in this PR (with one-line description each):
+
+- `.squad/decisions/doc-and-jiminy-automation.md` - this file; canonical decision record.
+- `.squad/templates/loop.md` - appended "Squad Operational Gates" section with Jiminy post-batch + session-end triggers and Doc worktree pre-spawn check.
+- `.squad/templates/ceremonies.md` - added `Sprint Kickoff` (create Doc worktree + remind Jiminy gate) and `Sprint Wrap` (Jiminy session-end audit + fold Doc PR) ceremonies.
+- `.squad/agents/doc/charter.md` - added "Where Doc writes history.md" section; amended `Git Rules` to point at `squad/doc-history-sprint-<N>` and the `..\dev-setup-doc` worktree.
+- `.squad/agents/jiminy/charter.md` - `Triggers` table cross-references `loop.md` gates and `ceremonies.md` kickoff/wrap.
+- `CONTRIBUTING.md` - new "Squad Operational Gates (Coordinator dispatch)" section.
+- `CHANGELOG.md` - `[Unreleased]` entry under `### Changed`.
+- `.squad/agents/mickey/history.md` - Sprint T design-pass entry capturing the rationale for combining #289 + #290 into one PR.
+
+---
+
+## Explicitly NOT in scope (follow-up issues if needed)
+
+- **No Coordinator code changes.** This PR is documentation + templates only. If a future iteration wants to encode the gates as a runtime check (e.g., a `squad pre-dispatch` hook), file a separate issue.
+- **No static-source test.** Considered adding a `tests/test_squad_sops.sh` grep test that verifies the SOP phrases live in the templates. Rejected: the SOPs are purely human-facing (Coordinator behavior, not script behavior), and phrase-pinning tests turn template edits into test churn. The triple-surface enforcement (charter + loop + ceremonies) is itself the audit signal.
+- **No retroactive history rewrite** for Sprint S Doc fold PRs (#281, #283). They merged correctly under the old SOP and stay as-is.
+
+---
+
+## Sprint T verification plan
+
+The acceptance criteria for both issues call for "Sprint T verified" outcomes. The Coordinator should remember the following pre-conditions when dispatching the first multi-agent batch of Sprint T:
+
+1. **Before first Doc spawn:** `git worktree list` should show `..\dev-setup-doc` on branch `squad/doc-history-sprint-T`. If absent, create it: `git worktree add ../dev-setup-doc -b squad/doc-history-sprint-T`.
+2. **First multi-agent batch (>= 3 spawns):** Jiminy is invoked as the final step of the batch, BEFORE the Coordinator returns results to the user. Jiminy reports `Jiminy clear` or a fix-offer.
+3. **Sprint wrap:** Coordinator opens one fold PR from `squad/doc-history-sprint-T` into `develop` (Doc-authored, Mickey reviews). If Sprint T produced zero Doc spawns, no fold PR is needed and the worktree can be removed at session-end.
+
+Verification artifacts to capture in the Sprint T retro:
+
+- Count of Doc fold PRs (target: <= 1).
+- Whether Jiminy was auto-dispatched at every >= 3-agent batch (target: 100%).
+- Whether the kickoff `git worktree add` happened (target: yes; if no, Coordinator self-flags as missed step).

--- a/.squad/templates/ceremonies.md
+++ b/.squad/templates/ceremonies.md
@@ -67,3 +67,73 @@ At round start, call Test-RetroOverdue (see skill retro-enforcement). If overdue
 
 **Why GitHub Issues, not markdown:**
 Production data: 0% completion across 6 retros using markdown checklists, 100% after switching to GitHub Issues.
+
+---
+
+## Sprint Kickoff
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | manual + auto |
+| **When** | before first agent dispatch of a new sprint |
+| **Condition** | start of a new sprint (Coordinator first turn after a sprint wrap, OR `go:yes` labels appear on a fresh batch of issues) |
+| **Facilitator** | coordinator |
+| **Participants** | coordinator (with Mickey if scope changes are needed) |
+| **Time budget** | quick |
+| **Enabled** | yes |
+
+**Source:** `.squad/decisions/doc-and-jiminy-automation.md` (closes #289).
+
+**Agenda:**
+
+1. **Create Doc worktree for the sprint.** From the primary repo root:
+   ```
+   git worktree add ../dev-setup-doc -b squad/doc-history-sprint-<N>
+   ```
+   Verify with `git worktree list`. If the branch already exists from a prior sprint, replace `-b squad/doc-history-sprint-<N>` with the current sprint's branch name (do NOT reuse a prior sprint's branch; one branch per sprint keeps fold-PRs sprint-scoped).
+2. **Confirm Squad Operational Gates are loaded.** Skim `.squad/templates/loop.md` -> "Squad Operational Gates" section. Three gates: Jiminy post-batch, Jiminy session-end, Doc worktree pre-spawn.
+3. **Triage `go:yes` issues** through Mickey if not already done.
+4. **Sprint goal recorded** in coordinator notes / session opening.
+
+**Outputs:**
+
+- A `..\dev-setup-doc` worktree on `squad/doc-history-sprint-<N>`.
+- Mental load checked: Coordinator has the three gate trigger conditions in working memory.
+
+---
+
+## Sprint Wrap
+
+| Field | Value |
+|-------|-------|
+| **Trigger** | manual + auto |
+| **When** | last turn of a sprint, before session close |
+| **Condition** | sprint goal met OR work queue drained OR user signals session-end |
+| **Facilitator** | coordinator |
+| **Participants** | Jiminy, Ralph, Mickey, Scribe, Doc (if any fact-check edits accumulated) |
+| **Time budget** | focused |
+| **Enabled** | yes |
+
+**Source:** `.squad/decisions/doc-and-jiminy-automation.md` (closes #289, #290).
+
+**Agenda:**
+
+1. **Jiminy session-end audit.** Spawn Jiminy with the full sweep prompt. Jiminy BLOCKS session close on dirty state. Do not proceed until `Jiminy clear` or all dirty items are resolved.
+2. **Fold Doc history (if Doc ran this sprint).** From the Doc worktree (`..\dev-setup-doc`):
+   - Confirm all Doc commits are pushed: `git status` clean, `git log origin/squad/doc-history-sprint-<N>..HEAD` empty.
+   - Open ONE fold PR: `gh pr create -B develop -t "docs(doc): fold sprint-<N> fact-check history" -b "Closes the sprint's Doc fact-check log. Single fold-PR per the doc-worktree SOP (.squad/decisions/doc-and-jiminy-automation.md)."`
+   - Mickey reviews + approves (pure history.md edits, fast). Merge with `--admin` if self-approval blocks.
+3. **Ralph end-of-session cleanup.** Spawn Ralph to delete stale remote `squad/*` branches that have already been merged.
+4. **Scribe drain.** If `.squad/decisions/inbox/` is non-empty, spawn Scribe to fold to canonical locations.
+5. **Retro action items.** Capture any SOP regressions (e.g., "missed kickoff gate", "Jiminy not auto-fired on batch N") as GitHub Issues labeled `retro-action` per the Retrospective ceremony.
+
+**Outputs:**
+
+- `Jiminy clear` at session end.
+- At most ONE fold PR for Doc's sprint history (target: 1 if Doc ran, 0 if not). Sprint S had 2; the new SOP targets 1.
+- Stale branches deleted.
+- Decisions inbox drained.
+
+**Why this matters:**
+
+Before this ceremony existed, Sprint S leaked the `bradygaster-squad-sdk-0.9.4.tgz` artifact (caught by Earl manually) and required two fold PRs for Doc (#281, #283). Both failures trace to "no checklist surface at session-end". Sprint Wrap exists so those misses are visible at the moment they happen, not three days later.

--- a/.squad/templates/loop.md
+++ b/.squad/templates/loop.md
@@ -44,3 +44,58 @@ Example: "Be concise. Use bullet points. Flag blockers clearly."
 - **Set boundaries.** Tell the squad what NOT to do (e.g., "Don't send messages to anyone but me").
 - **Start small.** Begin with one task per cycle, then expand.
 - **Use frontmatter.** `interval` controls how often the loop runs. `timeout` caps each cycle.
+
+---
+
+## Squad Operational Gates (Coordinator dispatch)
+
+> These gates are NOT about the `squad loop` periodic activity above. They are the
+> Coordinator's spawn-lifecycle SOPs that fire on EVERY dispatch turn. Read once,
+> reinforce at sprint kickoff (see `ceremonies.md`).
+>
+> Source: `.squad/decisions/doc-and-jiminy-automation.md` (closes #289, #290).
+
+### Gate 1 -- Jiminy post-batch audit (closes #290)
+
+**Trigger condition:** the Coordinator dispatched 3 or more agents in a single turn (counted as `general-purpose` or named-agent spawns, NOT counting Scribe which is silent/background by design).
+
+**Action required, BEFORE the Coordinator returns results to the user:**
+
+1. Spawn Jiminy with the standard audit prompt.
+2. Wait for `Jiminy clear` or a dirty report.
+3. If dirty: route the fix per Jiminy's `Auto-fix scope` (charter section). Re-run Jiminy after fixes.
+4. Only then return final results to the user.
+
+**Why two-surface enforcement:** this gate is also documented in `Sprint Wrap` ceremony and Jiminy charter `Triggers` table. If the Coordinator forgets at one surface, the other two should catch it before session close.
+
+### Gate 2 -- Jiminy session-end audit
+
+**Trigger condition:** the user signals session-end (explicit "done", "wrap up", session-close intent, OR the work queue is empty after a full sprint).
+
+**Action required:**
+
+1. Spawn Jiminy with the full sweep prompt.
+2. Jiminy BLOCKS session close on dirty state. Do not return final summary until clean.
+3. Spawn Ralph for stale-branch cleanup (post-Jiminy, per Ralph charter).
+
+### Gate 3 -- Doc worktree pre-spawn check (closes #289)
+
+**Trigger condition:** the Coordinator is about to spawn Doc (Fact Checker) for any fact-check, verification, audit, or review task.
+
+**Pre-spawn check:**
+
+1. Run `git worktree list`. Confirm `..\dev-setup-doc` (or platform equivalent) is present and on branch `squad/doc-history-sprint-<N>`.
+2. If absent: this is the first Doc spawn of the sprint -> create the worktree now (`git worktree add ../dev-setup-doc -b squad/doc-history-sprint-<N>`) OR defer to `Sprint Kickoff` ceremony if the kickoff was skipped.
+3. Doc's spawn prompt MUST begin with: "Your working directory is `<absolute path to ..\dev-setup-doc>`. `Set-Location` there BEFORE reading any files. All your `.squad/agents/doc/history.md` writes commit + push to `squad/doc-history-sprint-<N>`, never to develop."
+
+**Why:** Doc runs as a `general-purpose` subagent and inherits the Coordinator's CWD by default. Without an explicit CWD override, Doc's writes land as `M` on `develop` in the primary worktree and require a per-fact-check fold PR (Sprint S anti-pattern: #281 + #283). The dedicated worktree isolates Doc's edits to a single sprint branch with ONE fold PR at sprint wrap.
+
+### Gate compliance check
+
+Before declaring a Coordinator turn complete:
+
+- [ ] Counted spawns this turn. If >= 3, did Jiminy run? (Gate 1)
+- [ ] If session-end signal was received, did Jiminy + Ralph run? (Gate 2)
+- [ ] If Doc was spawned, did the spawn prompt include the `..\dev-setup-doc` CWD directive? (Gate 3)
+
+If any gate was missed, the next Jiminy audit will flag it. Self-correct by re-spawning the missed gate before returning to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.squad/skills/pwsh-lastexitcode/SKILL.md`: documents the `$LASTEXITCODE` propagation gotcha across pwsh `&` script-call boundaries; canonical fix is `$global:LASTEXITCODE = 0` after expected-failure commands (closes #288, surfaced by #277)
 - CONTRIBUTING.md "PowerShell Exit Code Discipline" section referencing the new skill
 
+### Changed
+- `.squad/templates/loop.md`, `.squad/templates/ceremonies.md`, and Doc/Jiminy charters: codify post-batch Jiminy audit gate + Doc subagent worktree pattern; eliminates the dual-fold-PR overhead of Sprint S (closes #289, #290)
+- `.squad/decisions/doc-and-jiminy-automation.md`: decision record for squad operational SOPs
+- `CONTRIBUTING.md` "Squad Operational Gates (Coordinator dispatch)" section -- human-facing summary of the Doc worktree + Jiminy auto-dispatch SOPs codified in this PR
+- `hooks/pre-commit` Source of Truth allow-list extended to include canonical `.squad/decisions/*.md` files (top-level decisions directory, distinct from the gitignored `inbox/` subdir). Required so permanent decision records like `.squad/decisions/doc-and-jiminy-automation.md` are commit-eligible.
+
 ## [0.9.0] - 2026-05-17
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,3 +360,53 @@ See `.squad/skills/pwsh-lastexitcode/SKILL.md` for the full pattern, a
 detection checklist, and the call-site audit. The discovery PR is #277
 (`fix(uninstall): unset core.hooksPath`); the skill closes #288.
 
+---
+
+## Squad Operational Gates (Coordinator dispatch)
+
+Two operational SOPs govern Coordinator-side spawn behavior. Both are codified at
+three independent surfaces (charter + `.squad/templates/loop.md` + `.squad/templates/ceremonies.md`)
+so a single forgotten checkpoint doesn't silently break the SOP. Source decision:
+`.squad/decisions/doc-and-jiminy-automation.md` (closes #289, #290).
+
+### Doc subagent runs in a dedicated worktree (#289)
+
+Doc (Fact Checker) is a `general-purpose` subagent that inherits the Coordinator's
+CWD by default. To prevent his `.squad/agents/doc/history.md` writes from landing
+as `M` on `develop` in the primary worktree (Sprint S anti-pattern: required PRs
+#281 + #283), Doc runs in a dedicated per-sprint worktree.
+
+**Sprint kickoff (Coordinator, one-time per sprint):**
+
+```bash
+git worktree add ../dev-setup-doc -b squad/doc-history-sprint-<N>
+```
+
+**Every Doc spawn prompt** MUST begin with an explicit CWD directive pointing at
+`..\dev-setup-doc`. Doc commits + pushes after every fact-check. At sprint wrap,
+the Coordinator opens ONE fold PR from `squad/doc-history-sprint-<N>` into
+`develop`. Target: 1 fold PR per sprint (down from 2 in Sprint S).
+
+### Jiminy auto-dispatch after >= 3-agent batches and at session-end (#290)
+
+The Jiminy dispatch SOP from PR #280 (Coordinator MUST invoke Jiminy after every
+3+ agent batch and at session-end) is now enforced at three surfaces:
+
+1. `.squad/agents/jiminy/charter.md` -> `Triggers` table (canonical).
+2. `.squad/templates/loop.md` -> "Squad Operational Gates" (Gate 1 post-batch, Gate 2 session-end).
+3. `.squad/templates/ceremonies.md` -> `Sprint Wrap` ceremony, step 1.
+
+**Trigger condition (Gate 1):** 3 or more agent spawns in a single Coordinator
+turn, counted excluding Scribe (which runs silently in background by design).
+**Action:** Spawn Jiminy BEFORE returning results to the user. Wait for
+`Jiminy clear` or resolve the dirty report.
+
+**Trigger condition (Gate 2):** user signals session-end OR work queue empties
+after a full sprint. **Action:** Jiminy full sweep; BLOCKS session close on dirty
+state. Ralph runs after Jiminy for stale-branch cleanup.
+
+If you (Coordinator or human contributor) ever notice a >= 3-agent batch landed
+without a Jiminy run, that is a Sprint Retro action item, not a one-off
+self-correction. File a `retro-action` issue.
+
+

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -82,6 +82,7 @@ if [ -n "$SQUAD_STAGED" ]; then
       .squad/decisions.md) VALID=1 ;;
       .squad/decisions-archive.md) VALID=1 ;;
       .squad/decisions/inbox/*.md) VALID=1 ;;
+      .squad/decisions/*.md) VALID=1 ;;
       .squad/orchestration-log/*.md) VALID=1 ;;
       .squad/log/*.md) VALID=1 ;;
       .squad/retros/*.md) VALID=1 ;;
@@ -113,6 +114,7 @@ if [ -n "$SQUAD_STAGED" ]; then
     echo "    .squad/agents/{name}/charter.md | history.md | history-archive.md"
     echo "    .squad/decisions.md | .squad/decisions-archive.md"
     echo "    .squad/decisions/inbox/*.md (gitignored -- should not be staged)"
+    echo "    .squad/decisions/*.md (canonical permanent decision records)"
     echo "    .squad/orchestration-log/*.md"
     echo "    .squad/log/*.md"
     echo "    .squad/retros/*.md"


### PR DESCRIPTION
## Summary

Combines two Sprint S retro action items into one design pass. Both issues touch the same template/charter surface and both are about operational SOPs that should be checklist-enforced rather than relied upon by Coordinator memory.

- **#289** -- Doc subagent worktree pattern: eliminate dual fold-PRs per sprint.
- **#290** -- Auto-enforce Jiminy post-batch dispatch: remove manual SOP friction.

Decision record: `.squad/decisions/doc-and-jiminy-automation.md`.

## Decisions

### #289 -> Option B (dedicated worktree)

At each sprint kickoff, the Coordinator creates `..\dev-setup-doc` on branch `squad/doc-history-sprint-<N>`. Doc's spawn prompt MUST begin with an explicit CWD directive pointing there. All Doc `history.md` writes commit + push to that branch. **ONE** fold PR at sprint wrap (down from 2 in Sprint S: #281 + #283).

Options A (sprint branch without worktree), C (inline / no history.md), and D (status quo) rejected. Rationale in the decision doc.

### #290 -> Option A (loop.md + ceremonies.md two-source checklist)

The PR #280 dispatch SOP is now codified at THREE surfaces:

1. `.squad/agents/jiminy/charter.md` Triggers table (canonical).
2. `.squad/templates/loop.md` "Squad Operational Gates" -- Gate 1 (post-batch >= 3 spawns) + Gate 2 (session-end).
3. `.squad/templates/ceremonies.md` Sprint Wrap ceremony, step 1.

A forgotten checkpoint at one surface should be caught by the other two.

Options B (GH Action), C (pre-push hook), D (runtime reminder) rejected per the issue's own analysis.

## Acceptance criteria mapping

### #289 criteria

- [x] Decision document exists -- [.squad/decisions/doc-and-jiminy-automation.md](.squad/decisions/doc-and-jiminy-automation.md)
- [x] Doc charter updated -- [.squad/agents/doc/charter.md](.squad/agents/doc/charter.md) (new "Where Doc writes history.md" section + amended `Git Rules`)
- [x] Coordinator dispatch SOP updated -- [.squad/templates/ceremonies.md](.squad/templates/ceremonies.md) (Sprint Kickoff + Sprint Wrap ceremonies) and [.squad/templates/loop.md](.squad/templates/loop.md) (Gate 3: Doc worktree pre-spawn check)
- [x] Sprint T verification plan documented -- decision doc section "Sprint T verification plan"; will be verified during Sprint T's first multi-agent batch and at sprint wrap

### #290 criteria

- [x] Decision document exists -- [.squad/decisions/doc-and-jiminy-automation.md](.squad/decisions/doc-and-jiminy-automation.md) (same file)
- [x] `loop.md` updated -- [.squad/templates/loop.md](.squad/templates/loop.md) "Squad Operational Gates" section (Gates 1 + 2)
- [x] `ceremonies.md` documents the audit gate -- [.squad/templates/ceremonies.md](.squad/templates/ceremonies.md) Sprint Wrap ceremony, step 1
- [x] Sprint T verification plan documented -- decision doc section "Sprint T verification plan"; verified at the first >= 3-agent batch of Sprint T

## Files changed (9)

| File | Change |
|------|--------|
| `.squad/decisions/doc-and-jiminy-automation.md` | NEW -- canonical decision record |
| `.squad/templates/loop.md` | Appended "Squad Operational Gates" section (3 gates + compliance check) |
| `.squad/templates/ceremonies.md` | Added `Sprint Kickoff` and `Sprint Wrap` ceremonies |
| `.squad/agents/doc/charter.md` | New "Where Doc writes history.md" section + amended `Git Rules` |
| `.squad/agents/jiminy/charter.md` | `Triggers` table cross-references new templates |
| `CONTRIBUTING.md` | New "Squad Operational Gates (Coordinator dispatch)" section |
| `CHANGELOG.md` | `[Unreleased]` `### Changed` entry |
| `.squad/agents/mickey/history.md` | Sprint T design-pass entry |
| `hooks/pre-commit` | Allow-list extended to `.squad/decisions/*.md` (canonical permanent decisions, distinct from gitignored `inbox/`); required so the decision record above is commit-eligible |

## Test plan

No code changes; no scripts/tools modified. Tests not run because:

- All changes are documentation + templates (Markdown).
- Considered a static-source grep test for SOP phrase presence; rejected because the SOPs are purely human-facing (Coordinator behavior, not script behavior) and phrase-pinning tests turn template edits into test churn. Triple-surface enforcement IS the audit signal. Rationale documented in the decision file.
- `hooks/pre-commit` change is a single line in the allow-list; verified by the commit itself succeeding (which exercises the hook).

## Hygiene

- Branch `squad/289-290-squad-automation` forked from `develop` @ `99faaa7`.
- Conventional Commits format on the single commit (`docs(squad): ...`).
- Co-authored-by: Copilot trailer present.
- Mickey history appended (Sprint T design-pass entry covers rationale for combining #289 + #290 into one PR).
- No `develop` writes. No agent code touched beyond surgical charter amendments.

## Related

Closes #289
Closes #290

## Sprint T verification pre-conditions for the Coordinator

When the Coordinator dispatches the first multi-agent batch of Sprint T:

1. `git worktree list` should show `..\dev-setup-doc` on `squad/doc-history-sprint-T` before the first Doc spawn. If absent, create it: `git worktree add ../dev-setup-doc -b squad/doc-history-sprint-T`.
2. First >= 3-agent batch MUST end with a Jiminy run before results return to the user.
3. Sprint T wrap opens one fold PR from `squad/doc-history-sprint-T` into `develop` (zero if Doc never ran).