### PR TITLE
docs(mickey): rewrite ARCHITECTURE.md Script Conventions (closes #309)

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -1114,3 +1114,31 @@ needed for this design-pass PR until merge.
 - **Issue #306 body updated mid-sweep** to use "Sprint 12" (was "Sprint U") plus
   a new acceptance criterion referencing the new naming. Stays consistent when
   Sprint 12 picks it up.
+
+
+## 2026-05-17 -- Sprint 12 PR #314: ARCHITECTURE.md Script Conventions rewrite (#309)
+
+- **Closed #309** by rewriting the `Script Conventions` section in ARCHITECTURE.md.
+  Old section pointed contributors at `copy from setup.sh` / `copy from setup.ps1` --
+  obsolete since the Sprint 8/10 lib/ refactors. New section names the actual files
+  (`scripts/linux/lib/log.sh`, `scripts/windows/lib/logging.ps1`, `scripts/windows/lib/path.ps1`,
+  and the cross-platform `scripts/lib/Read-ToolVersion.ps1` / `read-tool-version.sh` pair)
+  with one-line copy-paste loading patterns for both bash `source` and PowerShell dot-source.
+- **Key asymmetry documented:** `setup.sh` runs each `tools/*.sh` via `bash <script>`
+  (subshell, no inherited scope, so tools must re-source `lib/log.sh`), but `setup.ps1`
+  `dot-sources` each `tools/*.ps1` (parent scope, tool functions like `Install-Nvm`
+  live there and are invoked by name from `Main`). This is real, intentional, and
+  was implicit in the code -- now explicit in the doc.
+- **Version-pin pattern made canonical.** The bash side captures stdout from
+  `sh scripts/lib/read-tool-version.sh <tool>`; the PS side dot-sources
+  `Read-ToolVersion.ps1` then calls `Get-ToolVersion -Name <tool>`. nvm.sh
+  and nvm.ps1 cited as reference implementations.
+- **Verification:** read all five lib files + both setup orchestrators + both nvm
+  tool scripts before writing any examples. Every code block in the new section
+  is grounded in actual repo source, not assumed.
+- **Out-of-scope hold:** did not touch `Dependency Order` (that's #310, Sprint 12
+  Wave 2). Single-section edit, clean diff.
+- **ASCII-clean diff:** removed the pre-existing em-dash from the old `Sourcing`
+  row; all new content is plain ASCII. (ARCHITECTURE.md has pre-existing non-ASCII
+  bytes elsewhere; the pre-commit hook only guards `*.ps1`, so this is fine,
+  but I avoided introducing any new ones in my edit.)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -187,6 +187,70 @@ Uses PowerShell's built-in `$IsWindows`, `$IsLinux`, `$IsMacOS` booleans. If Pow
 
 ## Script Conventions
 
+Shared helpers live in dedicated `lib/` directories. Tool scripts **load** them rather than redefining or copy-pasting. Source of truth:
+
+| File                                 | Purpose                                                                                  | Loaded by                                    |
+|--------------------------------------|------------------------------------------------------------------------------------------|----------------------------------------------|
+| `scripts/linux/lib/log.sh`           | `log_info`, `log_ok`, `log_warn`, `log_error`                                            | `setup.sh` and every `tools/*.sh`            |
+| `scripts/windows/lib/logging.ps1`    | `Write-Info`, `Write-Ok`, `Write-Warn`, `Write-Err`, `Assert-LastExit`                   | `setup.ps1` and every `tools/*.ps1`          |
+| `scripts/windows/lib/path.ps1`       | `Refresh-SessionPath` (re-reads Machine + User PATH from the registry into the session) | `setup.ps1` and any tool that mutates PATH   |
+| `scripts/lib/read-tool-version.sh`   | POSIX parser for `.tool-versions` (prints the pinned version to stdout)                  | Any `tools/*.sh` that needs a pinned version |
+| `scripts/lib/Read-ToolVersion.ps1`   | PowerShell `Get-ToolVersion -Name <tool>` (returns the pinned version)                   | Any `tools/*.ps1` that needs a pinned version |
+
+**Rule:** New helpers go in the appropriate `lib/` directory. Do not copy helper definitions into `setup.sh`, `setup.ps1`, or individual tool scripts.
+
+### Loading helpers
+
+**Bash** uses POSIX `source` (`.`). At the top of `setup.sh` or any `tools/*.sh`, after the safety flags:
+
+```bash
+# From scripts/linux/setup.sh (lib is one level down):
+. "$(dirname "${BASH_SOURCE[0]}")/lib/log.sh"
+
+# From scripts/linux/tools/<tool>.sh (lib is one level up):
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/log.sh"
+```
+
+Note that `setup.sh` runs each `tools/*.sh` via `bash <script>` (a subshell), so every tool script must re-source `lib/log.sh` itself; the parent scope is not inherited.
+
+**PowerShell** uses dot-sourcing (`.`). At the top of `setup.ps1` or any `tools/*.ps1`, after `Set-StrictMode` / `$ErrorActionPreference`:
+
+```powershell
+# From scripts/windows/setup.ps1 (lib is alongside):
+. "$PSScriptRoot\lib\logging.ps1"
+. "$PSScriptRoot\lib\path.ps1"
+
+# From scripts/windows/tools/<tool>.ps1 (lib is one level up):
+. "$PSScriptRoot\..\lib\logging.ps1"
+```
+
+`$PSScriptRoot` is the directory of the currently-executing file. Unlike the bash path, `setup.ps1` **dot-sources** each `tools/*.ps1`, so tool functions (`Install-Nvm`, `Install-GhCli`, ...) live in the parent scope and are invoked by name from `Main`. Tool scripts still re-dot-source any `lib/` files they need so they are also runnable standalone.
+
+### Reading pinned versions from `.tool-versions`
+
+`.tool-versions` is the single source of truth for tool versions (see "Tool Version Pinning" below). Tool scripts must read pins via the shared parsers in `scripts/lib/`; they must not hard-code versions.
+
+**Bash:** invoke the POSIX script and capture stdout. From `scripts/linux/tools/<tool>.sh`:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PINNED_NODE="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" nodejs)"
+```
+
+The parser walks up two levels to find the repo root, so the path from `scripts/linux/tools/` is `../../lib/read-tool-version.sh`. It exits non-zero if the tool is missing or `.tool-versions` is not found; `set -euo pipefail` will surface either.
+
+**PowerShell:** dot-source the parser, then call `Get-ToolVersion`. From `scripts/windows/tools/<tool>.ps1`:
+
+```powershell
+$libDir = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib'
+. (Join-Path $libDir 'Read-ToolVersion.ps1')
+$pinnedNode = Get-ToolVersion -Name 'nodejs'
+```
+
+Two `Split-Path -Parent` calls climb `tools/ -> windows/ -> scripts/`, then `lib` reaches the shared parser. `Get-ToolVersion` throws on missing tool or missing `.tool-versions`, which surfaces under `$ErrorActionPreference = 'Stop'`.
+
+Reference implementations: `scripts/linux/tools/nvm.sh` and `scripts/windows/tools/nvm.ps1`.
+
 ### Bash (`scripts/linux/`)
 
 | Convention | Rule |
@@ -194,8 +258,9 @@ Uses PowerShell's built-in `$IsWindows`, `$IsLinux`, `$IsMacOS` booleans. If Pow
 | Shebang | `#!/usr/bin/env bash` |
 | Safety flags | `set -euo pipefail` at top of every script |
 | Idempotency | Check `command -v <tool>` before installing; skip if present |
