### PR TITLE
docs: fix ARCH auth.ps1 path and README hooks count (#325, #326)

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -1215,3 +1215,19 @@ Cut 0.9.2 from elease/0.9.2 (based on develop @ 5e0fb53). Folded [Unreleased] -
 **Worktree-isolation lesson learned:** My own #310 PR earlier this sprint violated the CWD-pin discipline and triggered cross-worktree write contamination, which surfaced in Jiminy's audit and forced remediation. By Wave 3 #306 I corrected the protocol: Set-Location -LiteralPath + path-mismatch guard at the top of every powershell tool call, plus full absolute path prefixes on every file write. That discipline carried through this 0.9.2 release cut clean -- no main-checkout drift, no stray edits outside the release worktree. The lesson is now codified in Sprint 12 retro and the CWD-pin block is part of every Mickey dispatch brief going forward.
 
 **Job ends here:** Coordinator merges this release/0.9.2 -> develop PR, then opens develop -> main with regular merge, tags  .9.2, and runs gh release create --target main. I do not touch main or tag anything.
+
+
+## 2026-05-17 Sprint 13 Wave 1 (#325, #326)
+
+Shipped two narrow doc fixes batched into one PR on `squad/325-326-doc-fixes` (off develop @ 38e9c79):
+
+- **#325 ARCHITECTURE.md auth.ps1 path:** corrected both stale references (file-structure tree ~L54 and team-ownership map ~L505) from `scripts/windows/auth.ps1` to `scripts/windows/tools/auth.ps1`. Annotated the tree entry with `(moved from top-level in PR #297)` so the move is discoverable. Verified zero remaining `scripts/windows/auth.ps1` matches in the file.
+- **#326 README.md hooks count:** verified `hooks/` directory contents (commit-msg, pre-commit, pre-push, prepare-commit-msg = 4 files) before editing. Changed `three hooks are active` -> `four hooks are active` and inserted a `prepare-commit-msg` subsection between `commit-msg` and `pre-push`, describing the merge/revert subject rewrite behaviour (sourced from the hook's own header comment). PR #212 reference included in CHANGELOG.
+
+Both issues were originally surfaced as out-of-scope observations in my own Sprint 12 Wave 3 #306 history entry -- the filed issues paid off this sprint with a single small PR.
+
+**CWD-pin protocol:** verified pre-edit; every powershell call prefixed by `Set-Location -LiteralPath` + drift guard. All edits used absolute worktree path prefix. Post-commit main-checkout audit clean.
+
+**Files touched:** ARCHITECTURE.md (2 lines), README.md (2 chunks), CHANGELOG.md (+2 Unreleased/Fixed entries), .squad/agents/mickey/history.md (this entry), .squad/decisions/inbox/mickey-w1-2026-05-17-issues-325-326.md (new).
+
+**Skill-pattern note:** "batch narrow doc fixes into one PR" -- 2nd application (Sprint 12 also did this). Not formalizing yet; one more application next sprint would justify a skill drop.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,13 +50,13 @@ dev-setup/
 │   │       └── zsh.sh             # Install zsh + set as default shell
 │   │
 │   └── windows/
-│       ├── setup.ps1              # Orchestrator — dot-sources lib + tool modules below
-│       ├── auth.ps1               # GitHub CLI authentication (interactive)
+│       ├── setup.ps1              # Orchestrator -- dot-sources lib + tool modules below
 │       ├── uninstall.ps1          # Idempotent reverse of the installer
 │       ├── lib/
 │       │   ├── logging.ps1        # Write-Info / Write-Ok / Write-Warn / Write-Err + Assert-LastExit
-│       │   └── path.ps1           # Refresh-SessionPath — re-reads Machine+User PATH from registry
+│       │   └── path.ps1           # Refresh-SessionPath -- re-reads Machine+User PATH from registry
 │       └── tools/                  # Per-tool installers (orchestrator + 10 modules; PR #195 split)
+│           ├── auth.ps1           # GitHub CLI authentication (interactive; moved from top-level in PR #297)
 │           ├── copilot.ps1        # GitHub Copilot CLI (pin from .tool-versions)
 │           ├── dotfiles.ps1       # Apply config/dotfiles/ on Windows
 │           ├── gh.ps1             # GitHub CLI (pin from .tool-versions)
@@ -502,7 +502,7 @@ Permanent cross-agent decisions live in `.squad/decisions/*.md` (e.g., `doc-and-
 | `scripts/windows/setup.ps1` | Goofy | #2, #195 |
 | `scripts/windows/lib/` | Goofy | #195 |
 | `scripts/windows/tools/` | Goofy | #195 |
-| `scripts/windows/auth.ps1` | Goofy | #2 |
+| `scripts/windows/tools/auth.ps1` | Goofy | #2 |
 | `scripts/windows/uninstall.ps1` | Goofy | — |
 | `hooks/pre-commit` | Goofy | #138 |
 | `hooks/prepare-commit-msg` | Goofy | #212 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- docs(architecture): correct stale top-level path for auth.ps1; reflects post-PR #297 move to tools/ (#325)
+- docs(readme): correct active git hooks count from three to four; lists prepare-commit-msg post-PR #212 (#326)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Both `setup.sh` and `setup.ps1` automatically configure git to use this repo's h
 git config core.hooksPath hooks
 ```
 
-No manual copying needed. After running setup, three hooks are active:
+No manual copying needed. After running setup, four hooks are active:
 
 ### `pre-commit`
 
@@ -204,6 +204,10 @@ type(scope): description
 ```
 
 Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `revert`. Hard reject on non-conforming messages.
+
+### `prepare-commit-msg`
+
+Rewrites git's auto-generated merge/revert commit messages into Conventional Commits form so `commit-msg` can validate them (e.g. `Merge pull request #N from USER/BRANCH` -> `merge(pr): #N from USER/BRANCH`, `Revert "SUBJECT"` -> `revert: SUBJECT`). Non-matching messages are left unchanged.
 
 ### `pre-push`
 


### PR DESCRIPTION
## Summary

Two narrow doc fixes batched into one PR (Sprint 13 Wave 1).

### Fix 1 -- ARCHITECTURE.md auth.ps1 path (#325)
Corrected stale references to scripts/windows/auth.ps1 (top-level) so they point at the post-PR #297 location scripts/windows/tools/auth.ps1. Two occurrences updated: file-structure tree (~L54) and team-ownership map (~L505). The tree entry now carries a `(moved from top-level in PR #297)` annotation to make the move discoverable.

### Fix 2 -- README.md hooks count (#326)
- `three hooks are active` -> `four hooks are active`
- Added a `prepare-commit-msg` subsection between `commit-msg` and `pre-push`, describing the merge/revert subject rewriter added in PR #212 (Sprint 8-hotfix).
- Verified `hooks/` directory listing matches: commit-msg, pre-commit, pre-push, prepare-commit-msg (4 files).

## CHANGELOG
Two entries under `[Unreleased] / Fixed`.

## Out of scope
- Hooks scripts themselves (that's #322).
- Other ARCH / README content.

Closes #325
Closes #326