### PR TITLE
feat(hooks): extend pre-commit ASCII scan to .md and .sh (#322 part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - docs(architecture): correct stale top-level path for auth.ps1; reflects post-PR #297 move to tools/ (#325)
 - docs(readme): correct active git hooks count from three to four; lists prepare-commit-msg post-PR #212 (#326)
+- hooks(pre-commit): extend non-ASCII scan to include .md and .sh files (was .ps1 only, allowing 134 non-ASCII hits to land in ARCHITECTURE.md) (#322 part B)
 
 ### Removed
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,7 +2,7 @@
 # pre-commit hook: hygiene checks + shellcheck
 # Checks (ordered fastest-first):
 #   1. Branch ancestry (squad/* must descend from develop)
-#   2. ASCII-only on staged *.ps1 files
+#   2. ASCII-only on staged *.ps1, *.md, *.sh files
 #   3. Rogue path check under .squad/
 #   4. Staged inbox file check (.squad/decisions/inbox/ should be gitignored)
 #   5. Refuse commits directly on develop/main/master
@@ -34,12 +34,17 @@ case "$CURRENT_BRANCH" in
 esac
 
 # ---------------------------------------------------------------------------
-# Check 2: ASCII-only on staged *.ps1 files
+# Check 2: ASCII-only on staged *.ps1, *.md, *.sh files
+#
+# Scanned extensions:
+#   .ps1 -- PS 5.1 on Windows uses CP1252; non-ASCII breaks string literals
+#   .md  -- docs are the dominant source of em-dash / smart-quote leakage
+#   .sh  -- shell scripts; em-dashes from copy-paste can break here-docs / strings
 # ---------------------------------------------------------------------------
-PS1_STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep '\.ps1$' || true)
-if [ -n "$PS1_STAGED" ]; then
+ASCII_STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ps1|md|sh)$' || true)
+if [ -n "$ASCII_STAGED" ]; then
   ASCII_FAIL=0
-  for file in $PS1_STAGED; do
+  for file in $ASCII_STAGED; do
     # Use staged content (not working tree) via git show
     # grep -P with hex range works in git-bash (ships GNU grep with PCRE)
     # Do NOT set LC_ALL=C with -P (breaks on git-bash). Default UTF-8 locale is fine.
@@ -47,9 +52,11 @@ if [ -n "$PS1_STAGED" ]; then
     if [ -n "$NON_ASCII" ]; then
       if [ "$ASCII_FAIL" -eq 0 ]; then
         echo ""
-        echo "ERROR: Non-ASCII bytes detected in staged PowerShell file(s)."
+        echo "ERROR: Non-ASCII bytes detected in staged file(s)."
+        echo "  Scanned extensions: .ps1 (PowerShell), .md (Markdown), .sh (shell)."
         echo "  PS 5.1 on Windows uses CP1252 -- non-ASCII bytes (em dashes, smart quotes)"
-        echo "  break string literals at byte 0x94. Use ASCII equivalents."
+        echo "  break string literals at byte 0x94. Markdown / shell sources should also"
+        echo "  stay ASCII-clean to keep grep / sed / diff portable across locales."
         echo ""
       fi
       echo "  $file:"
@@ -61,7 +68,9 @@ if [ -n "$PS1_STAGED" ]; then
   if [ "$ASCII_FAIL" -ne 0 ]; then
     echo "  Fix: replace non-ASCII characters with ASCII equivalents."
     echo "    em dash (U+2014) -> --"
+    echo "    en dash (U+2013) -> -"
     echo "    smart quotes -> straight quotes"
+    echo "    ellipsis (U+2026) -> ..."
     echo ""
     exit 1
   fi

--- a/tests/test_precommit_hygiene.sh
+++ b/tests/test_precommit_hygiene.sh
@@ -4,7 +4,7 @@
 #
 # Covers:
 #   Check 1: Branch ancestry (squad/* must descend from develop)
-#   Check 2: ASCII-only on staged *.ps1 files
+#   Check 2: ASCII-only on staged *.ps1, *.md, *.sh files
 #   Check 3: Rogue path check under .squad/
 #   Check 4: Staged inbox file check
 #   Check 5: Protected branch refuse (develop/main/master)
@@ -101,10 +101,10 @@ else
 fi
 
 # ===========================================================================
-# Check 2 Tests: ASCII-only on staged .ps1 files
+# Check 2 Tests: ASCII-only on staged .ps1 / .md / .sh files
 # ===========================================================================
 echo ""
-echo "=== Check 2: ASCII-only .ps1 ==="
+echo "=== Check 2: ASCII-only .ps1 / .md / .sh ==="
 
 # Test 2a: FAIL - .ps1 with non-ASCII
 T2A_DIR="${TMPDIR_BASE}/t2a"
@@ -131,16 +131,52 @@ else
   fail "T2b: .ps1 with ASCII-only passes"
 fi
 
-# Test 2c: PASS - non-.ps1 file with non-ASCII is allowed
+# Test 2c: FAIL - .md with non-ASCII (em-dash) is now rejected (#322 part B)
 T2C_DIR="${TMPDIR_BASE}/t2c"
 setup_test_repo "$T2C_DIR"
-git checkout -q -b pluto/non-ps1
+git checkout -q -b pluto/md-nonascii
 printf 'hello \xe2\x80\x94 world\n' > notes.md
 git add notes.md
 if sh "$HOOK" >/dev/null 2>&1; then
-  pass "T2c: non-.ps1 with non-ASCII is allowed"
+  fail "T2c: .md with non-ASCII bytes should fail"
 else
