### PR TITLE
chore(ralph): EOS cleanup for 0.9.1 release session

### DIFF
--- a/.squad/agents/ralph/history.md
+++ b/.squad/agents/ralph/history.md
@@ -374,3 +374,74 @@ Initial setup complete.
   - Open PRs: 1 (this history-fold)
 - **Verdict:** CLEAN. 0 straggler branches, 0 worktrees to remove. Sprint 11
   EOS complete.
+
+## Post-0.9.1 Release + Sprint Rename EOS Cleanup -- 2026-05-17
+
+- **Trigger:** Session-end after 0.9.1 release shipped and Sprint naming
+  convention reverted to numbers (Q->8-hotfix, R->9, S->10, T->11, next=12).
+  Coordinator handed off to Ralph as final EOS step after Jiminy audit ran
+  clean. develop @ `e3418ac`, working tree clean.
+- **PR:** #312 (squad/ralph-eos-0.9.1) -- this history-fold
+- **Previous EOS:** PR #304 (Sprint 11 EOS, no stragglers)
+- **Session PRs merged (all confirmed merged + branches reaped):**
+  * PR #305 -- release/0.9.1 -> develop: 0.9.1 release fold
+  * PR #307 -- chore(release): fold [Unreleased] into 0.9.1 CHANGELOG
+    (merge commit 2b3afe1)
+  * PR #308 -- chore/sprint-naming-convention: revert + rename sprints to
+    numbers (merge commit c93a54c)
+  * PR #311 -- docs(scribe): 0.9.1 release + sprint naming rename retro +
+    history updates (squash-merged as e3418ac)
+- **Initial state snapshot:**
+  - Local branches: develop, main (no squad/* branches)
+  - Remote branches: origin/develop, origin/main, origin/HEAD -> origin/develop
+    (no squad/* branches)
+  - Worktrees: 1 (primary at C:\Users\Earl Tankard\Coding\dev-setup)
+  - Open PRs: 0 (clean board)
+  - Inbox: 1 file (jiminy-2026-05-17-post-batch-audit-fold.md) -- gitignored,
+    NOT Ralph's to action (Scribe will fold next dispatch)
+- **Cleanup actions:** None -- state was already clean. `git fetch --prune`
+  ran for hygiene and confirmed zero stale tracking refs.
+- **gh `--delete-branch` quirk (issue #300):** NOT encountered this session.
+  All 4 session PRs cleaned up their head branches cleanly. Post-Sprint-11
+  release pattern (release branch + revert/rename PRs + retro PR) appears
+  to leave nothing sticky -- the squash-merge in PR #311 also reaped its
+  source branch successfully.
+- **Final repo state:**
+  - develop: `e3418ac` (working tree clean before branch creation)
+  - main: `724c62c` (tagged 0.9.1, released)
+  - Local branches: develop, main, squad/ralph-eos-0.9.1 (this PR)
+  - Remote branches: origin/develop, origin/main,
+    origin/squad/ralph-eos-0.9.1 (this PR)
+  - Worktrees: 1 (primary)
+  - Open PRs: 1 (this history-fold)
+- **EOS pattern note:** Sprint 11 -> 0.9.1 release -> rename retro is now
+  the second consecutive EOS where the release+rename cadence produces
+  zero stragglers. The post-Sprint-10 cycle (PR #295) had 2 stragglers
+  to reap; Sprint 11 wrap (PR #304) and this 0.9.1 wrap had zero each.
+  Hypothesis: `gh pr merge --delete-branch` reliability has improved, OR
+  the team has internalized the cleanup-on-merge habit. Worth watching
+  for one more cycle before declaring the quirk obsolete.
+- **Verdict:** CLEAN. 0 straggler branches, 0 worktrees, 0 stale remotes.
+  0.9.1 release session fully reaped. Sprint 12 backlog staged and ready
+  for next dispatch.
+
+### Learnings (Ralph)
+
+- **Post-release + post-rename combo runs clean.** Even with 4 session PRs
+  spanning a release fold, a CHANGELOG cleanup, a naming revert, and a
+  retro, the board ended at zero stragglers. The release branch
+  (`release/0.9.1`) was reaped on merge; the chore/* and squad/* branches
+  same. No special handling needed for the squash-merged retro PR (#311).
+- **Inbox gitignore is the right pattern.** Jiminy's fold-request sitting
+  in `.squad/decisions/inbox/` is gitignored (`.gitignore:4`), so it
+  survives session boundaries without polluting develop. This is the
+  precedent for Ralph too if a future EOS has nothing committable.
+- **Default to PR over inbox fold-request when history.md is the only
+  delta.** Earl's preference (per spawn prompt) is an explicit paper
+  trail per session, and the cost of a tiny PR is low. Inbox path stays
+  reserved for genuinely uncertain situations.
+- **`git fetch --prune` on an already-clean board is a no-op but worth
+  running.** Confirms remote state matches local belief in ~50ms. Cheap
+  insurance against silent ghost refs.
+- **No new EOS rules to codify.** Pattern is stable: audit -> prune ->
+  history append -> PR. No skill extraction this round.


### PR DESCRIPTION
## Summary

End-of-session cleanup pass after the 0.9.1 release ships and the Sprint naming convention reverts to numbers.

**Audit results: zero stragglers.**

## Audit

| Check | Result |
|-------|--------|
| Worktrees | 1 (primary only) |
| Local squad/* branches | 0 |
| Remote squad/* branches | 0 |
| Open PRs before this one | 0 |
| `git fetch --prune` output | clean |

## Session PRs (all confirmed merged + branches reaped)

- #305 release/0.9.1 -> develop
- #307 chore(release): fold [Unreleased] into 0.9.1 CHANGELOG
- #308 chore/sprint-naming-convention: revert to sprint numbers
- #311 docs(scribe): 0.9.1 release + sprint rename retro

## Changes

Single file: `.squad/agents/ralph/history.md` -- appended a `Post-0.9.1 Release + Sprint Rename EOS Cleanup` section with the audit snapshot, EOS pattern note (second consecutive zero-straggler cycle), and a `Learnings (Ralph)` tail per spawn-hygiene directive.

No code/config changes. History paper trail only.

## Verdict

`Ralph clear`