### PR TITLE
docs(mickey): CHANGELOG editorial -- Sprint 13 retro entry placement (#343)

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -114,3 +114,15 @@ This catch-up entry was appended by Jiminy as part of the Sprint 13 Wave 2 post-
 
 ## 2026-05-17 0.9.3 Release Fold
 Cut the 0.9.3 release CHANGELOG fold (Sprint 13 wrap). Renamed [Unreleased] -> [0.9.3] - 2026-05-17 -- Sprint 13: Documentation accuracy and ASCII policy hardening. Created fresh empty [Unreleased] section above it with the four standard subheadings. Preserved all eight Sprint 13 entries verbatim (1 Added, 4 Changed, 3 Fixed, 0 Removed). Theme captures the two structural shifts: doc accuracy (ARCH path #325, README hooks count #326) and ASCII policy hardening (sweep #322A + hook extension #322B). Follows the proven 0.9.1/0.9.2 pattern: PR to develop with regular merge, Coordinator opens develop->main, tags on main. Sprint 13 retro to be written separately by Scribe.
+
+## 2026-05-17 Sprint 14 Wave 1 -- Issue #343: CHANGELOG editorial (Sprint 13 retro placement)
+
+Resolved Jiminy's EOS-audit CONCERN that the Sprint 13 retro pointer (added by Scribe PR #339 AFTER 0.9.3 was tagged at edc67e2) sat in `[Unreleased]` while prior-sprint convention places retros under their own sprint's release section. Chose Option A: retroactive fold into `[0.9.3] ### Added` to match Sprint 11 retro (under `[0.9.1]`) and Sprint 12 retro (under `[0.9.2]`). CHANGELOG is a curated narrative, not a tag-bound ledger; the `0.9.3` tag stays immutable and the editorial edit rides the next regular develop->main merge.
+
+Codified the rule in `.squad/decisions/changelog-retro-placement.md` so future Coordinators have a deterministic playbook: (1) fold post-tag retros into the released section, (2) never re-tag, (3) Lead owns the call at EOS, (4) batch multiple post-tag drops, (5) preferred Sprint 14 dispatch sequencing puts retro PR BEFORE release-cut PR to sidestep this entire class of issue.
+
+**Files touched:** CHANGELOG.md (moved 1 line from `[Unreleased]` to `[0.9.3]` ### Added with retroactive-fold annotation), `.squad/decisions/changelog-retro-placement.md` (new), this entry.
+
+**ASCII discipline:** pre-commit ASCII gate (extended in PR #334) kept happy throughout; byte-scan verified pre-stage.
+
+**Pattern note:** "post-tag retro fold" is now formalized. Watch Sprint 14 wrap for the recommended retro-PR-before-release-cut sequencing.

--- a/.squad/decisions/changelog-retro-placement.md
+++ b/.squad/decisions/changelog-retro-placement.md
@@ -1,0 +1,23 @@
+# CHANGELOG: Sprint retro entry placement
+
+**Decided:** 2026-05-17
+**By:** Mickey (Lead)
+**Triggered by:** Sprint 13 retro (#339) merged after 0.9.3 tag; Jiminy CONCERN in EOS audit.
+
+## Decision
+
+**Option A -- Move the Sprint 13 retro entry to `[0.9.3]`.** CHANGELOG.md is a curated narrative, not a commit-by-commit replay of the tagged ref. Prior-sprint convention places the retro entry under the sprint's release section (Sprint 11 retro lives under `[0.9.1]` line 65; Sprint 12 retro lives under `[0.9.2]` line 51). Diverging from this for Sprint 13 just because PR #339 merged a few hours after the `0.9.3` tag (`edc67e2`) was pushed would create an inconsistent reader experience and bury the retro under a future release header. The tag is immutable; the CHANGELOG-on-develop is a living document and is allowed to be edited retroactively for editorial coherence as long as the change is itself documented (which this decision file does).
+
+## Rule going forward
+
+When a sprint retro PR merges to develop AFTER the sprint's release tag has already been pushed:
+
+1. **Fold the retro entry into the already-released sprint's section** of `CHANGELOG.md` on `develop` (under `### Added`), matching the prior-sprint format `` `.squad/retros/<file>.md`: Sprint N retrospective (#PR; folded retroactively into X.Y.Z -- PR merged after tag) ``.
+2. **Do NOT re-tag the released version.** The tag stays at the commit it was pushed to. The retroactive CHANGELOG edit ships with the next regular `develop -> main` merge.
+3. **The Lead (Mickey) owns this editorial call** at sprint wrap or during EOS audit. Codify each instance via a per-topic file in `.squad/decisions/` so the retroactive edit is auditable.
+4. **If multiple post-tag drops accumulate** before the next release cut, batch them under the released section and reference each PR.
+5. **Coordinator preference:** Scribe should target the retro PR to land BEFORE the release-cut PR whenever possible, which avoids this whole class of issue. Sprint 14 dispatch sequencing should put `retro write -> retro PR merge -> release fold PR -> develop->main merge -> tag` in that order.
+
+## Applied to
+
+- Sprint 13 retro (#339) -- moved from `[Unreleased]` to `[0.9.3]` ### Added with a retroactive-fold annotation referencing this decision file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- squad: Sprint 13 retrospective at .squad/retros/2026-05-17-sprint-13-retro.md
 
 ### Changed
 
@@ -20,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - squad: skill formalizing the worktree-remove-FIRST PR merge pattern; documents the gh CLI quirk and proven 5-of-5 workaround (#317)
+- `.squad/retros/2026-05-17-sprint-13-retro.md`: Sprint 13 retrospective (#339; folded retroactively into 0.9.3 -- PR merged after tag; see `.squad/decisions/changelog-retro-placement.md`)
 
 ### Changed
 


### PR DESCRIPTION
Closes #343

**Option A:** moved the Sprint 13 retro pointer from `[Unreleased]` to `[0.9.3] ### Added` to match prior-sprint convention (Sprint 11 retro under `[0.9.1]`; Sprint 12 retro under `[0.9.2]`); the `0.9.3` tag (`edc67e2`) stays immutable, the CHANGELOG-on-develop is folded retroactively for reader coherence.

Codifies the rule in `.squad/decisions/changelog-retro-placement.md` for future sprints (fold post-tag retros into the released section; never re-tag; preferred Sprint 14 dispatch puts retro PR before release-cut PR).

## Files
- `CHANGELOG.md` -- moved 1 line; `[Unreleased]` is now empty under the 4 standard subheadings, `[0.9.3] ### Added` gains the retro pointer with a retroactive-fold annotation.
- `.squad/decisions/changelog-retro-placement.md` -- new per-topic decision file.
- `.squad/agents/mickey/history.md` -- Sprint 14 W1 entry (15160 B, under 15360 gate).

## ASCII validation
All three files byte-scanned post-edit: 0 non-ASCII bytes. Pre-commit ASCII hook (Sprint 13 PR #334) accepted the commit on first try.