### PR TITLE
chore(skills): formalize worktree-remove-first + gh-pr-base-develop

### DIFF
--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -44,6 +44,25 @@ How to decide who handles what for the dev-setup project.
 | `squad:jiminy` | Squad hygiene audit, process QA | Jiminy |
 | `squad:doc` | Fact-checking, verification, audit work | Doc |
 
+## Spawn-Prompt Hygiene
+
+Every coordinator spawn prompt that includes a `gh pr create` step MUST
+explicitly instruct the agent to pass `--base develop`. See
+`.squad/skills/gh-pr-base-develop/SKILL.md` for the full rule, the verification
+step (`gh pr view <N> --json baseRefName`), and the recovery recipe if the wrong
+base is used.
+
+Minimum required snippet in every spawn prompt that creates a PR:
+
+```
+**gh pr create MUST pass `--base develop` explicitly.**
+After creation, verify: gh pr view <N> --json baseRefName --jq .baseRefName
+Must equal "develop". If not, close the PR and recreate with --base develop.
+```
+
+See also `.squad/skills/pre-spawn-checklist/SKILL.md` for the full hygiene tail
+template.
+
 ## Rules
 
 1. **Eager by default** -- spawn all agents who could usefully start work, including anticipatory work.

--- a/.squad/skills/gh-pr-base-develop/SKILL.md
+++ b/.squad/skills/gh-pr-base-develop/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: "gh-pr-base-develop"
+description: "Every squad PR must explicitly pass --base develop to gh pr create. Omitting the flag defaults to the repo default branch (main), landing squad work directly on main outside a release cut."
+domain: "repo-meta, release-flow"
+confidence: "high"
+source: "earned (issue #384, Sprint 16 PR #368 incident -- rule is binary)"
+---
+
+## Context
+
+Sprint 16 PR #368 (Pluto-5, skill drift watchlist audit) was created without
+an explicit `--base` flag. The repo default branch is `main`, so `gh pr create`
+silently targeted main instead of develop. The PR merged cleanly on the GitHub
+side -- no guard caught it -- landing Sprint 16 skill work directly on main
+outside of any release cut.
+
+Recovery required:
+1. Checking out develop locally.
+2. Running `git merge origin/main --no-ff --no-verify -m "chore(merge): forward-port #368 from main to develop"`.
+3. The `--no-verify` flag was necessary because the pre-commit hook blocks direct
+   commits on develop. The "merge" Conventional Commits type is also rejected by
+   the commit-msg hook -- using `chore(merge)` as the type is the workaround.
+
+This is a one-line prevention with zero cost. Codified as a skill because the
+failure mode is silent, the recovery is non-trivial, and every squad PR creation
+goes through `gh pr create`.
+
+## Rule
+
+**Every `gh pr create` invocation by a squad agent MUST pass `--base develop`
+explicitly**, unless the PR is a release cut (develop -> main), in which case
+`--base main` is correct and intentional.
+
+There is no ambiguous middle ground: the flag is either present or it is not.
+Confidence is high because the rule is binary and the incident was direct.
+
+## Pre-Flight Check
+
+Before calling `gh pr create`, the agent MUST echo the intended base and confirm:
+
+```powershell
+# Pre-flight: confirm base before creating the PR
+Write-Host "INFO: PR base will be develop (squad work -- not a release cut)"
+gh pr create --base develop --title "..." --body "..."
+
+# Post-creation: verify base is develop
+gh pr view <N> --json baseRefName --jq .baseRefName
+# Must output: develop
+```
+
+If the output is anything other than `develop`, close the PR immediately and
+recreate with `--base develop`.
+
+## Spawn-Prompt Template Snippet
+
+Coordinators MUST include the following block (or equivalent) in every agent
+spawn prompt that involves `gh pr create`:
+
+```
+**gh pr create MUST pass `--base develop` explicitly.**
+Do NOT rely on the repo default branch. Omitting --base targets main silently.
+
+After creation, verify:
+  gh pr view <N> --json baseRefName --jq .baseRefName
+Must equal "develop". If not, close the PR and recreate with --base develop.
+```
+
+## Recovery Recipe
+
+If `--base main` was used by mistake and the PR has already merged:
+
+```bash
+# On develop branch (main checkout, not worktree):
+git fetch origin
+git checkout develop
+git merge origin/main --no-ff --no-verify -m "chore(merge): forward-port #N from main to develop"
+git push origin develop
+```
+
+Notes on the recovery:
+- `--no-verify` bypasses the pre-commit hook that blocks direct commits on develop.
+- Use `chore(merge)` as the Conventional Commits type -- the bare `merge` type
+  is rejected by the commit-msg hook.
+- After pushing, verify `git log --oneline origin/develop | head -5` shows the
+  forward-merge commit and that develop is ahead of main.
+
+## Examples
+
+**Sprint 16 PR #368 incident (the triggering case):**
+Pluto-5 created PR #368 (`squad/367-skill-drift-audit`) without `--base develop`.
+Repo default `main` was silently used. PR merged to main. Recovery: forward-merge
+commit `d102a7c` ("chore(merge): forward-port #368 from main to develop") applied
+on develop with `--no-ff --no-verify`. Sprint 16 retro documents this in the
+"What surprised us" section.
+
+**Sprint 17 PRs #383/#384 (this PR -- meta-discipline application):**
+This very PR (`squad/383-384-skill-formalize`) passes `--base develop` per the
+rule being codified. Verification: `gh pr view <N> --json baseRefName` after
+creation.
+
+## Anti-Patterns
+
+- **Omitting `--base` from `gh pr create`.** Silently targets the repo default
+  branch (main). No warning is printed. The PR appears normal until you inspect
+  `baseRefName`.
+- **Relying on repo settings alone.** Changing the default branch to develop in
+  GitHub settings is a mitigation, not a fix -- it can be changed back, and
+  release-cut PRs intentionally target main. The explicit flag is the only
+  reliable guard.
+- **Checking the base only after merge.** Once merged to main, recovery requires
+  a forward-merge commit with `--no-verify`, which produces a noise commit on
+  develop and risks pre-commit hook failures. Check before merge, not after.
+- **Closing the misrouted PR without forward-merging the content.** If the work
+  was already merged to main, simply closing a new PR on develop does not bring
+  the commits across. The forward-merge step is mandatory.
+
+## Related Skills
+
+- `.squad/skills/worktree-remove-first/SKILL.md` -- the companion merge-sequence
+  skill; both skills are required for a clean squad PR lifecycle
+- `.squad/skills/pre-spawn-checklist/SKILL.md` -- spawn hygiene checklist where
+  this rule must appear as a standing item
+- `.squad/routing.md` -- spawn-prompt hygiene section (updated Sprint 17) references
+  this skill for coordinators
+
+## References
+
+- Issue #384 -- formalization request (Sprint 17)
+- Sprint 16 retro (`.squad/retros/2026-05-17-sprint-16-retro.md`) -- "PR base=main
+  mishap and forward-merge recovery" section
+- PR #368 -- the incident; commit d102a7c is the forward-merge recovery
+- `gh pr create` docs: `gh pr create --help`
+
+**Last reviewed:** 2026-05-17 (Sprint 17, issue #384)

--- a/.squad/skills/worktree-remove-first/SKILL.md
+++ b/.squad/skills/worktree-remove-first/SKILL.md
@@ -1,60 +1,68 @@
 ---
 name: "worktree-remove-first"
-description: "Safe merge sequence for Squad PRs developed in a git worktree -- remove the worktree and delete the local branch BEFORE invoking gh pr merge --delete-branch, to sidestep a deterministic gh CLI quirk that leaves the remote branch ref orphaned"
+description: "Safe merge sequence for Squad PRs developed in a git worktree -- harvest hygiene files, remove the worktree, delete the local branch, THEN invoke gh pr merge --delete-branch. Skipping this order loses inbox files or leaves orphaned remote refs."
 domain: "repo-meta, release-flow"
-confidence: "high"
-source: "earned (issue #317, Sprint 12 -> Sprint 13, 5-of-5 proven)"
+confidence: "medium"
+source: "earned (issue #317 Sprint 12-13, 29+ applications Sprints 12-16)"
 ---
 
 ## Context
 
 When a Squad agent develops a PR in an isolated git worktree (per the
 `worktree-isolation` skill), the local feature branch is checked out inside the
-worktree, not the main checkout. Merging that PR via
-`gh pr merge <N> --delete-branch` while the worktree still owns the branch
-fails 100% deterministically: gh refuses to delete the remote ref (or reports
-"merge failed" / "branch still protected") because it sees the local branch is
-checked out in a working tree. The squash/merge itself succeeds on the GitHub
-side, but the remote-side `--delete-branch` step half-fails, leaving an
-orphaned `origin/squad/<N>-<slug>` ref behind.
+worktree, not the main checkout. Two independent failure modes arise if the
+merge sequence is wrong:
+
+1. **Hygiene loss.** The agent may have dropped files into
+   `.squad/decisions/inbox/` or appended to `history.md` inside the worktree
+   without pushing. Those changes live only in the worktree index. If the
+   worktree is torn down before they are harvested, or if the PR is merged
+   before the coordinator inspects the worktree, those files are silently lost.
+
+2. **Orphaned remote ref.** Calling `gh pr merge <N> --delete-branch` while the
+   worktree still has the branch checked out causes the gh CLI to abort the
+   remote-delete step (or half-fail silently), leaving `origin/squad/<N>-<slug>`
+   behind after the merge commit lands on develop.
 
 This skill applies whenever an agent (or coordinator) is about to merge any
 `squad/*` PR that was developed in a worktree -- which, under the standard
 Squad dispatch flow, is effectively every feature PR.
 
-The pattern was originally tracked as a recurring nuisance in issue #300
-(closed once as "no longer reproducible") and re-surfaced in Sprint 12 Wave 2,
-where it was reproduced 5-of-5 across PRs #320, #321, #323, #324, and #327
-(plus the 0.9.2 release PR #328 using `--merge`). Issue #317 captures the
-formal write-up; this skill is the codification.
+The pattern was originally tracked in issue #300 (closed once as
+"no longer reproducible") and re-surfaced in Sprint 12 Wave 2 across PRs
+#320, #321, #323, #324, #327. Issue #317 is the formal write-up.
+The skill has been applied 29+ times across Sprints 12-16 without a single
+failure when the order is followed.
 
 ## Patterns
 
 ### Pattern 1 -- The worktree-remove-FIRST sequence (mandatory for any worktree-developed PR)
 
-Run these five steps IN ORDER from the MAIN checkout (never from the worktree
+Run these steps IN ORDER from the MAIN checkout (never from the worktree
 being torn down).
 
 ```powershell
-# 0. Harvest. Before destroying the worktree, copy out any uncommitted hygiene
-# files the agent forgot to push (history.md tail, decisions/inbox/ drops).
-# Stage them on develop from the main checkout, or stash and re-push.
+# Step 1. Harvest hygiene files BEFORE touching the worktree.
+# Inspect .squad/decisions/inbox/* and any history.md appends the agent
+# dropped in the worktree but did not push. Copy or cherry-pick them onto
+# develop from the main checkout now, before the worktree is destroyed.
+# If everything is already pushed, this step is a quick ls-and-confirm.
 
-# 1. Remove the worktree. --force handles the case where the agent left a
-# dirty index; you have already harvested in step 0.
+# Step 2. Remove the worktree. --force handles a dirty index; you have
+# already harvested in step 1.
 git worktree remove ..\dev-setup-<N> --force
 
-# 2. Delete the LOCAL feature branch. It is now dangerous to leave around --
-# any future `git checkout` could land you back on it.
+# Step 3. Delete the LOCAL feature branch. With the worktree gone this ref
+# is now an orphan that will cause confusion on future checkouts.
 git branch -D squad/<N>-<slug> 2>$null
 
-# 3. Merge the PR with --delete-branch. With the worktree gone and the local
-# ref deleted, gh's pre-flight check passes and the remote ref is removed
-# cleanly along with the merge.
+# Step 4. Merge the PR with --delete-branch. With the worktree gone and the
+# local ref deleted, gh's pre-flight check passes and the remote ref is
+# removed cleanly along with the merge commit.
 gh pr merge <N> --admin --squash --delete-branch
 
-# 4. Verify. Both local AND remote refs should be gone.
-git branch --list "squad/<N>-*"          # expect empty
+# Step 5. Verify. Both local AND remote refs should be gone.
+git branch --list "squad/<N>-*"             # expect empty
 git ls-remote --heads origin "squad/<N>-*"  # expect empty
 ```
 
@@ -67,7 +75,7 @@ commit history preserved, swap `--squash` for `--merge`:
 gh pr merge <N> --admin --merge --delete-branch
 ```
 
-The worktree-remove-FIRST sequence (steps 0-2 above) is identical; only the
+The worktree-remove-FIRST sequence (steps 1-3 above) is identical; only the
 merge strategy differs. Proven on the 0.9.1 and 0.9.2 cuts.
 
 ### Pattern 3 -- Recovery if you forget and merge with the worktree still attached
@@ -102,30 +110,45 @@ the worktree first removes the precondition that trips the check.
 
 ## Examples
 
-**Sprint 12 Wave 2 (5-of-5 successful applications):**
+**Sprint 12 Wave 2 (5-of-5 -- first formal application after issue #317):**
 - PR #320 (Donald, `squad/237-test-harness-pattern`)
 - PR #321 (Mickey, `squad/310-arch-windows-dep-order`)
-- PR #323 (Scribe wave-2 fold, `squad/scribe-sprint-12-wave-2-fold`)
+- PR #323 (Scribe wave-2 fold)
 - PR #324 (Mickey, `squad/306-readme-refresh`)
 - PR #327 (Scribe sprint-12 retro fold)
+- PR #328 (`release/0.9.2`) -- same sequence with `--merge` to preserve history
 
-**Sprint 12 release:**
-- PR #328 (`release/0.9.2`), same sequence with `--merge` instead of
-  `--squash` to preserve the release history.
+**Sprint 15 (4-of-4 -- Doc dual-worktree wave):**
+- PR #357 (Mickey, `squad/355-sprint-letter-normalization`)
+- PR #358 (Doc, `squad/356-ascii-sweep`)
+- PR #359 (Doc, history fold `squad/doc-history-sprint-15`)
+- PR #360 (Coordinator, develop->main release fold)
+
+Lifetime record at Sprint 15 close: 25-of-25 across Sprints 12-15.
+
+**Sprint 16 (3 additional applications):**
+- PR #368 (Pluto, `squad/367-skill-drift-audit`) -- also the `--base main`
+  incident; worktree-remove-FIRST itself was followed correctly
+- PR #369 (Pluto, `squad/362-ascii-docs-skill`)
+- PR #370 (Pluto, `squad/364-worktree-base-refresh-skill`)
 
 **Counter-example (Sprint 11, before the pattern was named):**
 - Issue #300 tracked an apparent 5-of-6 fail rate of
-  `gh pr merge --delete-branch` producing ghost remote refs. At the time, the
-  root cause was hypothesised as a `gh` upstream bug. The Sprint 12 evidence
-  reframes it: the trigger was the worktree-owns-branch precondition, not a
-  CLI regression. Closing #300 as "no longer reproducible" was premature; the
-  fix is procedural (this skill), not waiting on upstream.
+  `gh pr merge --delete-branch` producing ghost remote refs. At the time the
+  root cause was hypothesised as a gh upstream bug. The Sprint 12 evidence
+  reframes it: the trigger was the worktree-owns-branch precondition. Closing
+  #300 as "no longer reproducible" was premature; the fix is procedural (this
+  skill), not waiting on upstream.
 
 ## Anti-Patterns
 
 - **Calling `gh pr merge --delete-branch` while the worktree is still attached.**
   100% failure on the remote-delete step. Symptoms: merge succeeds on GitHub,
   but `git ls-remote origin` still shows the feature branch ref days later.
+- **Merging the PR before harvesting hygiene files.** The worktree may contain
+  inbox drops or history.md appends the agent did not push. Once the PR is
+  merged and the worktree is removed, those files are unrecoverable from the
+  branch history.
 - **Removing the worktree but skipping the local branch delete.** Leaves a
   dangling local `squad/<N>-<slug>` ref that future `git checkout` or
   `git branch -a` listings will surface as noise. Ralph's EOS sweep cleans
@@ -143,12 +166,15 @@ the worktree first removes the precondition that trips the check.
 
 ## References
 
-- Issue #317 -- formalization request and 5-of-5 evidence
+- Issue #317 -- formalization request and 5-of-5 Sprint 12 evidence
+- Issue #383 -- Sprint 17 revision request (hygiene harvest + medium confidence)
 - Issue #300 -- earlier (closed) tracker of the same symptom
 - PR #295 -- Ralph EOS post-merge `git push origin --delete` fallback
 - `.squad/skills/worktree-isolation/SKILL.md` -- the agent-dispatch race
   condition that necessitates worktrees in the first place (a different
   concern; this skill covers the merge tail, that skill covers the spawn head)
+- `.squad/skills/gh-pr-base-develop/SKILL.md` -- companion skill: every
+  `gh pr create` must pass `--base develop` explicitly
 - `git worktree` man page
 
-**Last reviewed:** 2026-05-17
+**Last reviewed:** 2026-05-17 (Sprint 17, issue #383)


### PR DESCRIPTION
## Summary

Formalize two squad skills for Sprint 17 Wave 1, resolving issues #383 and #384.

### Skill 1: worktree-remove-first (update)

- Confidence updated to **medium** (29+ applications, Sprints 12-16)
- Hygiene harvest added as the **primary** ordering rationale (step 1 of recipe)
- Added Sprint 15 citations: PRs #357, #358, #359, #360 (4-of-4 success)
- Added Sprint 16 citations: PRs #368, #369, #370
- Cross-link to new gh-pr-base-develop skill
- Last reviewed updated to Sprint 17

### Skill 2: gh-pr-base-develop (new)

- Codifies the --base develop rule triggered by Sprint 16 PR #368 incident
- Confidence: **high** (binary rule, direct incident)
- Includes pre-flight check, spawn-prompt template snippet, recovery recipe
- Documents forward-merge recovery pattern with --no-ff --no-verify

### routing.md

- Added Spawn-Prompt Hygiene section pointing coordinators to gh-pr-base-develop
- Minimum required snippet documented for any spawn that creates a PR

## Checklist

- [x] ASCII-clean (0 non-ASCII bytes verified)
- [x] Pre-commit hook passed
- [x] --base develop passed explicitly (meta-discipline applied)
- [x] Conventional Commits format
- [x] Co-authored-by trailer present
- [x] Closes #383 and #384

Closes #383
Closes #384