### PR TITLE
docs(mickey): refresh README.md for Sprints 8-12 changes (closes #306)

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -1170,3 +1170,40 @@ needed for this design-pass PR until merge.
 - CHANGELOG.md (+1 line under Unreleased / Changed)
 
 **Commit:** `docs(mickey): document Windows orchestrator Dependency Order chain in ARCHITECTURE.md (closes #310)`
+
+
+### 2026-05-17T03:55-04:00 -- Sprint 12 Wave 3 -- README refresh (#306)
+
+**Issue:** #306 -- docs(readme): refresh README.md to reflect Sprints 8-12 changes
+**Branch:** squad/306-readme-refresh (worktree: dev-setup-306)
+**Mode:** SOLO dispatch, Wave 3
+
+**What changed in README.md:**
+1. GitHub Authentication blockquote now names both `scripts/linux/tools/auth.sh` and `scripts/windows/tools/auth.ps1` (PR #297 moved auth.ps1 into per-tool layout; README previously referenced only auth.sh).
+2. Repo Structure tree: Windows `scripts/windows/tools/` listing now includes `auth.ps1` and `dotfiles.ps1`; total file count corrected from 9 to 11 (verified via Get-ChildItem). Also added `uninstall.ps1` to the Windows subtree.
+3. `.tool-versions` Version Pinning section: example block now reflects all 7 pins (added `squad-cli 0.9.4` and `gh 2.92.0`); narrative names this file as the single source of truth including `nvm-windows` and points at the canonical parsers (`read-tool-version.sh` POSIX, `Read-ToolVersion.ps1` PowerShell `Get-ToolVersion`).
+4. `.squad/` tree entry expanded with 4 sub-entries (agents/, decisions.md + fold note, retros/, `...`) and a "see ARCHITECTURE.md" redirect; dropped misleading "(not shipped)" qualifier in favor of "committed; not installed onto end-user machines".
+5. Contributing section: now names the 9-agent roster (5 engineering, 4 process) and adds bullet links to ARCHITECTURE.md / CONTRIBUTING.md / CHANGELOG.md with one-line scope blurbs each. Mentions numeric sprint naming + `(formerly Sprint X)` aliasing convention in the CHANGELOG bullet.
+
+**Verification methodology:**
+Each change was grounded by reading the cited file:
+- `scripts/windows/tools/auth.ps1` (confirmed file exists at per-tool location; matches CHANGELOG #292 move)
+- `.tool-versions` (read full file; 7 pins confirmed)
+- `.squad/team.md` (confirmed 9-member roster; Doc + Jiminy present)
+- `.squad/decisions.md` + `.squad/decisions-archive.md` (workflow + archive file present at 122 KB)
+- `.squad/retros/` (confirmed dir + 5 retro files, pre-commit allow-list per CHANGELOG #189)
+- `CHANGELOG.md` (Sprint 8 through Sprint 11 entries; numeric convention with `(formerly Sprint X)` aliases per Sprint 12 Wave 2)
+- `ARCHITECTURE.md` (cross-ref target; #310 Windows dependency order + #309 Script Conventions sections live)
+- `CONTRIBUTING.md` (cross-ref target; Test Harness Pattern at line 259 per #237, Sprint Naming Convention at line 417, Group Letter Assignment at 405)
+
+**Out-of-scope items observed (filed as follow-ups):**
+- ARCHITECTURE.md still references `scripts/windows/auth.ps1` (top-level) at line 54 of File Structure tree and line 505 of Team Ownership Map -- both should point to `scripts/windows/tools/auth.ps1`. Scope rule (do not touch ARCHITECTURE.md) honored; will file separate issue.
+- README "Git Hooks" section (line 192) claims "three hooks are active" and lists pre-commit/commit-msg/pre-push; `prepare-commit-msg` (PR #212, Sprint 8-hotfix) is missing. Scope: not in the named items list; will file separate issue.
+
+**CWD-pin protocol:** verified pre-edit; every powershell call prefixed by `Set-Location -LiteralPath` + `` guard. All file writes used absolute worktree path prefix. Post-commit main-checkout audit pending.
+
+**Files touched:**
+- README.md (~26 lines changed; 5 surgical edits)
+- CHANGELOG.md (+1 entry under Unreleased / Changed)
+
+**Commit:** `docs(mickey): refresh README.md for Sprints 8-12 changes (closes #306)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md `Test Harness Pattern` section: documents the `set -uo` (intentionally NOT `set -euo`) convention for bash tests; failure tally pattern, helper conventions, minimal skeleton (closes #237)
 
 ### Changed
+- README.md: refreshed to reflect Sprints 8-12 changes (auth.ps1 path move, .tool-versions pinning, expanded squad roster, decisions/retros workflow, numeric sprint naming convention, ARCH/CONTRIB cross-references) (closes #306)
 - ARCHITECTURE.md: documented Windows orchestrator dependency order chain; mirrors the Linux Dependency Order section for parallel install flow visibility (closes #310)
 - ARCHITECTURE.md: rewrote `Script Conventions` section to point at `scripts/{linux,windows}/lib/` as source of truth; documents `source` / dot-source loading + `Read-ToolVersion.ps1` parser pattern (closes #309)
 - Sprint naming convention reverted from letters back to numbers: Q -> Sprint 8-hotfix, R -> Sprint 9, S -> Sprint 10, T -> Sprint 11; next = Sprint 12. Tier 3 full sweep across 21 files (~170 refs). Retro files renamed with `git mv`. First-occurrence `(formerly Sprint X)` aliases added for grep continuity. CONTRIBUTING.md "Sprint Naming Convention" section updated with mapping table and aliasing convention.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd dev-setup
 bash setup.sh
 ```
 
-> **GitHub Authentication:** During setup, `auth.sh` checks whether you are already authenticated with the GitHub CLI. If not, it launches `gh auth login` interactively so you can complete authentication. In non-interactive environments (CI, GitHub Codespaces, piped stdin), the prompt is skipped automatically and a warning is printed — run `gh auth login` manually after setup completes if you need to authenticate.
+> **GitHub Authentication:** During setup, `scripts/linux/tools/auth.sh` (Linux/macOS/WSL) or `scripts/windows/tools/auth.ps1` (Windows) checks whether you are already authenticated with the GitHub CLI. If not, it launches `gh auth login` interactively so you can complete authentication. In non-interactive environments (CI, GitHub Codespaces, piped stdin), the prompt is skipped automatically and a warning is printed -- run `gh auth login` manually after setup completes if you need to authenticate.
 
 ### Windows (PowerShell)
 
@@ -100,11 +100,13 @@ dev-setup/
 │   │       └── zsh.sh
 │   └── windows/
 │       ├── setup.ps1         — Orchestrator (dot-sources tools/ scripts)
+│       ├── uninstall.ps1     — Idempotent reverse of the installer
 │       └── tools/            — Per-tool install scripts
-│           ├── copilot.ps1, gh.ps1, git.ps1, nvm.ps1
+│           ├── auth.ps1      — GitHub CLI authentication (interactive)
+│           ├── copilot.ps1, dotfiles.ps1, gh.ps1, git.ps1, nvm.ps1
 │           ├── profile.ps1, psmux.ps1, squad-cli.ps1
 │           ├── uv.ps1, vim.ps1
-│           └── (9 files total)
+│           └── (11 files total)
 ├── config/
 │   └── dotfiles/             — Dotfile templates (.aliases, .gitconfig, .editorconfig, etc.)
 │       └── install.sh        — Dotfile installer
@@ -120,7 +122,11 @@ dev-setup/
 │   └── test_windows_setup.ps1
 ├── .devcontainer/            — Dev Container / Codespace configuration
 ├── .github/workflows/        — CI validation and squad automation
-└── .squad/                   — Internal squad coordination (not shipped)
+└── .squad/                   — Squad coordination (committed; not installed onto end-user machines)
+    ├── agents/                 — per-agent charter.md + history.md
+    ├── decisions.md            — append-only decision log; older entries fold to decisions-archive.md
+    ├── retros/                 — sprint retrospectives (committed; pre-commit allow-listed)
+    └── ...                     — see ARCHITECTURE.md for the full breakdown
 ```
 
 Root entry points (`setup.sh`, `setup.ps1`) are thin routers — they detect the OS and delegate to the appropriate script under `scripts/`. They install nothing themselves.
@@ -213,7 +219,7 @@ Use `--no-verify` to bypass hooks in emergencies.
 
 ### Version Pinning
 
-Tool versions are pinned in `.tool-versions` at the repo root (asdf/mise format). Setup scripts read this file directly -- no asdf or mise dependency needed.
+Tool versions are pinned in `.tool-versions` at the repo root (asdf/mise format). This file is the single source of truth for every tool version installed by setup, including `nvm-windows`. Setup scripts read it directly via `scripts/lib/read-tool-version.sh` (POSIX) and `scripts/lib/Read-ToolVersion.ps1` (`Get-ToolVersion`) -- no asdf or mise dependency needed.
 
 ```
 nodejs 22.11.0
@@ -221,6 +227,8 @@ nvm 0.39.7
 nvm-windows 1.2.2
 uv 0.4.18
 copilot-cli 1.0.48
+squad-cli 0.9.4
+gh 2.92.0
 ```
 
 To bump a tool version, edit the version number in `.tool-versions` and re-run setup. Each line is `toolname version`, one per line. Blank lines and lines starting with `#` are ignored.
@@ -231,8 +239,12 @@ To bump a tool version, edit the version number in `.tool-versions` and re-run s
 
 ## Contributing
 
-This repo is maintained by the **dev-setup squad** — a set of specialized AI agents, each owning a slice of the codebase. See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full technical overview, team ownership map, and guide on how to add a new tool.
+This repo is maintained by the **dev-setup squad** -- a team of nine specialized AI agents (Mickey, Donald, Goofy, Pluto, Chip on engineering; Jiminy, Doc, Scribe, Ralph on process and hygiene), each owning a slice of the codebase. Human contributors are welcome too.
+
+- [ARCHITECTURE.md](./ARCHITECTURE.md) -- full technical overview, OS detection logic, script conventions, Windows dependency order, team ownership map, and a guide for adding a new tool.
+- [CONTRIBUTING.md](./CONTRIBUTING.md) -- contributor workflow: branch naming (`squad/{issue}-{slug}` from `develop`), PR checklist, Conventional Commits, test harness pattern, sprint naming convention.
+- [CHANGELOG.md](./CHANGELOG.md) -- release history in Keep a Changelog format. Sprints use numeric naming (Sprint 1 through Sprint 12); historical letter-named sprints (Q, R, S, T) appear as `Sprint N (formerly Sprint X)` aliases for grep continuity.
 
 ---
 
-For deeper technical detail — OS detection logic, script conventions, decision records — see [ARCHITECTURE.md](./ARCHITECTURE.md).
+For deeper technical detail -- OS detection logic, script conventions, decision records -- see [ARCHITECTURE.md](./ARCHITECTURE.md).


### PR DESCRIPTION
## Summary

Refresh README.md to reflect changes accumulated across Sprints 8-12. Five surgical edits, no structural refactor.

1. **GitHub Authentication blockquote** -- now names both `scripts/linux/tools/auth.sh` (Linux/macOS/WSL) and `scripts/windows/tools/auth.ps1` (Windows). PR #297 moved `auth.ps1` into the per-tool layout; the README previously referenced only `auth.sh`.
2. **Repo Structure tree** -- Windows `scripts/windows/tools/` listing now includes `auth.ps1` and `dotfiles.ps1`; total file count corrected from 9 to 11 (verified by `Get-ChildItem`: 11 files). `uninstall.ps1` added to the Windows subtree.
3. **Version Pinning section** -- `.tool-versions` example block now lists all 7 pins (added `squad-cli 0.9.4` and `gh 2.92.0` to match the real file). Narrative names this file as the single source of truth (including `nvm-windows`) and points at the canonical parsers (`scripts/lib/read-tool-version.sh` POSIX, `scripts/lib/Read-ToolVersion.ps1` `Get-ToolVersion`).
4. **`.squad/` tree entry** -- expanded with `agents/`, `decisions.md` (with fold-to-archive note), `retros/` (pre-commit allow-listed), and a redirect to `ARCHITECTURE.md` for the full breakdown. Dropped the misleading "(not shipped)" qualifier in favor of "committed; not installed onto end-user machines".
5. **Contributing section** -- names the nine-agent roster (5 engineering: Mickey/Donald/Goofy/Pluto/Chip + 4 process: Jiminy/Doc/Scribe/Ralph; Doc and Jiminy joined since the last README refresh) and links `ARCHITECTURE.md` / `CONTRIBUTING.md` / `CHANGELOG.md` with scope blurbs. Mentions numeric sprint naming + `(formerly Sprint X)` aliasing convention.

## Verification

Each change was grounded by reading the cited file (no inference, no memory):

| Cited change | File(s) read | Result |
|---|---|---|
| auth.ps1 path move (PR #297) | `scripts/windows/tools/auth.ps1`, CHANGELOG.md #292 entry | File at per-tool location confirmed; CHANGELOG line 36 confirms move |
| `.tool-versions` pinning | `.tool-versions` (full file) | 7 pins: nodejs, nvm, nvm-windows, uv, copilot-cli, squad-cli, gh |
| Squad roster growth | `.squad/team.md` Members table | 9 active members confirmed; Doc + Jiminy present |
| Decisions workflow | `.squad/decisions.md` (57 KB live), `.squad/decisions-archive.md` (122 KB) | Both files present; fold-to-archive header in live file |
| Retros directory | `.squad/retros/` (5 retro files) | Confirmed; pre-commit allow-list per CHANGELOG #189 |
| Numeric sprint naming | CHANGELOG.md (lines 1-90) | Numeric Sprint 1-11 entries; `(formerly Sprint X)` aliases confirmed |
| ARCH cross-ref targets | ARCHITECTURE.md (#310 Windows Dependency Order, #309 Script Conventions) | Both sections live |
| CONTRIB cross-ref targets | CONTRIBUTING.md Test Harness Pattern (L259, #237), Sprint Naming Convention (L417), Group Letter Assignment (L405) | All sections live |
| `.aliases` bash/zsh-only | README L155 (existing wording) | Already correctly documents bash/zsh-only since #236 -- no change required |

## Files touched

- `README.md` (~26 line delta; 5 surgical edits)
- `CHANGELOG.md` (+1 entry under `## [Unreleased]` -> `### Changed`)
- `.squad/agents/mickey/history.md` (+1 Sprint 12 Wave 3 entry; hygiene tail)

## Out of scope (will file follow-ups)

Two stale references discovered during verification but **not** touched per scope rules:

1. **ARCHITECTURE.md still references `scripts/windows/auth.ps1` (top-level)** at L54 (File Structure tree) and L505 (Team Ownership Map). Both should point to `scripts/windows/tools/auth.ps1`. Scope: `DO NOT touch ARCHITECTURE.md`.
2. **README "Git Hooks" section (L192) claims "three hooks are active"** and lists pre-commit / commit-msg / pre-push. `prepare-commit-msg` (PR #212, Sprint 8-hotfix) is the fourth active hook and is missing from the listing. Scope: hook documentation was not in the named change list.

Follow-up issues to be filed by coordinator after merge.

## CWD-pin / worktree-isolation compliance (Jiminy #310 remediation)

- Every `powershell` call started with the 3-line CWD guard and `\` throw.
- Every file write used the absolute worktree path prefix; no bare `.squad/...` relatives.
- **Post-commit audit of main checkout** (`C:\Users\Earl Tankard\Coding\dev-setup`): clean (zero modified files reported). Worktree isolation preserved.

Closes #306
