### PR TITLE
chore(pluto): sync-squad-labels.yml follow-ups (#350)

### DIFF
--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -59,13 +59,9 @@ jobs:
 
             core.info(`Found ${members.length} squad members: ${members.map(m => m.name).join(', ')}`);
 
-            // Check if @copilot is on the team
-            const hasCopilot = content.includes('🤖 Coding Agent');
-
             // Define label color palette for squad labels
             const SQUAD_COLOR = '9B8FCC';
             const MEMBER_COLOR = '9B8FCC';
-            const COPILOT_COLOR = '10b981';
 
             // Define go: and release: labels (static)
             const GO_LABELS = [
@@ -93,7 +89,14 @@ jobs:
             const PRIORITY_LABELS = [
               { name: 'priority:p0', color: 'B60205', description: 'Blocking release' },
               { name: 'priority:p1', color: 'D93F0B', description: 'This sprint' },
-              { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
+              { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' },
+              { name: 'priority:p3', color: 'D4E5F7', description: 'Backlog / icebox' }
+            ];
+
+            const PLATFORM_LABELS = [
+              { name: 'platform:linux',   color: '0052CC', description: 'Linux-specific' },
+              { name: 'platform:macos',   color: '0052CC', description: 'macOS-specific' },
+              { name: 'platform:windows', color: '0052CC', description: 'Windows-specific' }
             ];
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
@@ -111,20 +114,12 @@ jobs:
               });
             }
 
-            // Add @copilot label if coding agent is on the team
-            if (hasCopilot) {
-              labels.push({
-                name: 'squad:copilot',
-                color: COPILOT_COLOR,
-                description: 'Assigned to @copilot (Coding Agent) for autonomous work'
-              });
-            }
-
-            // Add go:, release:, type:, and priority: labels
+            // Add go:, release:, type:, priority:, and platform: labels
             labels.push(...GO_LABELS);
             labels.push(...RELEASE_LABELS);
             labels.push(...TYPE_LABELS);
             labels.push(...PRIORITY_LABELS);
+            labels.push(...PLATFORM_LABELS);
 
             // Sync labels (create or update)
             for (const label of labels) {

--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -125,3 +125,39 @@ Then per the run-book:
   engineer knows.
 
 **PR:** (pending push -- worktree branch `squad/347-label-cleanup`).
+
+---
+
+## Sprint 14 W3 -- Issue #350: sync-squad-labels.yml follow-up fixes
+
+**Branch:** `squad/350-sync-workflow-followups`
+**Issue:** #350
+**Status:** Complete.
+
+### What I did
+
+Three mechanical gaps in `sync-squad-labels.yml` surfaced by the #347
+Phase 6 audit, filed as #350 and pulled into Sprint 14 W3.
+
+- **Fix 1 (priority:p3):** Added `priority:p3` to `PRIORITY_LABELS`.
+  Color chosen: `D4E5F7` (light blue, same as `release:backlog`), NOT
+  `0E8A16` (green / go:yes). Rationale: backlog/icebox is a deferral
+  signal, not a readiness signal; light blue groups it with
+  `release:backlog` visually.
+
+- **Fix 2 (PLATFORM_LABELS):** Added `PLATFORM_LABELS` const array for
+  `platform:linux/macos/windows` (color `0052CC`, matching PR #349) and
+  the corresponding `labels.push(...PLATFORM_LABELS)` call.
+
+- **Fix 3 (hasCopilot removal -- Option A):** Removed `COPILOT_COLOR`
+  const, `hasCopilot` content-includes check (which searched for a robot
+  emoji marker that never existed in any real team.md), and the
+  `if (hasCopilot)` conditional push. Dead code from birth; Option A per
+  issue body (Earl specified no @copilot integration plans).
+
+Side-benefit of Fix 3: U+1F916 four-byte sequence removed from YAML.
+Workflow non-ASCII count dropped from 19 to 15 (5 pre-existing em-dashes
+at 3 bytes each remain; those are out of scope -- hook does not scan
+`.yml`).
+
+Decision drop: `.squad/decisions/sync-workflow-followups-2026-05-17.md`

--- a/.squad/decisions/sync-workflow-followups-2026-05-17.md
+++ b/.squad/decisions/sync-workflow-followups-2026-05-17.md
@@ -1,0 +1,145 @@
+# Decision: sync-squad-labels.yml Follow-up Fixes
+
+**Date:** 2026-05-17
+**Issue:** #350 (closes)
+**PR:** squad/350-sync-workflow-followups
+**Sprint:** 14 Wave 3 (pulled from Sprint 15 candidates per Earl's call)
+**Surfaces from:** #347 Phase 6 workflow audit
+
+---
+
+## Context
+
+Three mechanical gaps in `.github/workflows/sync-squad-labels.yml` were
+identified during the #347 Phase 6 audit and filed as #350. The workflow
+was not managing three label groups that exist in the repo:
+`priority:p3`, and the `platform:*` set created in PR #349. Additionally,
+dead code left over from an abandoned @copilot integration path was
+cluttering the script.
+
+---
+
+## Fix 1: Add `priority:p3` to PRIORITY_LABELS (line ~93)
+
+`priority:p3` has existed in the repo since Sprint 12 W1 (#254) but was
+never added to the workflow's `PRIORITY_LABELS` array. Without this entry,
+the workflow cannot re-create the label if it is ever deleted, and will not
+sync description or color changes.
+
+**Entry added:**
+```js
+{ name: 'priority:p3', color: 'D4E5F7', description: 'Backlog / icebox' }
+```
+
+### Color choice rationale
+
+Two options were presented in the issue:
+- `0E8A16` (green) -- same as `go:yes` (Ready to implement)
+- `D4E5F7` (light blue) -- same as `release:backlog` (Not yet targeted)
+
+**Chosen: `D4E5F7`**
+
+Rationale: "Backlog / icebox" is semantically equivalent to
+`release:backlog` -- both signal "not yet targeted / deferred". Using the
+same cool-tone light blue (`D4E5F7`) groups them visually and avoids
+conflating `priority:p3` with `go:yes`, which carries a "ready" signal.
+Green (`0E8A16`) connotes readiness; light blue connotes deferral. The
+choice is self-documenting.
+
+Note: The existing repo label had color `0075CA` and description
+"Enhancement -- nice to have". The workflow will update it to `D4E5F7` /
+"Backlog / icebox" on next sync run per the `updateLabel` path.
+
+---
+
+## Fix 2: Add PLATFORM_LABELS array + push (lines ~96-100, ~122)
+
+Three `platform:*` labels were created in PR #349 (`platform:linux`,
+`platform:macos`, `platform:windows`, all color `0052CC`). The workflow
+had no `PLATFORM_LABELS` array, so these labels were unmanaged -- they
+could not be re-created or synced if deleted.
+
+**Array added after PRIORITY_LABELS:**
+```js
+const PLATFORM_LABELS = [
+  { name: 'platform:linux',   color: '0052CC', description: 'Linux-specific' },
+  { name: 'platform:macos',   color: '0052CC', description: 'macOS-specific' },
+  { name: 'platform:windows', color: '0052CC', description: 'Windows-specific' }
+];
+```
+
+**Push added with the other static label groups:**
+```js
+labels.push(...PLATFORM_LABELS);
+```
+
+Color `0052CC` matches the labels created in PR #349 (confirmed via
+`gh label list --search "platform:"`).
+
+---
+
+## Fix 3: Remove dead `hasCopilot` code (Option A)
+
+Three code blocks were removed:
+
+1. **`const hasCopilot` check** (was line 62-63):
+   ```js
+   // Check if @copilot is on the team
+   const hasCopilot = content.includes('...robot emoji... Coding Agent');
+   ```
+
+2. **`COPILOT_COLOR` const** (was line 68):
+   ```js
+   const COPILOT_COLOR = '10b981';
+   ```
+
+3. **`if (hasCopilot)` conditional push** (was lines 114-121):
+   ```js
+   if (hasCopilot) {
+     labels.push({
+       name: 'squad:copilot',
+       color: COPILOT_COLOR,
+       description: 'Assigned to @copilot (Coding Agent) for autonomous work'
+     });
+   }
+   ```
+
+**Rationale for Option A (remove, not integrate):**
+
+Earl did not specify @copilot integration plans for #350. Option A was the
+explicit fallback in the issue body. The `content.includes()` check searched
+for a robot emoji string that never matched any actual `team.md` content
+(no team.md has ever included that exact emoji + text combination). The
+code was dead from birth. Removing it eliminates 4 bytes of non-ASCII
+(the robot emoji U+1F916 UTF-8 encoding) as a side benefit.
+
+If @copilot integration is later desired, a new issue should be filed to
+design the team.md marker format and workflow behavior explicitly.
+
+---
+
+## Pre-existing non-ASCII em-dashes in workflow YAML
+
+The workflow YAML contains 5 em-dashes on lines 31, 80, 86, 106, 132
+(15 non-ASCII bytes total in UTF-8). These are **deliberately left in
+place** and are out of scope for this PR.
+
+The pre-commit ASCII Check 2 (`grep -nP '[^\x00-\x7f]'`) does NOT scan
+`.yml` files -- its scope is `.ps1`, `.sh`, and `.md` only. Therefore
+these em-dashes do not violate any enforced policy. This was documented in
+the #347 decision drop and confirmed again here.
+
+**Post-Fix 3 workflow YAML non-ASCII byte count: 15**
+(was 19 before Fix 3; delta is exactly 4 bytes -- the U+1F916 UTF-8
+four-byte sequence that was removed with the dead code)
+
+---
+
+## References
+
+- Closes #350
+- Surfaces from #347 Phase 6 audit (Sprint 14 W2)
+- Sprint 14 Wave 3 attribution (pulled from Sprint 15 candidates)
+- PR #349: platform:* labels created (Pluto, Sprint 14 W2)
+- Sprint 12 W1 precedent: #254 / PR #315 (same gap for priority:p3 first noted)
+- `.squad/skills/label-hygiene/SKILL.md`: audit-before-delete SOP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - README refreshed: pre-commit 6-check description (F1), ascii-sweep.py docs (F2), file-tree hand-converted to ASCII (F3), file-tree updated (F4), pre-commit one-liner expanded (F5) (#342)
 - Label taxonomy slimmed from 45 to 32 labels (drop 8 GitHub-default duplicates, 4 stale release version labels, 1 lonely status label; rename area:linux/macos/windows -> platform:*) (#347)
+- sync-squad-labels.yml: add priority:p3 + platform:* to managed labels, remove dead hasCopilot code (#350)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Three mechanical gaps in \.github/workflows/sync-squad-labels.yml\ identified during the #347 Phase 6 workflow audit.

### Fix 1: Add \priority:p3\ to PRIORITY_LABELS

\priority:p3\ has existed in the repo since Sprint 12 W1 but was never added to the workflow. Now managed with color \D4E5F7\ (light blue, matching \elease:backlog\) and description \Backlog / icebox\.

### Fix 2: Add PLATFORM_LABELS array + push

\platform:linux\, \platform:macos\, \platform:windows\ were created in PR #349 (color \