### PR TITLE
docs(donald): mark .aliases as bash/zsh-only (closes #236)

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -446,3 +446,11 @@ both platform branches get the package to maintain the cross-platform parity doc
 
 - **2026-05-16 -- Reviewed PR #244 (Mickey's retroactive tags + 0.8.0 cut).** Verdict: APPROVE (posted as comment since GitHub single-owner repos cannot self-approve; --admin merge used). CHANGELOG cut is clean (empty Unreleased, all entries under 0.8.0, no drops). Spot-checked 3/7 SHAs (0.1.0, 0.5.0, 0.7.0) -- all point at release-shaped merge commits matching Mickey's rationale table. All 7 tags and GitHub releases confirmed present. Commit uses Conventional Commits format with Copilot co-author trailer.
 2026-05-16 -- #223 logging consolidation
+
+### Sprint 12 -- PR #313: Issue #236 docs(.aliases): mark file as bash/zsh-only
+
+- **What:** Added a header to `config/dotfiles/.aliases` stating the file is bash/zsh only (not POSIX), listing non-POSIX features in use (`[[ ]]`, `[[ =~ ]]`, `local`, `$BASH_VERSION` / `$ZSH_VERSION` shell-detection vars, `alias --` long-option terminator), documenting the loading pattern (sourced from ~/.bashrc / ~/.zshrc via `config/dotfiles/install.sh`), and warning `sh`/`dash`/`ash` users away.
+- **Why:** Closes the V-10 follow-up from the 2026-05-04 verification batch -- POSIX-conformance for `.aliases` was rejected then. This issue makes that decision explicit at the top of the file so future audits / contributors do not re-litigate it.
+- **Files:** `config/dotfiles/.aliases` (header), `README.md` (Shell Aliases section adds a "bash/zsh only -- see header" pointer), `CHANGELOG.md` (Unreleased / Changed entry).
+- **Out of scope (held):** Did NOT rewrite any aliases, did NOT add new aliases, did NOT do shellcheck fixes. Pure documentation.
+- **Lesson:** A "do not chase X" decision is easier to defend when the file itself documents the non-X features it relies on. Header doubles as a reviewer cheat-sheet and as a contract with anyone tempted to `sh ~/.aliases`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Sprint naming convention reverted from letters back to numbers: Q -> Sprint 8-hotfix, R -> Sprint 9, S -> Sprint 10, T -> Sprint 11; next = Sprint 12. Tier 3 full sweep across 21 files (~170 refs). Retro files renamed with `git mv`. First-occurrence `(formerly Sprint X)` aliases added for grep continuity. CONTRIBUTING.md "Sprint Naming Convention" section updated with mapping table and aliasing convention.
+- `.aliases`: added header marking the file as bash/zsh-only (not POSIX); documents non-POSIX features in use and intended loading pattern (closes #236)
 
 ## [0.9.1] - 2026-05-17 -- Sprint 11 (formerly Sprint T): Architecture refresh and tools hardening
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ After running setup, you get shortcuts for common git, dev, and utility commands
 **ls shortcuts** (Linux/macOS only): `ll`, `la`, `l`, `lh`
 
 Full definitions:
-- **Linux/macOS:** `config/dotfiles/.aliases`
+- **Linux/macOS:** `config/dotfiles/.aliases` (bash/zsh only — see header for the non-POSIX features in use)
 - **Windows:** `scripts/windows/setup.ps1` (the `Write-PowerShellProfile` function)
 
 ## Shell Functions

--- a/config/dotfiles/.aliases
+++ b/config/dotfiles/.aliases
@@ -1,7 +1,39 @@
 # ~/.aliases
 #
-# Shell aliases for common developer workflows.
-# Sourced by ~/.zshrc or ~/.bashrc — see config/dotfiles/.zshrc.template.
+# Shell aliases and helper functions for common developer workflows.
+#
+# ============================================================================
+# Shell compatibility: bash/zsh only -- NOT POSIX
+# ============================================================================
+#
+# This file is intended for bash and zsh. It is NOT POSIX-compatible
+# (sh / dash / ash). Do not source it from /bin/sh -- the non-POSIX
+# features below will fail to parse or misbehave.
+#
+# Non-POSIX features intentionally used in this file:
+#
+#   [[ ... ]]              -- extended test command (bash/zsh, not POSIX)
+#   [[ ... =~ ... ]]       -- regex match operator (bash/zsh)
+#   local <var>            -- function-local variables (bash/ksh/zsh)
+#   $BASH_VERSION          -- shell-detection variable used by `sb` alias
+#   $ZSH_VERSION           -- shell-detection variable used by `sz` alias
+#   alias -- -='cd -'      -- `alias --` long-option terminator (bash/zsh)
+#
+# Note: function definitions use the POSIX `name() { ... }` form, but the
+# bodies use `local` (non-POSIX), so the file as a whole is bash/zsh-only.
+#
+# If you need POSIX compatibility, do NOT source this file from /bin/sh.
+# Maintain a separate POSIX-only rc file for sh/dash/ash environments.
+#
+# ============================================================================
+# Loading pattern
+# ============================================================================
+#
+# Sourced from ~/.bashrc and ~/.zshrc. The dotfile installer
+# (config/dotfiles/install.sh) wires this in for new shells; existing shells
+# pick it up on next launch or via the `reload` / `sb` / `sz` aliases.
+# See README.md "Shell Aliases" for the cross-platform picture and the
+# Windows-side equivalent in scripts/windows/tools/profile.ps1.
 #
 # Categories:
 #   - Navigation


### PR DESCRIPTION
## Summary

Adds a clear header to `config/dotfiles/.aliases` declaring it **bash/zsh only -- NOT POSIX** (sh/dash/ash). The header lists the non-POSIX features the file intentionally uses, documents the loading pattern (sourced from `.bashrc` / `.zshrc` via `config/dotfiles/install.sh`), and warns POSIX-shell users not to source it from `/bin/sh`.

This is the documentation counterpart of the V-10 verification finding (2026-05-04, Donald's history): "POSIX syntax in .aliases -- not needed". This PR makes that decision explicit at the top of the file so future audits do not re-litigate it.

## Non-POSIX features documented in the new header

- `[[ ... ]]` extended test command (bash/zsh)
- `[[ ... =~ ... ]]` regex match operator (bash/zsh)
- `local <var>` function-local variables (bash/ksh/zsh)
- `$BASH_VERSION` / `$ZSH_VERSION` shell-detection variables (used by `sb` / `sz` aliases)
- `alias -- -='cd -'` long-option terminator (bash/zsh)

## Files touched

- `config/dotfiles/.aliases` -- new header (33 lines of comments) at the top of the file. No alias bodies changed.
- `README.md` -- "Shell Aliases" section: appended `(bash/zsh only -- see header for the non-POSIX features in use)` to the Linux/macOS bullet.
- `CHANGELOG.md` -- one entry under `[Unreleased]` -> `### Changed`.
- `.squad/agents/donald/history.md` -- Sprint 12 PR entry.

## Out of scope (explicitly held)

- Did NOT rewrite any aliases
- Did NOT add new aliases
- Did NOT run shellcheck or other lint fixes

## Verification

- `git diff` reviewed; only documentation lines changed.
- Header lines all start with `#` -- `test_aliases.sh` and `test_alias_parity.sh` parsers (which key on `^\s*alias\s+` and `^\s*[a-zA-Z_]\w*\s*\(\)`) are unaffected.
- ASCII-only check (pre-commit) applies to `.ps1` files only; `.aliases` already uses unicode box-drawing characters elsewhere and is exempt.

Closes #236