### PR TITLE
chore(skills): formalize history-md-pre-size-check + changelog-fold-completeness

### DIFF
--- a/.copilot/skills/changelog-fold-completeness/SKILL.md
+++ b/.copilot/skills/changelog-fold-completeness/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: "changelog-fold-completeness"
+description: "Before folding [Unreleased] into a versioned release block, verify every PR merged and every issue closed since the last release tag has an entry in [Unreleased]. Add any missing entries first. Only then fold and restore the empty [Unreleased] block."
+domain: "release-flow"
+confidence: "high"
+source: "earned (issues #399, Sprints 15/16/17 -- 3 consecutive releases, binary rule)"
+---
+
+## Context
+
+The `CHANGELOG.md` file follows Keep a Changelog format. The `[Unreleased]` block is
+supposed to accumulate entries as PRs merge to develop throughout a sprint. In practice,
+only the first agent to land a feature PR adds their entry. Subsequent agents either
+skip the update (single-PR scope feels too small) or defer it to "someone else." By
+release time, the `[Unreleased]` block contains only the first-lander's entry --
+typically 1 of N contributions.
+
+The release agent (Mickey) folds `[Unreleased]` to `[X.Y.Z]` and ships. The missing
+entries are gone from the release notes permanently.
+
+This pattern has repeated identically in Sprints 15, 16, and 17. The fix is a
+mandatory completeness check before every fold. This skill codifies that check.
+
+**Rule:** The fold step is GATED on completeness. Do not fold until every merged PR
+and every closed issue has a corresponding entry in `[Unreleased]`.
+
+## Recipe
+
+Run these steps IN ORDER during every release cut. Run from the main checkout (not a
+worktree).
+
+```bash
+# Step 1. Identify the last release tag.
+git fetch --tags origin
+LAST_TAG=$(git describe --tags --abbrev=0 origin/main)
+echo "Last release tag: $LAST_TAG"
+# Expected format: X.Y.Z (bare, no 'v' prefix -- see tag convention)
+
+# Step 2. Identify the last release date (needed for gh queries).
+LAST_RELEASE_DATE=$(git log -1 --format=%ci "$LAST_TAG" | cut -d' ' -f1)
+echo "Last release date: $LAST_RELEASE_DATE"
+
+# Step 3. List all merge commits on develop since the last tag.
+echo "=== Merge commits on develop since $LAST_TAG ==="
+git log --oneline "$LAST_TAG"..develop --merges
+
+# Step 4. List all PRs merged to develop since the last release date.
+echo "=== PRs merged to develop since $LAST_RELEASE_DATE ==="
+gh pr list --state merged --base develop --limit 50 \
+  --json number,title,mergedAt,labels \
+  --jq ".[] | select(.mergedAt >= \"$LAST_RELEASE_DATE\") | \"#\(.number) \(.title)\""
+
+# Step 5. List all issues closed since the last release date.
+echo "=== Issues closed since $LAST_RELEASE_DATE ==="
+gh issue list --state closed \
+  --search "closed:>$LAST_RELEASE_DATE" \
+  --json number,title,closedAt \
+  --limit 50 \
+  --jq '.[] | "#\(.number) \(.title)"'
+
+# Step 6. Open CHANGELOG.md [Unreleased] and cross-reference.
+# For each PR number and each issue number from Steps 4-5:
+#   - Search CHANGELOG.md [Unreleased] for "(#NNN)"
+#   - If NOT found: ADD a one-line entry under the correct section
+#     (Added / Changed / Fixed / Removed) before proceeding.
+grep -n "Unreleased" CHANGELOG.md  # find the block boundary
+
+# Step 7. ONLY AFTER all entries are confirmed present, fold [Unreleased].
+# Replace:  ## [Unreleased]
+# With:     ## [X.Y.Z] - YYYY-MM-DD -- Sprint NN: <theme>
+# (Use sed, a text editor, or a script -- whatever the release runbook specifies.)
+
+# Step 8. Restore the empty [Unreleased] block immediately after the fold.
+# The block must be present at the top of CHANGELOG.md for the next sprint.
+# Template:
+#
+# ## [Unreleased]
+#
+# ### Added
+#
+# ### Changed
+#
+# ### Fixed
+#
+# ### Removed
+```
+
+### PowerShell equivalent for Steps 1-5
+
+```powershell
+$lastTag = git describe --tags --abbrev=0 origin/main
+Write-Host "Last tag: $lastTag"
+$lastDate = (git log -1 --format="%ci" $lastTag).Split(" ")[0]
+Write-Host "Last release date: $lastDate"
+
+# Merges on develop since the tag
+git log --oneline "$lastTag..develop" --merges
+
+# PRs -- gh outputs UTC timestamps; compare as strings (ISO8601 sorts correctly)
+gh pr list --state merged --base develop --limit 50 `
+  --json number,title,mergedAt,labels `
+  --jq ".[] | select(.mergedAt >= `"$lastDate`") | `"#\(.number) \(.title)`""
+
+# Closed issues
+gh issue list --state closed `
+  --search "closed:>$lastDate" `
+  --json number,title,closedAt --limit 50 `
+  --jq '.[] | "#\(.number) \(.title)"'
+```
+
+### Why this order
+
+- **Steps 3-5 before touching CHANGELOG.md.** Gathering the complete PR + issue list
+  first gives a concrete checklist. Without it, "add missing entries" is subjective --
+  you can't add what you don't know is missing.
+- **Step 6 (cross-reference) before fold.** Once the fold happens, the window to add
+  missing entries closes. The release is immutable. The completeness check must be
+  inside the release transaction, not a best-effort beforehand.
+- **Step 8 (restore empty block) immediately after fold.** If the fold succeeds but
+  the restore is skipped, the next sprint starts without a `[Unreleased]` block, which
+  causes the first agent to manually edit CHANGELOG structure instead of appending
+  to a predictable location.
+
+## Examples
+
+**Sprint 17 release (0.9.7, PR #393, commit 71d2ffe):**
+At release time, `[Unreleased]` contained only the `#382` (sprint-end label automation)
+entry -- 1 of 6 total PRs merged to develop that sprint. Mickey-14 ran the completeness
+check and added 5 missing entries (PRs #383, #384, #385, #388, #390 plus issues #371,
+#381) before folding. Without this check, 0.9.7 release notes would have been ~85%
+incomplete. Cited in Sprint 17 retro under "Key learnings."
+
+**Sprint 16 release (0.9.6, PR #372, commit 7172ae7):**
+`[Unreleased]` had sparse coverage -- only the first-lander entry. Mickey-12 added
+missing Sprint 16 entries (PRs #368, #369, #370, #363, #365, #367) before folding to
+`[0.9.6] - 2026-05-17 -- Sprint 16: Skill formalization + hygiene gate review`.
+
+**Sprint 15 release (0.9.5, PR #360, commit 0c8d710):**
+Same pattern. Only 1 entry in `[Unreleased]` at release time. Mickey added the missing
+Sprint 15 PR entries (#355 normalization, #356 ASCII sweep, #357-#359 Doc wave) before
+folding. Sprint 15 retro noted this as a process gap; it was not fixed structurally
+until this skill was formalized.
+
+**Pattern summary:** Three consecutive releases (0.9.5, 0.9.6, 0.9.7) had incomplete
+`[Unreleased]` blocks at release time. The merge PR template asks contributors to
+update CHANGELOG.md, but agents on single-PR scopes routinely skip it. The live block
+contains only the first agent's entry by release time. The completeness check has
+never failed to find missing entries when applied.
+
+## Anti-Patterns
+
+- **Trusting that `[Unreleased]` is complete.** It never is by release time. The
+  pattern is binary: the first lander adds one entry; subsequent agents skip. Every
+  sprint, every release.
+- **Skipping Steps 3-5 because the sprint was "small."** Sprint 17 had 6 PRs; only 1
+  entry was in `[Unreleased]`. Sprint 16 had 7 Sprint PRs; same pattern. There is no
+  sprint small enough that the completeness check is unnecessary.
+- **Adding entries AFTER the fold.** Once `[0.9.7]` is committed and pushed, adding
+  to it requires a second commit amending the release block -- noisy and confusing for
+  readers of the git log.
+- **Folding without restoring `[Unreleased]`.** Leaves CHANGELOG.md with no top-level
+  Unreleased block. First agent next sprint either forgets to add the block and
+  appends under the versioned section, or adds the block incorrectly.
+- **Relying on the PR template alone.** The template asks for a CHANGELOG update on
+  every PR. Agents on single-PR scope treat it as optional. The release gate is the
+  only reliable enforcement point.
+
+## Placement decision
+
+This skill lives in `.copilot/skills/` (coordinator level) rather than `.squad/skills/`
+(team level). Rationale: the fold step is performed by Mickey (or the coordinator
+directly) during a release cut -- it is release-process governance, not day-to-day
+agent workflow. The coordinator is responsible for ensuring the fold is gated on
+completeness. If Mickey is the release agent, the coordinator must include this skill
+reference in Mickey's release spawn prompt.
+
+Compare with `.squad/skills/history-md-pre-size-check/SKILL.md`, which governs
+individual agent appends and therefore lives at the team level.
+
+## Related Skills
+
+- `.squad/skills/gh-pr-base-develop/SKILL.md` -- every squad PR must pass
+  `--base develop`; if any PR was misrouted (base=main), the gh queries in Steps 4-5
+  will miss it; verify develop ancestry with `git log $LAST_TAG..develop --merges`
+  as the authoritative source.
+- `.copilot/skills/release-process/SKILL.md` -- the full release runbook; this skill
+  is a pre-step for the fold phase of that runbook.
+- `.squad/skills/history-md-pre-size-check/SKILL.md` -- companion hygiene check
+  (agent-level); ensures agents' own history files are within gate before the sprint
+  closes and before the release audit.
+
+## References
+
+- Issue #399 -- formalization request (Sprint 18)
+- Sprint 17 retro (`.squad/retros/2026-05-18-sprint-17-retro.md`) -- "Key learnings:
+  RECURRING: Pre-append history.md size check missing" and release completeness notes
+- PR #393 (commit 71d2ffe) -- Sprint 17 release (0.9.7); completeness check applied,
+  5 missing entries added
+- PR #372 (commit 7172ae7) -- Sprint 16 release (0.9.6); completeness check applied
+- PR #360 (commit 0c8d710) -- Sprint 15 release (0.9.5); same pattern
+- `CHANGELOG.md` -- Keep a Changelog format reference
+- `https://keepachangelog.com/en/1.1.0/` -- canonical format spec
+
+**Last reviewed:** 2026-05-17 (Sprint 18, issue #399)

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -84,6 +84,13 @@ Rationale: Sprint 17 retro identified 3 hygiene failures (history.md gate breach
 ASCII em-dash in .gitignore, PR #368 --base=main) all preventable by a mandatory
 template. Issue #397.
 
+Every release spawn (Mickey or coordinator) MUST run a CHANGELOG completeness
+check before folding `[Unreleased]`. See
+`.copilot/skills/changelog-fold-completeness/SKILL.md` for the full recipe
+(git log + gh pr list + gh issue list cross-reference against [Unreleased]).
+The fold is GATED on completeness -- do not fold until all merged PRs and closed
+issues have entries.
+
 ## Rules
 
 1. **Eager by default** -- spawn all agents who could usefully start work, including anticipatory work.

--- a/.squad/skills/history-md-pre-size-check/SKILL.md
+++ b/.squad/skills/history-md-pre-size-check/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: "history-md-pre-size-check"
+description: "Before appending to any agent history.md, check the file size and either shorten the entry or archive old entries if (current_size + planned_bytes) > 14336. Prevents mid-sprint Jiminy emergency compresses and post-batch audit blockers."
+domain: "repo-meta, agent-hygiene"
+confidence: "medium"
+source: "earned (issues #398, Sprint 17 retro -- 3+ observations across 3 sprints)"
+---
+
+## Context
+
+Every agent appends work records to `.squad/agents/{name}/history.md` after each task.
+The repo enforces a hard gate of 15360 bytes (15 KB) on that file via the pre-commit hook.
+Agents consistently skip a size check before appending, trusting that their entry is small.
+It is not always small. Blindly appending and pushing then triggers one of two failure modes:
+
+1. **Pre-commit block.** The commit fails; the agent's work is left uncommitted while
+   the coordinator must intervene to compress the file before the sprint can continue.
+
+2. **Post-batch audit blocker.** The oversized file lands on develop and is caught by
+   Jiminy during the EOS audit. Jiminy compresses it in a follow-up PR, but this is
+   wasted ceremony and delays the sprint close.
+
+Both failure modes have occurred in three consecutive sprints (15, 16, 17). The fix
+is a single size read before each append. This skill codifies that pre-check as a
+mandatory step.
+
+**Hard gate:** 15360 bytes (pre-commit hook in `hooks/pre-commit`, Check 4).
+**Safe threshold:** 14336 bytes (90% of the gate, leaving ~1 KB headroom).
+
+## Recipe
+
+Run these steps IN ORDER every time you are about to append to your own
+`.squad/agents/{name}/history.md`. Replace `{name}` with your agent name.
+
+```powershell
+# Step 1. Read current file size (bytes).
+$histPath = ".squad/agents/{name}/history.md"
+$size = (Get-Item $histPath).Length
+Write-Host "INFO: history.md current size: $size bytes (gate: 15360)"
+
+# Step 2. Estimate planned entry size.
+# Rough rule: 1 KB = ~1000 characters of plain ASCII text.
+# If your entry is a short 3-5 line bullet, budget ~200-400 bytes.
+# If your entry is a full section with code blocks, budget ~800-2000 bytes.
+$plannedBytes = <your estimate>
+
+# Step 3. Decide path.
+if (($size + $plannedBytes) -gt 14336) {
+    # Option A: Shorten the entry.
+    # Cut your planned entry to 1-2 lines:
+    #   "Sprint NN -- #NNN: <one-sentence summary>. PR #NNN."
+    # Prefer Option A if you have a prior section that is already a stub.
+
+    # Option B: Mini-fold (archive old entries first).
+    # Move entries from pre-Sprint-(current-2) or older to history-archive.md:
+    #   1. Open history.md. Identify the oldest dated section(s).
+    #   2. Cut those sections and paste them into history-archive.md.
+    #   3. Save history-archive.md. Verify: (Get-Item ".squad/agents/{name}/history-archive.md").Length
+    #   4. Save history.md with the old sections removed.
+    #   5. Re-measure: $size = (Get-Item $histPath).Length
+    #   6. Confirm ($size + $plannedBytes) -le 14336 before proceeding.
+    Write-Warning "SIZE CHECK: $size + $plannedBytes = $($size + $plannedBytes) > 14336. Applying Option A or B."
+}
+
+# Step 4. Append the (possibly shortened) entry.
+# ... your append logic here ...
+
+# Step 5. Post-write verification.
+$postSize = (Get-Item $histPath).Length
+Write-Host "INFO: history.md post-write size: $postSize bytes"
+if ($postSize -gt 15360) {
+    Write-Error "GATE EXCEEDED: $postSize > 15360. Compress immediately before git add."
+    # Do NOT proceed to git add until size is under the gate.
+}
+```
+
+### Why this order
+
+- **Size read before append** (Step 1) catches the problem before any bytes are
+  written, giving you a clean recovery path (shorten the entry, never touch git).
+- **Option A before Option B.** Shortening is always cheaper than a full archive fold.
+  Archive only when Option A would produce a stub so terse it would be useless as a
+  history record.
+- **Post-write verify** (Step 5) is the safety net for mis-estimates. If you undercount
+  your entry, the post-write check catches the overrun before `git add`.
+
+### Bash / zsh equivalent (for agents running on Linux)
+
+```bash
+hist_path=".squad/agents/{name}/history.md"
+size=$(wc -c < "$hist_path")
+echo "INFO: history.md current size: $size bytes (gate: 15360)"
+# Same decision logic as above; use wc -c for byte count (matches git blob size).
+```
+
+## Examples
+
+**Sprint 15 -- pluto/history.md and scribe/history.md (first documented occurrence):**
+Both files exceeded the gate during the Sprint 15 EOS sweep. Compressed during Ralph's
+cleanup before the 0.9.5 release cut (commit 7fe4eb0, "chore(ralph): Sprint 15 EOS
+cleanup -- 0.9.5 final state"). Root cause: no pre-check; appends accumulated across
+the sprint.
+
+**Sprint 16 -- pluto/history.md compressed 15694 B -> 8734 B (scribe-8, PR #378):**
+Scribe ran an EOS cleanup pass and found pluto/history.md over the gate. Compressed
+by moving pre-Sprint-13 entries to history-archive.md. Merge commit: df59a9c
+("Merge pull request #378 from primetimetank21/squad/scribe-s16-eos-cleanup").
+
+**Sprint 17 -- donald/history.md compressed 15860 B -> 10236 B (jiminy-5, PR #390):**
+Donald-2 appended the #389 sprint-end-labels entry without a size check. File reached
+15860 B, exceeding the 15360 B gate. Jiminy caught it in the post-batch audit and
+compressed by moving pre-Sprint-12 entries to history-archive.md (6298 B moved).
+Commit: 6375a49 ("chore(hygiene): Sprint 17 Wave 1 post-batch audit fixes (#390)").
+Sprint 17 retro names this as the #1 "What surprised us" item and explicitly calls for
+this SKILL.
+
+**Lifecycle math from Sprint 17:**
+- donald/history.md at overrun: 15860 B (500 B over gate)
+- Jiminy compress delta: -5624 B (moved 2 sprint's worth of entries to archive)
+- Post-compress: 10236 B (33% under gate, safe for 3-5 more sprints at typical velocity)
+
+## Anti-Patterns
+
+- **Blind append + git push without size check.** The #1 trigger for all three
+  incidents above. The entry always feels small; the file is not always small.
+- **Trusting "my entry is short."** A single entry with two code blocks and a
+  methodology subsection can easily run 1500-2000 bytes. Always measure.
+- **Compressing only after git push.** Once the oversized file is on develop,
+  recovery requires a follow-up PR (Jiminy's compress commit), which is
+  ceremony that costs coordinator time and sprint bandwidth.
+- **Archiving inside the same append PR.** If you archive AND append in one
+  commit, a bug in the archive step (wrong section boundary) can corrupt both
+  history.md and history-archive.md simultaneously. Always: check, then optionally
+  archive (separate save), then append, then post-verify.
+- **Setting the threshold at exactly 15360.** The pre-commit hook fires at 15360.
+  If your estimate is off by even 1 byte, the commit fails. Use 14336 (90%) as
+  the threshold so there is always ~1 KB of headroom for measurement error.
+
+## Related Skills
+
+- `.squad/skills/history-compression/SKILL.md` -- the full compression recipe
+  (multi-sprint heuristics, front-matter verbatim rule, 13 KB target). Use when
+  Option B (mini-fold) above needs guidance on what to keep vs. archive.
+- `.squad/skills/worktree-remove-first/SKILL.md` -- companion cleanup discipline;
+  harvest hygiene files (including history.md appends) before removing the worktree.
+- `.squad/skills/pre-spawn-checklist/SKILL.md` -- the mandatory hygiene tail for
+  every spawn; references this skill for history.md append gate awareness.
+
+## References
+
+- Issue #398 -- formalization request (Sprint 18)
+- Sprint 17 retro (`.squad/retros/2026-05-18-sprint-17-retro.md`) -- "What surprised
+  us: history.md gate breeched mid-sprint (RECURRING)" and "Key learnings: Pre-append
+  history.md size check missing"
+- PR #390 (commit 6375a49) -- Sprint 17 incident: donald/history.md 15860->10236 B
+- PR #378 (commit df59a9c / 8e2c659) -- Sprint 16 incident: pluto/history.md 15694->8734 B
+- Commit 7fe4eb0 -- Sprint 15 EOS cleanup (pluto + scribe history compress)
+- `hooks/pre-commit` Check 4 -- the 15360 B gate enforcement
+
+**Last reviewed:** 2026-05-17 (Sprint 18, issue #398)


### PR DESCRIPTION
## Summary

Formalizes two skills identified in Sprint 17 retro as recurring patterns needing explicit documentation. Mirrors Sprint 17 #386 (worktree-remove-first + gh-pr-base-develop) bundling approach.

## Skill 1: history-md-pre-size-check (.squad/skills/)

**Issue #398 | Confidence: medium (3+ observations, 3 sprints)**

Trigger: Any agent about to append to .squad/agents/{name}/history.md.

Recipe: Read size -> compare (size + planned bytes) against 14336 B (90% gate) -> Option A shorten or Option B mini-fold -> append -> post-write verify at 15360 B hard gate.

Real citations:
- Sprint 15 EOS: pluto/history.md compressed (commit 7fe4eb0)
- Sprint 16 PR #378 (df59a9c): pluto/history.md 15694->8734 B
- Sprint 17 PR #390 (6375a49): donald/history.md 15860->10236 B (the Sprint 17 retro incident)

## Skill 2: changelog-fold-completeness (.copilot/skills/)

**Issue #399 | Confidence: high (3 consecutive sprints, binary rule)**

Trigger: Mickey (or coordinator) dispatched for a release cut.

Recipe: Last tag -> git log merges -> gh pr list -> gh issue list -> cross-ref [Unreleased] -> add missing entries -> fold -> restore empty block.

Real citations:
- Sprint 15 PR #360 (0c8d710): same pattern
- Sprint 16 PR #372 (7172ae7): same pattern
- Sprint 17 PR #393 (71d2ffe): 5 of 6 entries missing; mickey-14 added them

Placement decision: .copilot/skills/ (not .squad/skills/) -- this is release-process governance performed by Mickey/coordinator at release time, not a day-to-day agent workflow. Documented in SKILL.md placement-decision section.

## routing.md cross-link

changelog-fold-completeness fold-gate reference added to Spawn-Prompt Hygiene section. Note: history-md-pre-size-check was already referenced in the Mandatory Hygiene Tail section (item 4) via upstream PR #401 -- no duplicate added.

## Verification

- ASCII check: 0 non-ASCII bytes in all 3 changed files
- Pre-commit hook: passed (branch ancestry verified against origin/develop after rebase over #401)
- Base: develop (verified below)

Closes #398
Closes #399