### PR TITLE
docs(pluto): add worktree-base-refresh SKILL.md (#364)

### DIFF
--- a/.copilot/skills/worktree-base-refresh/SKILL.md
+++ b/.copilot/skills/worktree-base-refresh/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: "worktree-base-refresh"
+description: "When the pre-commit branch-ancestry hook rejects a stale sprint branch (cut from an old develop tip), use a 3-phase backup + git reset --hard origin/develop + restore recipe. Avoid git reset --soft -- it leaves the index pinned to the divergent base."
+domain: "git-recovery"
+confidence: "low"
+source: "earned"
+---
+
+## Context
+
+Sprint-scoped squad branches (e.g., `squad/doc-history-sprint-N`) are cut from
+`develop` at sprint kickoff. As the sprint progresses, `develop` moves forward via
+squash-merges of sister PRs. By the time the sprint-scoped branch is ready to
+commit, its base is stale and the pre-commit branch-ancestry hook rejects the
+commit with:
+
+```
+ERROR: Branch ancestry bleed detected.
+
+  Branch '<name>' is not descended from 'develop'.
+```
+
+(Hook source: `hooks/pre-commit`, Check 1.)
+
+This skill applies when:
+- You have staged-but-uncommitted work.
+- The branch has NO unique commits you need to keep (it is effectively a
+  "fresh-cut" branch that never got a commit before develop moved on).
+
+If the branch HAS unique commits you want to preserve, use `git rebase` instead
+(see Anti-Patterns below).
+
+## Patterns
+
+### Why `git reset --soft` is unsafe
+
+Intuition says: "preserve staged files, move HEAD to develop."
+
+But `git reset --soft` moves only HEAD; it leaves the INDEX pinned to the old
+base. Result: `git status` now shows every file that `develop` changed (relative
+to the old base) as `M` -- spurious mass-staging that would commit a reversion
+if you ran `git commit` without careful inspection. With 30+ changed files this
+is nearly impossible to untangle safely.
+
+**Never use `git reset --soft` for base-refresh on a diverged branch.**
+
+---
+
+### The 3-Phase Recovery Recipe
+
+#### Phase 1 -- Backup staged files
+
+Identify which files are staged (`git status --short` -- lines starting with
+`M `, `A `, etc. in the index column). Copy each one to a safe scratch
+directory inside the repo (never `/tmp` -- use a `_tmp_recovery_<slug>` folder
+under `scripts/`).
+
+```powershell
+# Resolve repo root dynamically -- never hardcode a user path
+$repoRoot = (git rev-parse --show-toplevel)
+$tmpDir = Join-Path $repoRoot 'scripts\_tmp_recovery_<slug>'
+New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+Copy-Item '<staged-file-1>' "$tmpDir\<name-1>"
+Copy-Item '<staged-file-2>' "$tmpDir\<name-2>"
+# ... repeat for every staged file
+```
+
+#### Phase 2 -- Hard-reset to origin/develop
+
+```powershell
+git reset --hard origin/develop   # wipes working tree to develop's state
+git --no-pager log --oneline -2   # verify HEAD is now on origin/develop tip
+```
+
+After this step `git status --short` must show an empty output. If it does not,
+stop and investigate before proceeding.
+
+#### Phase 3 -- Restore files and commit
+
+```powershell
+Copy-Item "$tmpDir\<name-1>" '<staged-file-1>' -Force
+Copy-Item "$tmpDir\<name-2>" '<staged-file-2>' -Force
+# ... restore all backed-up files
+
+git add '<staged-file-1>' '<staged-file-2>'
+git status --short   # MUST show ONLY your intended files
+
+git commit -m "<your message>"
+Remove-Item -Recurse -Force $tmpDir   # clean up scratch dir
+```
+
+---
+
+### Acceptance Checks Before Pushing
+
+Run all three checks. If any fails, stop and diagnose before pushing.
+
+```powershell
+# 1. Only intended files staged -- no 30+ M lines
+git status --short
+
+# 2. Only your additions in the diff -- no spurious reversions
+git --no-pager diff HEAD~1
+
+# 3. Branch is now descended from origin/develop (exits 0 on success)
+git merge-base --is-ancestor origin/develop HEAD
+echo "exit code: $LASTEXITCODE"   # must be 0
+```
+
+## Examples
+
+**Sprint 15 -- PR #359 (`doc-history-sprint-15`)**
+
+- Branch cut at `5c5eda4` (Sprint 14 end-of-sprint tip).
+- `develop` advanced to `b471e76` via squash-merges #357 + #358.
+- pre-commit Check 1 rejected the commit with the ancestry-bleed error.
+- Recovery: 3-phase recipe above applied by the Coordinator.
+- Recovery commit: `d3229c8`.
+
+This is the single observed application that established this skill
+(confidence: low). Confidence will graduate to medium on second observation.
+
+## Anti-Patterns
+
+- **`git reset --soft origin/develop`** -- leaves index pinned to old base;
+  produces spurious mass-staging of all files develop changed. Do not use.
+
+- **Committing after `--soft` without inspecting `git status --short`** --
+  you will silently revert a large portion of develop's changes.
+
+- **Using this recipe when the branch has real commits to keep** -- use
+  `git rebase origin/develop` (interactive if needed) to replay commits
+  on top of the new develop tip. This recipe is for zero-unique-commit
+  branches with only staged-but-uncommitted work.
+
+- **If you have time before staging work** -- the cleanest path is always:
+  `git rebase origin/develop` first, then commit on the rebased branch.
+  The 3-phase recipe is the emergency recovery path.
+
+## Related Skills
+
+- `.copilot/skills/git-workflow/SKILL.md` -- squad branching model,
+  worktree setup, develop-first workflow.
+- `hooks/pre-commit` Check 1 -- the branch-ancestry guard that produces
+  the `Branch ancestry bleed detected` error triggering this recipe.
+- Future skill: `worktree-remove-first` (12-of-12 lifetime but not yet
+  formalized -- noted for a separate issue).

--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -168,6 +168,10 @@ Decision drop: `.squad/decisions/sync-workflow-followups-2026-05-17.md`
 
 **Branch:** `squad/367-skill-drift-audit`
 **PR:** #368
+## Sprint 15 -- Issue #364: worktree-base-refresh SKILL.md
+
+**Branch:** `squad/364-worktree-base-refresh-skill`
+**Issue:** #364
 **Status:** Complete.
 
 ### What I did
@@ -225,3 +229,36 @@ skill must follow the rule it teaches. Skill placed in `.copilot/skills/`
 (not `.squad/skills/` as originally suggested) to match the existing 30-skill
 convention. Decision drop at
 `.squad/decisions/inbox/pluto-362-ascii-docs-skill.md`.
+Drafted and landed `.copilot/skills/worktree-base-refresh/SKILL.md` --
+the first formal writeup of the stale-sprint-branch recovery pattern that
+surfaced in Sprint 15 PR #359.
+
+The skill documents:
+- Why the pre-commit branch-ancestry hook (Check 1) fires when a sprint
+  branch is cut from an old develop tip and develop has since advanced.
+- Why `git reset --soft` is unsafe (leaves INDEX pinned to divergent base,
+  spurious mass-staging result).
+- The 3-phase recovery recipe: backup staged files to
+  `scripts/_tmp_recovery_<slug>/`, `git reset --hard origin/develop`,
+  restore + commit + cleanup.
+- Three acceptance checks before pushing (status clean, diff clean,
+  ancestry verified via `git merge-base --is-ancestor origin/develop HEAD`).
+- Anti-patterns and when to use `git rebase` instead.
+
+Confidence set to `low` (1 application: Sprint 15 #359, recovery commit
+`d3229c8`). Will graduate to medium on second observation.
+
+### Key learnings
+
+- **`git reset --soft` on a diverged branch produces a mass-staging trap.**
+  The INDEX is still set relative to the old base tip, so every file develop
+  changed appears as a staged modification. With 30+ changed files this is
+  effectively un-reviewable and risks committing a silent reversion.
+- **`git reset --hard origin/develop` + copy-back is the safe path** when
+  the branch has no unique commits. It fully syncs the working tree and index
+  to develop's state, leaving only the explicitly restored files as staged.
+- **`git merge-base --is-ancestor origin/develop HEAD`** is the canonical
+  post-recovery verification -- exits 0 means ancestry is correct and the
+  hook will pass.
+
+Decision drop: `.squad/decisions/inbox/pluto-364-worktree-base-refresh.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sprint 16 skill drift watchlist audit at `.squad/decisions/pluto-skill-drift-2026-05-17.md`. (#367)
 - New `.copilot/skills/ascii-docs-about-non-ascii/SKILL.md` formalizing the "self-documenting non-ASCII" discipline (medium confidence, 2 observations across Sprint 14 #340 and Sprint 15 #356/#359). (#362)
+- New `.copilot/skills/worktree-base-refresh/SKILL.md` formalizing the stale-sprint-branch recovery pattern from Sprint 15 #359 (low confidence, 1 observation). (#364)
 
 ### Changed
 


### PR DESCRIPTION
Formalizes the 3-phase stale-sprint-branch recovery recipe discovered in Sprint 15 (#359).

## Summary

- New skill: \.copilot/skills/worktree-base-refresh/SKILL.md\
- Documents why \git reset --soft\ is unsafe for base-refresh (index stays pinned to divergent base -> spurious mass-staging)
- 3-phase recipe: backup staged files, \git reset --hard origin/develop\, restore + commit + cleanup
- 3 acceptance checks before pushing (status, diff, \merge-base --is-ancestor\)
- Confidence: low (1 application, Sprint 15 #359). Graduates to medium on next observation.

## Files changed

- \.copilot/skills/worktree-base-refresh/SKILL.md\ (new, 0 non-ASCII bytes)
- \CHANGELOG.md\ (Unreleased -> Added entry)
- \.squad/agents/pluto/history.md\ (Sprint 15 entry appended)

Closes #364