### PR TITLE
docs(squad): clarify merge policy in Jiminy charter

### DIFF
--- a/.squad/agents/jiminy/charter.md
+++ b/.squad/agents/jiminy/charter.md
@@ -38,7 +38,7 @@ What Jiminy checks, by lane:
 
 - Open PRs have `priority:pN` + `squad:{member}` labels
 - Open issues have phase priority label when actionable
-- No squash merges on `develop` or `main` (Earl's standing directive: regular merge commits only)
+- Regular merge commits ONLY for `develop -> main` release cuts and recovery back-merges. Feature/sprint PRs to `develop` use squash merges (Earl's standing directive, clarified 2026-05-17 -- see decisions.md).
 - Conventional Commits format on recent commits (commit-msg hook enforces, but Jiminy spot-checks)
 - PRs include `Co-authored-by: Copilot` trailer when authored via the agent system
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1152,3 +1152,15 @@ PR #368 (skill drift audit) landed on main by mistake at commit 128218a. Forward
 
 Accept all Sprint 16 work as complete. Acknowledge decisions.md gate breach (#371 tracks policy review). Scribe compression of pluto/history.md resolves blocker #2.
 
+---
+
+## 2026-05-17T20:30 Earl directive -- squash-merge policy clarification
+
+**By:** Earl (via Coordinator, Sprint 16 EOS Q&A)
+**What:** Squash merges to `develop` ARE the standing policy. Regular merges apply ONLY to `develop -> main` release cuts (and any back-merge recovery). Jiminy's charter line 41 ("No squash merges on develop or main") was outdated -- update to clarify.
+**Why:** Sprint 16 squash-merge mismatch surfaced by Jiminy-4 EOS audit. Earl confirmed via choice "Charter is outdated -- squash to develop is what I want."
+**Impact:**
+- Jiminy charter line 41 needs rewrite
+- No retroactive changes to past sprints (no history rewriting)
+- This memory should be stored for future sessions
+


### PR DESCRIPTION
Earl directive: squash to develop is standard; regular merge only for develop->main releases.