### PR TITLE
refactor(scripts/windows): move auth.ps1 under tools/ (closes #230)

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -489,3 +489,61 @@ must return the version number (not an error) before the pin is committed.
 The version `0.0.339` was never verifiable -- it was copied from curl installer internal
 state without checking whether it corresponded to a real npm package version.
 Add this check to `.squad/skills/tool-version-pin/SKILL.md` validation steps.
+
+
+---
+
+## [2026-05-18] Sprint T -- Issue #230: Move auth.ps1 under tools/ (Wave 1)
+
+**Branch:** `squad/230-auth-to-tools`
+**Status:** PR open
+
+### Background
+
+After PR #195's per-tool refactor, `scripts/windows/auth.ps1` was the lone
+top-level installer left at `scripts/windows/`. Issue #230 (P2 chore) called
+for relocating it under `tools/` to match the established layout.
+
+### What I did
+
+- `git mv scripts/windows/auth.ps1 scripts/windows/tools/auth.ps1` (git
+  reports 96% similarity, rename history preserved).
+- Updated the dot-source path inside `auth.ps1` from
+  `\lib\logging.ps1` to `\..\lib\logging.ps1`
+  to match the pattern used by every other `tools/*.ps1` script. Also
+  updated the file's header comment to reflect the new path. No logic
+  changes; `Invoke-GhAuth` body is byte-identical.
+- `scripts/windows/setup.ps1` line 34: updated dot-source from
+  `\auth.ps1` to `\tools\auth.ps1`.
+- `tests/test_windows_setup.ps1` line 1195 (Group S setup): added
+  `tools` segment to `Join-Path` chain.
+- CHANGELOG.md: added an `[Unreleased]` `### Changed` entry.
+
+### Files I did NOT touch
+
+- **ARCHITECTURE.md** -- no auth.ps1 reference present anyway, and Mickey
+  owns the file in concurrent worktree #229. Confirmed clean grep.
+- **CHANGELOG.md line 76** -- historical entry under 0.8.0 ("Windows
+  GitHub auth step via scripts/windows/auth.ps1 (closes #191)") is a
+  historically accurate description of the original add and must remain
+  pinned to the path at the time. New `[Unreleased]` entry documents
+  the move.
+- **auth.ps1 function body** -- the four `& gh ...` `0`
+  read-without-reset sites flagged in the pwsh-lastexitcode SKILL are
+  out of scope for this issue. Wave 2 (#292) handles that hardening.
+
+### Verification
+
+- `Test-Path scripts/windows/tools/auth.ps1` -> True
+- `Test-Path scripts/windows/auth.ps1` -> False
+- PowerShell parser: all three modified files parse cleanly
+- Dot-source from new location succeeds; `Invoke-GhAuth` function defined
+- Full `tests/test_windows_setup.ps1` run: Group S 3/3 PASS; 114 total
+  PASS, 8 baseline FAIL (Group O alias / live Copilot) -- identical to
+  `develop` baseline, unrelated to this change
+
+### Wave 2 queued
+
+- **#292** -- harden the 4 `0` sites in `auth.ps1` plus
+  any in `setup.ps1` (per pwsh-lastexitcode SKILL). Next task.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.squad/decisions/doc-and-jiminy-automation.md`: decision record for squad operational SOPs
 - `CONTRIBUTING.md` "Squad Operational Gates (Coordinator dispatch)" section -- human-facing summary of the Doc worktree + Jiminy auto-dispatch SOPs codified in this PR
 - `hooks/pre-commit` Source of Truth allow-list extended to include canonical `.squad/decisions/*.md` files (top-level decisions directory, distinct from the gitignored `inbox/` subdir). Required so permanent decision records like `.squad/decisions/doc-and-jiminy-automation.md` are commit-eligible.
+- `scripts/windows/auth.ps1` moved to `scripts/windows/tools/auth.ps1` for consistency with the per-tool layout introduced in #195; all callers updated (closes #230)
 
 ## [0.9.0] - 2026-05-17
 

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -31,7 +31,7 @@ function Test-WingetAvailable {
 . "$PSScriptRoot\tools\squad-cli.ps1"
 . "$PSScriptRoot\tools\dotfiles.ps1"
 . "$PSScriptRoot\tools\profile.ps1"
-. "$PSScriptRoot\auth.ps1"
+. "$PSScriptRoot\tools\auth.ps1"
 
 function Install-GitHook {
     Write-Info "Configuring git hooks..."

--- a/scripts/windows/tools/auth.ps1
+++ b/scripts/windows/tools/auth.ps1
@@ -1,4 +1,4 @@
-# scripts/windows/auth.ps1 - GitHub authentication check and prompt
+# scripts/windows/tools/auth.ps1 - GitHub authentication check and prompt
 #
 # Called by: scripts/windows/setup.ps1 (after gh CLI is installed)
 # Owner:     Goofy (#2)
@@ -13,7 +13,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-. "$PSScriptRoot\lib\logging.ps1"
+. "$PSScriptRoot\..\lib\logging.ps1"
 
 function Invoke-GhAuth {
     # Guard: gh CLI must be available

--- a/tests/test_windows_setup.ps1
+++ b/tests/test_windows_setup.ps1
@@ -1192,7 +1192,7 @@ Write-Host "`n========================================================" -Foregro
 Write-Host " Group S: GitHub auth step (Issue #191)" -ForegroundColor Cyan
 Write-Host "========================================================" -ForegroundColor Cyan
 
-$authScript = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'auth.ps1'
+$authScript = Join-Path $RepoRoot 'scripts' | Join-Path -ChildPath 'windows' | Join-Path -ChildPath 'tools' | Join-Path -ChildPath 'auth.ps1'
 
 . $authScript
 


### PR DESCRIPTION
## Summary

Issue **#230** -- after PR #195's per-tool refactor, `scripts/windows/auth.ps1` was the lone top-level installer left under `scripts/windows/`. This PR moves it into the per-tool layout for consistency.

## New path

- **Before:** `scripts/windows/auth.ps1`
- **After:** `scripts/windows/tools/auth.ps1`

## What changed

| File | Change |
|---|---|
| `scripts/windows/auth.ps1` -> `scripts/windows/tools/auth.ps1` | `git mv` (96% similarity, rename history preserved via `git log --follow`) |
| `scripts/windows/tools/auth.ps1` (in place) | Header comment + dot-source path: `\lib\logging.ps1` -> `\..\lib\logging.ps1` (matches every other `tools/*.ps1`). No logic changes. |
| `scripts/windows/setup.ps1` | Dot-source updated: `\auth.ps1` -> `\tools\auth.ps1` |
| `tests/test_windows_setup.ps1` (Group S, line 1195) | `Join-Path` chain updated to include `tools` segment |
| `CHANGELOG.md` | New `[Unreleased]` `### Changed` entry |
| `.squad/agents/goofy/history.md` | Sprint T Wave 1 hygiene entry |

## Non-goals (explicit)

- **No body changes to `auth.ps1`.** The `Invoke-GhAuth` function body is byte-identical to `develop`. Only the file's header path comment and its `lib/logging.ps1` dot-source path were updated -- both required by the relocation, both called out in the issue body ("Verify dot-source paths inside auth.ps1 still resolve").
- **`0` hardening is out of scope.** The four `& gh ...` sites flagged in `.squad/skills/pwsh-lastexitcode/SKILL.md` are tracked separately as **#292** (Sprint T Wave 2, my next task).

## Deferred to another worktree

- **`ARCHITECTURE.md`** -- no `auth.ps1` reference exists in this file at present, so nothing to change. Mickey owns the file in concurrent worktree **#229** (ARCHITECTURE refresh); if his refresh adds any new content covering Windows tooling layout, the new path is already canonical.

## Verification

- `Test-Path scripts/windows/tools/auth.ps1` -> `True`
- `Test-Path scripts/windows/auth.ps1` -> `False`
- `git log --follow scripts/windows/tools/auth.ps1` traces back to the original creation commit (`dab46b9 feat(windows): add gh auth step`)
- All three modified `.ps1` files parse cleanly with the PowerShell language parser
- Dot-source from new location succeeds; `Invoke-GhAuth` defined
- `tests/test_windows_setup.ps1` full run: **Group S 3/3 PASS** (S-1 function defined, S-2 missing-gh path, S-3 already-authenticated short-circuit). Overall 114 PASS / 8 baseline FAIL -- identical failure set to `develop` baseline (Group O alias / live Copilot), unrelated to this change.

## Acceptance criteria (from #230)

- [x] `auth.ps1` lives under `tools/`
- [x] `setup.ps1` still wires it correctly
- [x] Tests green (Group S 3/3; pre-existing baseline failures untouched)

Closes #230.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
