### PR TITLE
docs(donald): document bash test harness pattern (closes #237)

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -454,3 +454,13 @@ both platform branches get the package to maintain the cross-platform parity doc
 - **Files:** `config/dotfiles/.aliases` (header), `README.md` (Shell Aliases section adds a "bash/zsh only -- see header" pointer), `CHANGELOG.md` (Unreleased / Changed entry).
 - **Out of scope (held):** Did NOT rewrite any aliases, did NOT add new aliases, did NOT do shellcheck fixes. Pure documentation.
 - **Lesson:** A "do not chase X" decision is easier to defend when the file itself documents the non-X features it relies on. Header doubles as a reviewer cheat-sheet and as a contract with anyone tempted to `sh ~/.aliases`.
+
+
+### Sprint 12 Wave 2 -- PR #N (closes #237): Test harness pattern docs
+- Documented the bash test harness convention in CONTRIBUTING.md as a new `Test Harness Pattern` top-level section. Convention: tests in `tests/*.sh` use `set -uo pipefail` (NOT `-euo`) so individual assertion failures do not abort the suite; PASS/FAIL state is tallied via counters and the script exits non-zero only when `FAIL > 0`. `-euo` is acceptable when every potentially-failing command is wrapped in `if` / `||`.
+- Covered the gotcha for contributors: a well-meaning `-e` addition to a tally suite breaks it silently because the first failing assertion aborts before the tally can finish; CI sees a partial run.
+- Reference files cited: `test_idempotency.sh` (canonical complex suite + `assert_*` helpers), `test_aliases.sh` (mock subcommands), `test_tool_versions.sh` (smallest minimal), `test_precommit_hygiene.sh` + `test_shared_logging.sh` (valid `-euo` use).
+- Provided a copy-paste skeleton for new `tests/test_<thing>.sh` files: `-uo` + `PASS`/`FAIL` counters + `pass()`/`fail()` one-liners + final `if [ "FAIL" -gt 0 ]; then exit 1; fi`.
+- Authored `.squad/skills/test-harness-pattern/SKILL.md` (confidence: medium, domain: testing). Skill captures the rule, the rule of thumb, the counter-naming variance, the path-setup boilerplate, the helper convention, and four anti-patterns (notably the `((PASS++))` exit-code-1 trap under `set -e`).
+- Cross-link: CONTRIBUTING.md's new section sits between Parallel Agent Work and Group Letter Assignment, so the testing sections cluster.
+- Out of scope (per ticket): refactoring tests, adding new tests, changing `set -*` flags in existing files, PowerShell test harness.

--- a/.squad/skills/test-harness-pattern/SKILL.md
+++ b/.squad/skills/test-harness-pattern/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: "test-harness-pattern"
+description: "Bash test files in tests/*.sh use a tally-counter harness with set -uo pipefail (NOT -euo) so individual assertion failures don't abort the suite."
+domain: "testing"
+confidence: "medium"
+source: "observed"
+---
+
+## Context
+
+dev-setup ships several bash test suites under `tests/*.sh`. Contributors authoring
+a new test (or extending an existing one) need to know two non-obvious conventions:
+
+1. The test files deliberately use `set -uo pipefail` rather than `set -euo
+   pipefail`. The `-e` flag is OFF on purpose.
+2. PASS / FAIL state is tracked by tally counters; the script exits non-zero only
+   after counting every assertion.
+
+A contributor who "fixes" the missing `-e` will break the suite: the first failing
+assertion will abort the script before the tally can finish, hiding the rest of
+the failures from CI.
+
+## Patterns
+
+### The set-flags decision
+
+| Pattern | When to use |
+|---------|-------------|
+| `set -uo pipefail` | Default for new bash tests. Use when the test body invokes scripts or commands that may exit non-zero outside an `if`/`||` guard (e.g., `bash setup.sh`, `bash tools/foo.sh`). |
+| `set -euo pipefail` | Only acceptable when every potentially-failing command is wrapped in `if ...; then`/`else fail; fi` or `cmd || handler`. Three current files use it (`test_nvm_bootstrap.sh`, `test_precommit_hygiene.sh`, `test_shared_logging.sh`) because every assertion is grep-in-an-if. |
+
+Rule: when in doubt, `-uo`. The tally still works either way; `-uo` is the safer
+default because it lets you call subprocesses freely.
+
+### The tally skeleton
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+
+PASS=0
+FAIL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${RESET}: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}FAIL${RESET}: $1"; FAIL=$((FAIL + 1)); }
+
+# ...assertions...
+
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0
+```
+
+### Counter naming
+
+Older suites (`test_aliases.sh`, `test_idempotency.sh`, `test_tool_versions.sh`,
+`test_alias_parity.sh`) use uppercase `PASS` / `FAIL`. Newer suites
+(`test_precommit_hygiene.sh`, `test_shared_logging.sh`) use lowercase `passed` /
+`failed`. Both work. Pick one within a file; don't mix.
+
+### Path setup boilerplate
+
+Every bash test resolves paths relative to the repo root rather than CWD, so the
+suite works regardless of where it's invoked from:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+```
+
+`${BASH_SOURCE[0]}` is preferred over `$0` because it works when the test file is
+sourced (e.g., for shared helper extraction).
+
+### Reusable assertion helpers
+
+When a test does the same shape of check repeatedly, wrap it in an `assert_*`
+helper that tallies internally. `test_idempotency.sh` is the canonical reference:
+
+```bash
+assert_command_exists() {
+  local cmd="$1"
+  local msg="${2:-$cmd is on PATH}"
+  if command -v "$cmd" &>/dev/null; then
+    pass "$msg"
+  else
+    fail "$msg (command not found: $cmd)"
+  fi
+}
+```
+
+Helpers are file-local today. If a helper is reused across 2+ files, move it to
+`tests/lib/` (matches the `scripts/{linux,windows}/lib/` source-of-truth pattern).
+
+## Examples
+
+### Reference files
+
+| File | Style | Notes |
+|------|-------|-------|
+| `tests/test_idempotency.sh` | `-uo` + `PASS`/`FAIL` + `assert_*` helpers | Canonical complex suite. Calls tool scripts directly. |
+| `tests/test_aliases.sh` | `-uo` + `PASS`/`FAIL` + tmux mock | Shows how to mock subcommands inside a tally suite. |
+| `tests/test_tool_versions.sh` | `-uo` + `PASS`/`FAIL` minimal | Smallest reference; good for new contributors. |
+| `tests/test_precommit_hygiene.sh` | `-euo` + `passed`/`failed` | Valid `-euo` use: every assertion is an `if grep -q`. |
+| `tests/test_shared_logging.sh` | `-euo` + `passed`/`failed` | Valid `-euo` use: small file, every check guarded. |
+
+### CHANGELOG-visible discovery PR
+
+PR closing #237 (this skill's authoring trigger) extended CONTRIBUTING.md with
+the `Test Harness Pattern` section; the prose mirrors this skill.
+
+## Anti-Patterns
+
+- **Adding `-e` to a tally-based suite "for safety".** This is the trap. The
+  script will exit on the first `grep -q PATTERN file` that returns 1, before the
+  matching `fail()` runs. The remaining tests never execute, and CI sees a
+  partial run that looks like a different failure mode.
+- **Tallying without exit code at the end.** A test that prints `Results: 5
+  passed, 3 failed` but exits 0 will be reported as green in CI. Always end with
+  `if [ "$FAIL" -gt 0 ]; then exit 1; fi`.
+- **Using bash arithmetic on a pre-incremented counter under `-e`.**
+  `PASS=$((PASS + 1))` when `PASS=0` returns exit code 1 (the expression value
+  was 0 before increment? no -- actually the assignment exit code is fine).
+  Real footgun: `((PASS++))` evaluates to the OLD value of `PASS`; when `PASS=0`,
+  `((PASS++))` is `((0))` which exits 1. Under `set -e` this aborts. Use
+  `PASS=$((PASS + 1))` (the form already in the suite) or `((PASS+=1))`.
+- **ASCII-only matters here too.** Bash test PASS / FAIL lines render on
+  contributors' terminals and CI logs. The output prefixes (`PASS`, `FAIL`,
+  `[PASS]`, `[FAIL]`, `[OK]`, `[X]`) vary across files, but the surrounding code
+  must remain ASCII to satisfy the pre-commit hygiene check on staged files.
+- **Bash test relying on a working directory.** Use the `SCRIPT_DIR` /
+  `REPO_ROOT` boilerplate. Tests that `cd` somewhere mid-run must restore the
+  cwd or fail predictably.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `tests/test_windows_setup.ps1` Group FF (FF-1 through FF-10): idempotency + restore coverage for `scripts/windows/uninstall.ps1` -- 5 static-source checks (managed dotfile list, newest-wins backup selection, Move-Item -Force usage; Linux uninstall.sh parity) + 5 functional checks (newest timestamped .bak.* wins, legacy .bak fallback, second-run idempotency on dotfiles, profile-block removal preserves surrounding content, second-run idempotency on profile). Functional tests run uninstall.ps1 in a child powershell process with USERPROFILE/HOMEDRIVE/HOMEPATH redirected to a tmp HOME so the script's `$HOME` resolves to throwaway state, and pin CWD to a tmp git repo so `git config --unset-all core.hooksPath` cannot affect the user's real config (closes #238)
+- CONTRIBUTING.md `Test Harness Pattern` section: documents the `set -uo` (intentionally NOT `set -euo`) convention for bash tests; failure tally pattern, helper conventions, minimal skeleton (closes #237)
 
 ### Changed
 - ARCHITECTURE.md: rewrote `Script Conventions` section to point at `scripts/{linux,windows}/lib/` as source of truth; documents `source` / dot-source loading + `Read-ToolVersion.ps1` parser pattern (closes #309)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,152 @@ Or list all active worktrees with `git worktree list`.
 
 ---
 
+## Test Harness Pattern
+
+Bash test files in `tests/*.sh` follow a **tally-based harness convention**: each assertion
+increments a `PASS` or `FAIL` counter, the script prints a results line, and the script
+exits non-zero only if `FAIL > 0`. **This is intentional** -- a single failed assertion must
+not abort the rest of the suite, because contributors need to see every failure in one run.
+
+### `set -uo pipefail` vs `set -euo pipefail`
+
+The non-obvious gotcha: most bash test files use `set -uo pipefail` -- **`-e` is
+intentionally OFF**.
+
+| Flag | Behavior |
+|------|----------|
+| `-e` (errexit) | Abort the script on the first command that returns non-zero. |
+| `-u` (nounset) | Error on reference to an unset variable. |
+| `-o pipefail`  | A pipeline returns the first non-zero exit code in the chain. |
+
+If `-e` were on, a single failing assertion (e.g., `grep -q PATTERN file` returning 1
+because the pattern was absent) would kill the script before `fail()` could even
+increment the counter. The remaining tests would never run. The tally model relies on
+each assertion completing AND being counted, regardless of outcome.
+
+**When `-euo pipefail` IS acceptable:** when every potentially-failing command is
+wrapped in `if ...; then ... fi` or `cmd || handler`, `-e` does not fire on that
+command. Three files in the suite (`test_nvm_bootstrap.sh`, `test_precommit_hygiene.sh`,
+`test_shared_logging.sh`) use `-euo` because every assertion is `if grep -q ...; then
+pass; else fail; fi` shaped. Both styles are valid; prefer `-uo` when the test body
+calls subprocesses or scripts that may legitimately exit non-zero outside an `if`.
+
+**Rule of thumb:** if you add a new bash test that calls a script directly (e.g.,
+`bash setup.sh` as part of the test), use `set -uo pipefail` and let the tally
+counters be the source of truth for PASS/FAIL.
+
+### Failure tally pattern
+
+Every bash test file establishes counters at the top and exits based on the tally:
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+
+PASS=0
+FAIL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${RESET}: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}FAIL${RESET}: $1"; FAIL=$((FAIL + 1)); }
+
+# ...assertions invoke pass "..." or fail "..."...
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0
+```
+
+Notes:
+
+- Counter names vary by file (`PASS`/`FAIL` in older tests, `passed`/`failed` in
+  newer ones). Either is fine; pick one and use it consistently within a file.
+- The non-zero exit at the end is what CI sees. Without it, a tally of `5 passed,
+  3 failed` would still report success to CI.
+- Color escapes are conventional but optional. Tests must stay ASCII-only
+  (the `RED`/`GREEN`/`RESET` strings themselves are ASCII -- only the rendered
+  output is colored).
+
+### Helper conventions
+
+Most test files define `pass()` and `fail()` as one-liners (see snippet above).
+Files that test against a complex fixture (e.g., `test_idempotency.sh`) wrap
+common assertions in helpers prefixed with `assert_`:
+
+| Helper | Used in | What it checks |
+|--------|---------|----------------|
+| `assert_command_exists "<cmd>" "<msg>"` | `test_idempotency.sh` | `command -v` resolves the binary; tallies pass/fail with the supplied message. |
+| `assert_file_exists "<path>" "<msg>"` | `test_idempotency.sh` | `[[ -f $path ]]`; tallies pass/fail. |
+| `assert_dir_exists "<path>" "<msg>"` | `test_idempotency.sh` | `[[ -d $path ]]`; tallies pass/fail. |
+| `assert_no_duplicate_lines "<file>" "<pattern>" "<msg>"` | `test_idempotency.sh` | `grep -c <pattern> <file>` returns <= 1. |
+| `assert_idempotent_tool_script "<script>" "<name>"` | `test_idempotency.sh` | Runs the script a second time; expects exit 0 plus an "already installed / configured / skipping" marker. |
+
+These helpers are file-local -- there is no shared `tests/helpers.sh` yet. If a new
+helper is reused across two or more test files, factor it into a shared library
+under `tests/lib/` (matches the `scripts/linux/lib/` + `scripts/windows/lib/`
+source-of-truth pattern; see ARCHITECTURE.md).
+
+### Minimal skeleton
+
+Copy this into a new `tests/test_<thing>.sh` and adapt:
+
+```bash
+#!/usr/bin/env bash
+# tests/test_<thing>.sh -- <one-line description>
+#
+# Usage (from repo root):
+#   bash tests/test_<thing>.sh
+#
+# Exit codes:
+#   0 -- all assertions passed
+#   1 -- one or more assertions failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${RESET}: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}FAIL${RESET}: $1"; FAIL=$((FAIL + 1)); }
+
+# Example assertion
+if [ -f "${REPO_ROOT}/setup.sh" ]; then
+    pass "setup.sh exists at repo root"
+else
+    fail "setup.sh is missing at repo root"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0
+```
+
+### Scope
+
+This convention covers **bash** test files (`tests/*.sh`). PowerShell tests
+(`tests/*.ps1`) use a different harness (`Test-Scenario` blocks in
+`test_windows_setup.ps1`, see Group Letter Assignment below) and are out of scope
+for this section.
+
+For the broader rationale around test isolation and second-run safety, see
+`tests/README.md` (idempotency suite overview).
+
+---
+
 ## Group Letter Assignment (parallel test work)
 
 Behavioral tests in `tests/test_windows_setup.ps1` are organized by alphabetic groups


### PR DESCRIPTION
## Summary

Documents the bash test harness convention used across `tests/*.sh`: tally-based PASS / FAIL counters, `set -uo pipefail` as the default (intentionally NOT `-euo`), and a copy-paste skeleton for new test files. Closes #237.

### What and why

The non-obvious gotcha: a contributor who "fixes" the missing `-e` in a tally-based test breaks the suite silently. The first failing assertion (e.g. `grep -q PATTERN file` returning 1) aborts the script before the tally can finish; the remaining tests never run and CI sees a partial run.

This PR codifies the convention so it stops being tribal knowledge.

## Files touched

- `CONTRIBUTING.md` -- new `## Test Harness Pattern` top-level section (between `Parallel Agent Work` and `Group Letter Assignment`). Covers:
  1. `set -uo` vs `set -euo` distinction (with table of when each is valid)
  2. Failure tally pattern (counter setup + final non-zero exit)
  3. Helper conventions (`assert_command_exists`, `assert_file_exists`, `assert_dir_exists`, `assert_no_duplicate_lines`, `assert_idempotent_tool_script` -- all sourced from `test_idempotency.sh`)
  4. A copy-paste minimal skeleton for new `tests/test_<thing>.sh` files
  5. Scope statement (bash only; PowerShell tests use a separate `Test-Scenario` harness)
- `CHANGELOG.md` -- one `[Unreleased] -> Added` entry referencing the new section.
- `.squad/skills/test-harness-pattern/SKILL.md` -- new skill (confidence: medium, domain: testing). Captures the rule, rule of thumb, counter-naming variance (older `PASS`/`FAIL` vs newer `passed`/`failed`), the `SCRIPT_DIR`/`REPO_ROOT` boilerplate, the helper convention, and four anti-patterns (including the `((PASS++))` exit-code-1 trap under `set -e`).
- `.squad/agents/donald/history.md` -- Sprint 12 Wave 2 entry.

## Verification

Grounded the documentation by reading every bash test in `tests/`:

| File | `set` flags | Counter style | Pattern |
|------|---------------|---------------|---------|
| `test_aliases.sh` | `-uo pipefail` | `PASS`/`FAIL` | Tally + mocked `tmux`; final `[[ "" -eq 0 ]] || exit 1` |
| `test_alias_parity.sh` | `-uo pipefail` | `UNDOCUMENTED_DRIFT` (custom) | Single binary check; exits non-zero on drift |
| `test_idempotency.sh` | `-uo pipefail` | `PASS`/`FAIL` | Tally + `assert_*` helpers; canonical complex suite |
| `test_tool_versions.sh` | `-uo pipefail` | `PASS`/`FAIL` | Tally; smallest minimal reference |
| `test_nvm_bootstrap.sh` | `-euo pipefail` | `PASS`/`FAIL` | Tally; every check is `if grep -q` shaped |
| `test_precommit_hygiene.sh` | `-euo pipefail` | `passed`/`failed` | Tally; every check is `if` shaped; ends `echo "All tests PASSED"` |
| `test_shared_logging.sh` | `-euo pipefail` | `passed`/`failed` | Tally; every check is `if grep -q` shaped |

Both styles documented honestly -- `-uo` is the recommended default; `-euo` is acceptable when every potentially-failing command is wrapped in `if` / `||`.

ASCII check: all new content is pure ASCII (verified via byte scan of the touched files; pre-existing non-ASCII bytes in `CONTRIBUTING.md` are unchanged).

## Out of scope

- Refactoring existing tests
- Adding new tests
- Changing `set -*` flags in existing files
- PowerShell test harness (separate convention, separate ticket if needed)

Closes #237