### PR TITLE
chore(pluto): delete legacy priority labels (closes #254)

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -470,3 +470,42 @@ Therefore: NO behavior change in this PR, NO follow-up issue required.
   who see `|| true` and think "bug" need the comment within eyeshot, not three docs away.
 - README/CONTRIBUTING already said "advisory, never blocks" but never said WHY. The why is
   what prevents tightening. Always document the rationale, not just the behavior.
+
+### Sprint 12 (Wave 1): Legacy priority label cleanup (issue #254)
+
+**Context:** Issue #254 -- delete legacy `priority: high/medium/low` labels (with spaces) that
+predated the canonical `priority:p0..p3` taxonomy. Reassigned from Mickey to Pluto since
+this is config-engineering work (label inventory + workflow files).
+
+**Pre-deletion audit:**
+- Confirmed all three legacy labels existed (`gh label list --limit 100`).
+- Confirmed canonical `priority:p0`, `priority:p1`, `priority:p2`, `priority:p3` all in place.
+- Verified ZERO OPEN issues/PRs used legacy labels. 18 CLOSED issues (chip era: #178-194)
+  had used them, but closed issues retaining history was acceptable per task scope (the
+  explicit gate was `any OPEN issue/PR`).
+- Grepped `.github/`, `.squad/`, `CONTRIBUTING.md`, `README.md`, issue templates for any
+  references. Only matches were historical (a retro doc + decisions.md prose using
+  `Priority: HIGH` as a severity ranking, NOT label names).
+- Verified `.github/workflows/sync-squad-labels.yml` is additive-only (no delete pass) and
+  defines PRIORITY_LABELS as p0/p1/p2 only -- does NOT reference legacy labels, so deletion
+  is safe from auto-recreation.
+
+**Deletion:** `gh label delete "priority: high" --yes` (and medium/low). All three confirmed
+removed. Post-delete label list shows only `priority:p0..p3`.
+
+**Side observation (out of scope, flagged for follow-up):** `sync-squad-labels.yml`
+PRIORITY_LABELS list is missing `priority:p3` -- the label exists in the repo but the
+workflow will not re-sync it if deleted. Not in scope for #254 (which is removal-only) but
+worth tracking. `priority:p3` was likely added manually after the workflow was written.
+
+**Takeaway -- label hygiene SOP:**
+1. ALWAYS audit BEFORE delete: `gh label list --limit 100` (default limit 30 lies),
+   `gh issue list --label "X" --state open` (not `--state all`), `gh pr list --label "X"`.
+2. Grep the repo for the label name in workflows, issue templates, CONTRIBUTING, README,
+   and `.squad/`. A label that is mechanically defined in a workflow will silently auto-
+   recreate after manual deletion -- must be removed at the source.
+3. Closed-issue history loss is acceptable if the canonical taxonomy supersedes it.
+   Open-issue label loss is NOT -- would orphan triage signal.
+4. Captured this pattern in `.squad/skills/label-hygiene/SKILL.md` for the team.
+
+**PR:** #315 (filed end-of-session).

--- a/.squad/skills/label-hygiene/SKILL.md
+++ b/.squad/skills/label-hygiene/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: "label-hygiene"
+description: "Safe deletion and lifecycle management for GitHub labels -- audit before destroy, prevent auto-recreation, preserve open-issue triage signal"
+domain: "repo-meta, ci"
+confidence: "medium"
+source: "earned (issue #254, Sprint 12)"
+---
+
+## Context
+
+GitHub repo labels accrete over time -- legacy names, alternate taxonomies, abandoned
+prefixes. Cleaning them up is dangerous if done carelessly: deleting a label in active
+use orphans triage signal on open issues, and labels mechanically defined in workflows
+will silently auto-recreate after manual deletion, making the cleanup a no-op.
+
+This skill applies whenever an agent is asked to:
+- Delete a GitHub label
+- Rename a label
+- Consolidate two label namespaces into one
+- Audit label taxonomy alignment
+
+## Patterns
+
+### Pattern 1 -- Audit before delete (mandatory pre-flight)
+
+Run all three checks in parallel. Each one must come back clean before deletion.
+
+```bash
+# 1. Confirm the label actually exists. ALWAYS use --limit 100; default is 30 and lies.
+gh label list --limit 100 --json name --jq '.[].name' | grep -F "<label-name>"
+
+# 2. Confirm zero OPEN issues use it. --state all hides the signal you need.
+gh issue list --label "<label-name>" --state open --limit 50
+
+# 3. Confirm zero OPEN PRs use it.
+gh pr list --label "<label-name>" --state open --limit 50
+```
+
+If any OPEN issue or PR has the label, STOP. Either:
+- Migrate the issues/PRs to the canonical label first, OR
+- Defer the deletion and report back to the coordinator.
+
+Closed-issue label loss is acceptable when superseded by a canonical taxonomy.
+Open-issue label loss is NEVER acceptable -- it strips active triage signal.
+
+### Pattern 2 -- Grep for mechanical definitions (prevent auto-recreation)
+
+Workflows that sync labels will silently recreate any label they define after manual
+deletion. ALWAYS grep before destroy:
+
+```bash
+rg -i "<label-name>" .github/workflows/
+rg -i "<label-name>" .github/ISSUE_TEMPLATE/
+rg -i "<label-name>" CONTRIBUTING.md README.md
+rg -i "<label-name>" .squad/
+```
+
+For prefix-based label families (e.g., `priority:`), check whether the sync workflow
+is **additive-only** (creates/updates from a hard-coded list) or **destructive**
+(also deletes anything not in the list). On this repo, `sync-squad-labels.yml` is
+additive-only, so labels not in its list survive -- but anything in its list gets
+re-created if manually deleted.
+
+### Pattern 3 -- Delete with `gh label delete --yes`
+
+```bash
+gh label delete "<label-name>" --yes
+```
+
+Then re-run `gh label list --limit 100` to confirm. Take screenshots/logs of the
+before/after state for the PR body.
+
+### Pattern 4 -- Document in CHANGELOG
+
+Add a `### Removed` entry under `## [Unreleased]`. Include the exact label names
+(quoted, including any spaces) and reference the closing issue.
+
+### Pattern 5 -- File the decision
+
+Label taxonomy is a team-relevant decision. Drop a record in
+`.squad/decisions/inbox/{agent}-label-hygiene-{date}.md` declaring:
+- What the canonical taxonomy is now
+- What was deleted
+- Audit evidence (open issue count, workflow grep results)
+- Any out-of-scope follow-up gaps
+
+## Examples
+
+**Issue #254 (this skill's origin):**
+- Three legacy labels existed: `priority: high`, `priority: medium`, `priority: low`.
+- Canonical taxonomy: `priority:p0..p3` (colon-direct, no space).
+- Audit found 18 CLOSED issues used legacy labels, 0 OPEN issues/PRs.
+- Grep found two historical references (a retro doc, decisions.md prose) but no
+  workflow re-creation risk.
+- Deletion executed cleanly; only canonical labels remained post-delete.
+- Side gap found and flagged (not fixed): `sync-squad-labels.yml` PRIORITY_LABELS
+  list is missing `priority:p3`. Out of scope for #254 since it's not legacy cleanup.
+
+## Anti-Patterns
+
+- **Deleting without `--state open` check.** Using `--state all` shows both open AND
+  closed -- the closed count is irrelevant for safety; only the open count gates deletion.
+- **Trusting `gh label list` default limit.** Default is 30. Repos with more labels
+  (this one has ~45) will silently truncate. ALWAYS `--limit 100`.
+- **Skipping the workflow grep.** A workflow that defines the label in code will
+  silently re-create it on next run -- and your "fix" becomes a noisy no-op.
+- **Renaming instead of deleting when consolidating.** GitHub label renames preserve
+  history, but if the canonical name already exists, rename fails and you end up with
+  both labels anyway. Prefer migrate-then-delete.
+- **Deleting `bug`, `enhancement`, `documentation`, `good first issue`, `help wanted`,
+  `question`, `invalid`, `duplicate`, `wontfix`.** These are GitHub defaults and tooling
+  (e.g., issue templates, "good first issue" discovery) keys off them. Leave unless the
+  team has an explicit policy to remove.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Sprint naming convention reverted from letters back to numbers: Q -> Sprint 8-hotfix, R -> Sprint 9, S -> Sprint 10, T -> Sprint 11; next = Sprint 12. Tier 3 full sweep across 21 files (~170 refs). Retro files renamed with `git mv`. First-occurrence `(formerly Sprint X)` aliases added for grep continuity. CONTRIBUTING.md "Sprint Naming Convention" section updated with mapping table and aliasing convention.
 
+### Removed
+- Legacy GitHub labels `priority: high`, `priority: medium`, `priority: low` (with spaces) deleted; canonical taxonomy is now `priority:p0..p3` (closes #254)
+
 ## [0.9.1] - 2026-05-17 -- Sprint 11 (formerly Sprint T): Architecture refresh and tools hardening
 
 ### Fixed


### PR DESCRIPTION
## Summary

Deletes three legacy GitHub labels that predated the canonical `priority:p0..p3` taxonomy and were creating dual-namespace confusion:

- `priority: high` (with space)
- `priority: medium` (with space)
- `priority: low` (with space)

Canonical priority labels (`priority:p0`, `priority:p1`, `priority:p2`, `priority:p3` -- colon-direct, no space) are untouched and remain the sole priority taxonomy.

## Audit results

| Check | Result |
|---|---|
| `gh label list --limit 100` -- all three legacy labels present | YES (confirmed) |
| Canonical `priority:p0..p3` all present | YES (confirmed) |
| OPEN issues using legacy labels | **ZERO** |
| OPEN PRs using legacy labels | **ZERO** |
| All-state PRs using legacy labels | **ZERO** |
| CLOSED issues that historically used legacy labels | 18 (chip-era #178-194) |
| Workflow files referencing legacy names | NONE |
| Issue templates referencing legacy names | NONE |
| `CONTRIBUTING.md` / `README.md` references | NONE |

Closed-issue history loss is acceptable per task scope -- the explicit gate was `any OPEN issue/PR`, which was clean.

## Files touched

- `CHANGELOG.md` -- added `### Removed` entry under `## [Unreleased]`
- `.squad/agents/pluto/history.md` -- Sprint 12 Wave 1 entry + label hygiene SOP takeaways
- `.squad/skills/label-hygiene/SKILL.md` -- **NEW**: captures the audit-before-delete pattern (3 audit queries, mechanical-definition grep, deletion command, anti-patterns)

## gh commands executed

```
gh label list --limit 100 --json name --jq '.[].name'
gh issue list --label "priority: high" --state open --limit 20
gh issue list --label "priority: medium" --state open --limit 20
gh issue list --label "priority: low" --state open --limit 20
gh pr list --label "priority: high" --state all --limit 10
gh pr list --label "priority: medium" --state all --limit 10
gh pr list --label "priority: low" --state all --limit 10
gh label delete "priority: high" --yes
gh label delete "priority: medium" --yes
gh label delete "priority: low" --yes
```

Post-delete verification: `gh label list --limit 100 | grep priority` shows only `priority:p0`, `priority:p1`, `priority:p2`, `priority:p3`.

## Workflow safety check

- `.github/workflows/sync-squad-labels.yml` is **additive-only** (create/update loop, no delete pass). Its `PRIORITY_LABELS` constant defines `priority:p0` / `priority:p1` / `priority:p2` only -- zero legacy references. Deleted labels will NOT auto-recreate on next sync.
- `.github/workflows/squad-label-enforce.yml` keys on the prefix `priority:` (lines 25, 156-158) for mutual-exclusivity logic, not on enumerated names. Unaffected by deletion.

## Out-of-scope follow-up (flagged, NOT fixed here)

`sync-squad-labels.yml` PRIORITY_LABELS is missing `priority:p3` -- the label exists in the repo but the workflow will not re-sync it if manually deleted. Was likely added directly via gh after the workflow was written. Should be tracked as a separate hygiene issue if the team wants the workflow to be the single source of truth.

## Do not merge

Per Sprint 12 Wave 1 dispatch: coordinator merges, not me.

Closes #254