-| Logging | Use `log_info`, `log_ok`, `log_warn`, `log_error` helpers (copy from `setup.sh`) |
-| Sourcing | Scripts in `tools/` are run via `bash <script>` from the core installer, not `source` — keeps each script isolated |
+| Logging | Source `scripts/linux/lib/log.sh`; call `log_info`, `log_ok`, `log_warn`, `log_error` |
+| Version pinning | Read from `.tool-versions` via `sh scripts/lib/read-tool-version.sh <tool>`; never hard-code versions |
+| Sourcing | `setup.sh` runs each `tools/*.sh` via `bash <script>` (subshell); tool scripts re-source `lib/log.sh` themselves |
 | Exit codes | `exit 0` on success or skip, `exit 1` on unrecoverable error |
 
 ### PowerShell (`scripts/windows/`)
@@ -204,8 +269,12 @@ Uses PowerShell's built-in `$IsWindows`, `$IsLinux`, `$IsMacOS` booleans. If Pow
 |------------|------|
 | Safety | `Set-StrictMode -Version Latest` + `$ErrorActionPreference = 'Stop'` |
 | Idempotency | `Get-Command <tool> -ErrorAction SilentlyContinue` before installing |
-| Logging | Use `Write-Info`, `Write-Ok`, `Write-Warn`, `Write-Err` helpers (copy from `setup.ps1`) |
-| Install method | Prefer `winget`; fall back to `scoop` or direct download |
+| Logging | Dot-source `scripts/windows/lib/logging.ps1`; call `Write-Info`, `Write-Ok`, `Write-Warn`, `Write-Err` |
+| Exit-code discipline | After any external install, call `Assert-LastExit -ToolName <name>` (use `-AllowedExitCodes` for cases like winget `ALREADY_INSTALLED`); see `.squad/skills/pwsh-lastexitcode/SKILL.md` |
+| PATH refresh | After an install mutates PATH, dot-source `scripts/windows/lib/path.ps1` and call `Refresh-SessionPath` so `node`, `uv`, `gh`, etc. become callable in the same session |
+| Version pinning | Read from `.tool-versions` via `Get-ToolVersion` (dot-source `scripts/lib/Read-ToolVersion.ps1`); never hard-code versions |
+| Install method | Prefer `winget`; fall back to `scoop` or direct download (see `nvm.ps1` for the portable-zip pattern) |
+| Sourcing | `setup.ps1` dot-sources each `tools/*.ps1`; tool functions live in the parent scope and are invoked by name. Tool scripts re-dot-source their own `lib/` files so they remain runnable standalone. |
 | Profile injection | `Write-PowerShellProfile` writes aliases to **both** PS 5.1 (`Documents\WindowsPowerShell\`) and PS 7+ (`Documents\PowerShell\`) paths; sentinel strip+re-inject makes it idempotent |
 | Alias registration | All `Set-Alias` calls use `-Force -Scope Global` so aliases work in the current session immediately |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- ARCHITECTURE.md: rewrote `Script Conventions` section to point at `scripts/{linux,windows}/lib/` as source of truth; documents `source` / dot-source loading + `Read-ToolVersion.ps1` parser pattern (closes #309)
 - Sprint naming convention reverted from letters back to numbers: Q -> Sprint 8-hotfix, R -> Sprint 9, S -> Sprint 10, T -> Sprint 11; next = Sprint 12. Tier 3 full sweep across 21 files (~170 refs). Retro files renamed with `git mv`. First-occurrence `(formerly Sprint X)` aliases added for grep continuity. CONTRIBUTING.md "Sprint Naming Convention" section updated with mapping table and aliasing convention.
 
 ## [0.9.1] - 2026-05-17 -- Sprint 11 (formerly Sprint T): Architecture refresh and tools hardening


### PR DESCRIPTION
## Summary

Rewrites the `Script Conventions` section in `ARCHITECTURE.md` (lines 188-279) so it reflects the post-Sprint 8/10 layout. The old section told contributors to `copy from setup.sh` / `copy from setup.ps1` for log helpers; that guidance was obsolete the moment `scripts/linux/lib/log.sh` and `scripts/windows/lib/logging.ps1` landed. The new section:

- Names the actual source-of-truth files in a table at the top: `scripts/linux/lib/log.sh`, `scripts/windows/lib/logging.ps1`, `scripts/windows/lib/path.ps1`, plus the cross-platform `scripts/lib/Read-ToolVersion.ps1` and `scripts/lib/read-tool-version.sh`.
- Adds a `Loading helpers` subsection with copy-paste bash `source` (`.`) and PowerShell dot-source examples from both `setup` and `tools/` perspectives, and documents the real asymmetry: bash runs `tools/*.sh` in a subshell via `bash <script>` (tools must re-source `lib/log.sh`), while PowerShell `setup.ps1` dot-sources `tools/*.ps1` (tool functions live in the parent scope and are invoked by name from `Main`).
- Adds a `Reading pinned versions from .tool-versions` subsection with both bash and PowerShell patterns for the shared parsers. Cites `scripts/linux/tools/nvm.sh` and `scripts/windows/tools/nvm.ps1` as reference implementations.
- Updates the existing Bash and PowerShell convention tables: `Logging` rows now name the lib file to source instead of saying "copy from setup.sh"; new rows added for `Version pinning`, `Exit-code discipline` (PS, references `.squad/skills/pwsh-lastexitcode/SKILL.md`), and `PATH refresh` (PS, `Refresh-SessionPath` from `lib/path.ps1`).

## Files touched

- `ARCHITECTURE.md` (+77 / -4) -- rewrote `## Script Conventions` only; `## Dependency Order` untouched (that is #310, Sprint 12 Wave 2)
- `CHANGELOG.md` (+1) -- `[Unreleased]` -> `### Changed` entry
- `.squad/agents/mickey/history.md` (+24) -- Sprint 12 PR entry

## Verification

Read these files first, then drafted examples directly from their contents (no assumed function names):

- `scripts/linux/lib/log.sh` -- confirms `log_info` / `log_ok` / `log_warn` / `log_error`; usage comment `Source with: . "$(dirname "${BASH_SOURCE[0]}")/../lib/log.sh"` matches the example for `tools/*.sh`.
- `scripts/windows/lib/logging.ps1` -- confirms `Write-Info` / `Write-Ok` / `Write-Warn` / `Write-Err` plus the `Assert-LastExit` helper; usage comment matches the example for `tools/*.ps1`.
- `scripts/windows/lib/path.ps1` -- confirms `Refresh-SessionPath` and its Machine + User PATH merge behaviour.
- `scripts/lib/read-tool-version.sh` -- confirms the `sh scripts/lib/read-tool-version.sh <tool>` -> stdout contract and the two-level walk-up to repo root.
- `scripts/lib/Read-ToolVersion.ps1` -- confirms `Get-ToolVersion -Name <tool>` with `Continue = 'Stop'` throw-on-missing semantics.
- `scripts/linux/setup.sh` -- confirms `run_tool` uses `bash "${tool_script}"` (subshell), justifying the "must re-source lib" claim.
- `scripts/windows/setup.ps1` -- confirms it dot-sources both `lib/` files and all 11 `tools/*.ps1` files, justifying the "parent scope" claim.
- `scripts/linux/tools/nvm.sh` -- the exact `PINNED_NODE="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" nodejs)"` invocation is copied verbatim from line 17.
- `scripts/windows/tools/nvm.ps1` -- the ` = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) 'lib'` then `Get-ToolVersion -Name 'nodejs'` pattern is taken from lines 17-26.

Diff hygiene: the only non-ASCII byte in the diff is the em-dash being **removed** from the old `Sourcing` row. All new content is plain ASCII. The pre-commit hook only enforces ASCII on staged `*.ps1` files, so the pre-existing non-ASCII bytes elsewhere in `ARCHITECTURE.md` are unchanged and would not have been an issue anyway. `hooks/pre-commit` passed locally (branch ancestry, ASCII guard, `.squad/` allow-list, inbox guard, branch protection, shellcheck all green).

Closes #309