-  fail "T2c: non-.ps1 with non-ASCII is allowed"
+  pass "T2c: .md with non-ASCII bytes fails"
+fi
+
+# Test 2d: FAIL - .sh with non-ASCII (em-dash) is rejected (#322 part B)
+T2D_DIR="${TMPDIR_BASE}/t2d"
+setup_test_repo "$T2D_DIR"
+git checkout -q -b pluto/sh-nonascii
+printf 'echo "hello \xe2\x80\x94 world"\n' > script.sh
+git add script.sh
+if sh "$HOOK" >/dev/null 2>&1; then
+  fail "T2d: .sh with non-ASCII bytes should fail"
+else
+  pass "T2d: .sh with non-ASCII bytes fails"
+fi
+
+# Test 2e: PASS - non-scanned extension (.txt) with non-ASCII is allowed
+T2E_DIR="${TMPDIR_BASE}/t2e"
+setup_test_repo "$T2E_DIR"
+git checkout -q -b pluto/txt-nonascii
+printf 'hello \xe2\x80\x94 world\n' > notes.txt
+git add notes.txt
+if sh "$HOOK" >/dev/null 2>&1; then
+  pass "T2e: non-scanned extension (.txt) with non-ASCII is allowed"
+else
+  fail "T2e: non-scanned extension (.txt) with non-ASCII is allowed"
+fi
+
+# Test 2f: PASS - .md with ASCII-only passes
+T2F_DIR="${TMPDIR_BASE}/t2f"
+setup_test_repo "$T2F_DIR"
+git checkout -q -b pluto/md-ascii
+echo 'hello -- world' > notes.md
+git add notes.md
+if sh "$HOOK" >/dev/null 2>&1; then
+  pass "T2f: .md with ASCII-only passes"
+else
+  fail "T2f: .md with ASCII-only passes"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Issue #322 part B (Mickey). Extends `hooks/pre-commit` Check 2 (non-ASCII guard) to scan `.md` and `.sh` files in addition to `.ps1`. Goofy owns part A (the actual content sweep) in a parallel sibling worktree.

## Root cause

The hook globbed only `*.ps1`, so non-ASCII characters silently landed in:
- `ARCHITECTURE.md` -- 134 non-ASCII hits
- `README.md` -- 60
- `CONTRIBUTING.md` -- 12

This PR prevents regression once Goofy's sweep merges.

## Changes

**`hooks/pre-commit` Check 2** (lines changed: ~14 swapped, ~10 added):
- Glob regex: `\.ps1$` -> `\.(ps1|md|sh)$`
- Error message generalized: "PowerShell file(s)" -> "staged file(s)" with cited extension list
- Help text adds en-dash (U+2013) and ellipsis (U+2026) -> ASCII hints

**`tests/test_precommit_hygiene.sh`** (26/26 PASS):
- T2c flipped: `.md` with non-ASCII now expected to FAIL (was: allowed)
- T2d added: `.sh` with non-ASCII expected to FAIL
- T2e added: non-scanned extension (`.txt`) still allowed
- T2f added: `.md` ASCII-only passes

**`CHANGELOG.md`**: entry under `[Unreleased]` -> `### Fixed`.

## File extensions added to glob

| Ext   | Reason                                                  |
|-------|---------------------------------------------------------|
| `.md`  | The explicit gap behind #322 (134 hits in ARCHITECTURE) |
| `.sh`  | Defensive: em-dashes via copy-paste break here-docs     |
| `.py`  | Skipped: no `.py` files exist in repo                 |
| `.yml` | Skipped: low risk, false-positive risk in CI templates  |

## Test demo proof

Created `test-em-dash.md` with em-dash byte (U+2014, `E2 80 94`) and attempted to commit. Hook output:

```
ERROR: Non-ASCII bytes detected in staged file(s).
  Scanned extensions: .ps1 (PowerShell), .md (Markdown), .sh (shell).
  PS 5.1 on Windows uses CP1252 -- non-ASCII bytes (em dashes, smart quotes)
  break string literals at byte 0x94. Markdown / shell sources should also
  stay ASCII-clean to keep grep / sed / diff portable across locales.

  test-em-dash.md:
    1:Test -- em-dash here.   [byte position cited, U+2014 visible]

  Fix: replace non-ASCII characters with ASCII equivalents.
    em dash (U+2014) -> --
    en dash (U+2013) -> -
    smart quotes -> straight quotes
    ellipsis (U+2026) -> ...
```

Exit code: **1**. Test file reset + deleted post-demo.

## Test suite

``
Passed: 26
Failed: 0
==========================================
All tests PASSED
``

(Full output: includes 5 Check-2 ASCII tests now -- T2a, T2b, T2c, T2d, T2e, T2f.)

## Coordination with Goofy (#322 part A)

- Goofy's worktree (`squad/322-goofy-md-sweep`) sweeps `.md` content; he does NOT touch `hooks/pre-commit`.
- This PR touches ONLY `hooks/pre-commit`, `tests/test_precommit_hygiene.sh`, `CHANGELOG.md`.
- Predictable CHANGELOG conflict: I wrote under `### Fixed`; Goofy will likely write under `### Changed`. Resolve at rebase.

## Deferred items

- `.squad/agents/mickey/history.md` hygiene-tail append: the file already contains 60 pre-existing non-ASCII bytes (em-dashes in past entries). My own new hook would block staging it (correct dogfood behavior!). Deferred to a follow-up after Goofy's sweep lands. Decision is captured in `.squad/decisions/inbox/mickey-w2-2026-05-17-hook-extension.md` (local-only, gitignored).

Closes #322

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
