### PR TITLE
docs(hooks): document PSScriptAnalyzer advisory-only intent (closes #233)

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -421,3 +421,52 @@ Key learnings:
 - Git .gitattributes explicit rules are the cleanest way to override autocrlf behavior consistently across platforms.
 - eol=crlf ensures the working tree always has CRLF on checkout, regardless of core.autocrlf setting.
 - This is especially important for Windows-specific tooling like PowerShell, which expects CRLF.
+
+
+---
+
+## 2026-05-17 -- Sprint T Issue #233: docs(hooks) PSScriptAnalyzer advisory-only intent
+
+**Branch:** `squad/233-pssa-advisory-docs`
+**PR:** (pending push)
+**Status:** Docs-only change; PSSA logic already advisory (`|| true` on inner pwsh call, line 51)
+
+### What I did
+
+- `hooks/pre-push`: Added a 14-line comment block (lines 29-43) above the PSSA section
+  explaining advisory-only intent. Three reasons codified: (1) availability gap on hosts
+  without pwsh + PSGallery access, (2) subjective rules like PSAvoidUsingWriteHost are
+  style not bugs, (3) blocking would require version pin + cmdlet allowlist out of scope.
+  Practical implication noted: `|| true` is load-bearing, do not remove. No env var
+  opt-in to strict mode exists; flagged as potential future feature.
+- `CONTRIBUTING.md`: Added "Why is PSSA advisory in `pre-push`?" subsection (3 bullet
+  list) under existing "Installing PSScriptAnalyzer locally (optional)" block. Mirrors the
+  inline rationale and points readers back to the inline comment so the `|| true` is
+  not "fixed" away by well-meaning contributors.
+- `CHANGELOG.md`: Two entries in `[Unreleased]` `### Changed` for the pre-push comment
+  block and the CONTRIBUTING subsection, both closing #233.
+
+### Confirmation: PSSA logic was already advisory
+
+Verified `hooks/pre-push:51` ends with `|| true` and the surrounding `echo` on
+line 49 already says `(advisory)`. The Group L test suite in
+`tests/test_windows_setup.ps1` (L-1 through L-5) and `Tpp5` in
+`tests/test_precommit_hygiene.sh` already enforce the advisory contract
+(no `exit 1` on PSSA lines; pre-push exits 0 on feature branches even with .ps1 staged).
+Therefore: NO behavior change in this PR, NO follow-up issue required.
+
+### Validation
+
+- `git diff --stat`: 3 files, +25/-1 lines.
+- All Group L test invariants preserved: `command -v pwsh` still present, `Invoke-ScriptAnalyzer`
+  still present, `Get-Module.*PSScriptAnalyzer` still present, no comment line contains both
+  `PSScriptAnalyzer` and `exit 1`, shebang remains `#!/bin/sh`.
+- Comment block sized at 14 lines (within 8-15 budget from task spec).
+
+### Key learnings
+
+- When the intent IS already implemented correctly but undocumented, the cheap fix is
+  always an inline comment block adjacent to the load-bearing line. Future contributors
+  who see `|| true` and think "bug" need the comment within eyeshot, not three docs away.
+- README/CONTRIBUTING already said "advisory, never blocks" but never said WHY. The why is
+  what prevents tightening. Always document the rationale, not just the behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md "PowerShell Exit Code Discipline" section referencing the new skill
 
 ### Changed
+- `hooks/pre-push`: documented advisory-only intent of the PSScriptAnalyzer step with an inline comment block at the top of the PSSA section; clarifies that PSSA findings warn but do not block, explains the three reasons (availability gap, subjective rules, out-of-scope hardening), and flags `|| true` as load-bearing (closes #233)
+- `CONTRIBUTING.md` "Why is PSSA advisory in `pre-push`?" subsection under Git Hooks: codifies the advisory model for contributors so the `|| true` in `hooks/pre-push` is not incorrectly "fixed" away (closes #233)
 - `.squad/templates/loop.md`, `.squad/templates/ceremonies.md`, and Doc/Jiminy charters: codify post-batch Jiminy audit gate + Doc subagent worktree pattern; eliminates the dual-fold-PR overhead of Sprint S (closes #289, #290)
 - `.squad/decisions/doc-and-jiminy-automation.md`: decision record for squad operational SOPs
 - `CONTRIBUTING.md` "Squad Operational Gates (Coordinator dispatch)" section -- human-facing summary of the Doc worktree + Jiminy auto-dispatch SOPs codified in this PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,14 @@ Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
 
 The hook auto-detects `pwsh` and the module. If either is absent, the check is silently skipped.
 
+### Why is PSSA advisory in `pre-push`?
+
+PSSA findings warn but never block local pushes. The hook intentionally exits 0 even when PSSA reports issues. Three reasons:
+
+1. **Availability gap.** Not every contributor host has `pwsh` + the PSScriptAnalyzer module installed (e.g., Linux/macOS without PowerShell Core, or Windows boxes without PSGallery network access). Blocking would punish hosts that simply lack the tool.
+2. **Subjective rules.** Many PSSA rules (`PSAvoidUsingWriteHost`, `PSUseSingularNouns`, etc.) are style preferences, not bugs. CI -- not the developer's machine -- is the right gate for those.
+3. **Out of scope to harden.** Making PSSA blocking locally would require pinning a module version and curating a cmdlet allowlist. That work is deferred; if you need strict local linting today, run `Invoke-ScriptAnalyzer` manually before pushing. The inline comment block at the top of the PSSA section in `hooks/pre-push` records this intent so the `|| true` is not "fixed" away.
+
 ---
 
 ## Direct-Push Override Policy

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -26,7 +26,21 @@ if command -v shellcheck >/dev/null 2>&1; then
   fi
 fi
 
-# Run PSScriptAnalyzer on changed .ps1 files if pwsh is available (advisory)
+# --- PSScriptAnalyzer (PSSA): ADVISORY ONLY ---------------------------------
+# This block lints changed .ps1 files but NEVER blocks the push. Rationale:
+#   * PSSA is not always installed on contributor hosts (Linux/macOS without
+#     PowerShell Core, or Windows boxes without PSGallery network access).
+#   * Many PSSA rules are subjective style preferences (PSAvoidUsingWriteHost,
+#     PSUseSingularNouns, etc.) and should not gate a developer push.
+#   * Blocking would require pinning a specific PSSA version + curating a
+#     cmdlet allowlist; that is out of scope for the local pre-push hook.
+#     CI (PR gate, see CONTRIBUTING.md > Git Hooks) is the authoritative lint.
+# Practical implication: this block exits 0 regardless of findings; output is
+# informational only (Write-Warning). The `|| true` on the inner pwsh call is
+# load-bearing -- do not remove. Contributors who want strict local linting
+# can run `Invoke-ScriptAnalyzer` manually before pushing. No env var opt-in
+# to strict mode exists today; adding one is a potential future feature.
+# ----------------------------------------------------------------------------
 if command -v pwsh >/dev/null 2>&1; then
   PS1_CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep '\.ps1$' || true)
   if [ -n "$PS1_CHANGED" ]; then


### PR DESCRIPTION
## Summary

Documents the **advisory-only intent** of the PowerShell Script Analyzer (PSSA) block in `hooks/pre-push` so future contributors do not mistakenly tighten the hook to block on PSSA findings.

Closes #233.

## What changed

- `hooks/pre-push`: 14-line comment block (lines 29-43) above the PSSA section codifies the rationale and flags `|| true` as load-bearing.
- `CONTRIBUTING.md`: New "Why is PSSA advisory in `pre-push`?" subsection under the existing "Installing PSScriptAnalyzer locally" block, mirroring the inline rationale.
- `CHANGELOG.md`: Two entries in `[Unreleased]` `### Changed`.

## Why advisory (rationale captured in the comment block)

1. **Availability gap.** Not every contributor host has `pwsh` + PSScriptAnalyzer installed (Linux/macOS without PowerShell Core, Windows boxes without PSGallery network access).
2. **Subjective rules.** `PSAvoidUsingWriteHost`, `PSUseSingularNouns`, etc. are style, not bugs. CI is the right gate.
3. **Out of scope to harden.** Blocking would require pinning a PSSA version + curating a cmdlet allowlist.

## Verification

**PSSA logic was already advisory** -- this is docs only. `hooks/pre-push:51` ends with `|| true`; the existing echo on line 49 already says `(advisory)`. No follow-up issue required.

Existing tests preserved:
- `tests/test_windows_setup.ps1` Group L (L-1 through L-5): `command -v pwsh` guard, `Invoke-ScriptAnalyzer` invocation, module check, no `exit 1` on PSSA lines, `#!/bin/sh` shebang -- all still hold.
- `tests/test_precommit_hygiene.sh` Tpp5: pre-push exits 0 on feature branch with .ps1 staged -- unchanged.

## Acceptance criteria

- [x] `hooks/pre-push` has a clear comment block above the PSSA invocation explaining advisory intent (14 lines, within the 8-15 budget)
- [x] `CONTRIBUTING.md` mentions the advisory intent + the three reasons
- [x] PSSA logic already advisory; no follow-up issue needed
- [x] CHANGELOG `[Unreleased]` updated

## Out of scope

- Adding a `PSSA_STRICT=1` env var to opt in to blocking behavior. Flagged in the inline comment block as a potential future feature.

---

🤖 Authored by Pluto (Config Engineer) -- the dev-setup squad.
