### PR TITLE
chore(squad): jiminy S18 W1 audit fixes

### DIFF
--- a/.squad/agents/ralph/history.md
+++ b/.squad/agents/ralph/history.md
@@ -62,133 +62,13 @@ Initial setup complete.
 
 ## 2026-05-17 -- Sprint 12 EOS sweep (Earl, post-retro merge)
 
-- **Trigger:** Earl's EOS protocol after Sprint 12 wrap (3 waves, 10 PRs, 9
-  issues closed). Retro fold landed as PR #327 (`5e0fb53`) just before
-  dispatch. Coordinator had already drained 4 Wave-2 inbox drops inline
-  post-Jiminy-audit; board reported clean entering this sweep.
-- **Pre-sweep state:**
-  - develop @ `5e0fb53`, main @ `724c62c` (still 0.9.1, untouched)
-  - Working tree clean, 1 worktree (primary only)
-  - Inbox empty, no rogue body files, no temp/backup rogues
-- **Pruned (Step 1) -- 5 stale `origin/squad/*` tracking refs:**
-  - `origin/squad/237-test-harness-pattern`
-  - `origin/squad/306-readme-refresh`
-  - `origin/squad/310-arch-windows-dep-order`
-  - `origin/squad/scribe-sprint-12-retro` (Jiminy listed 4 -- this was the
-    5th, branch reaped when PR #327 squash-merged minutes earlier; local
-    tracking ref hadn't caught up yet)
-  - `origin/squad/scribe-sprint-12-wave-2-fold`
-- **Already clean (Steps 2-5) -- Jiminy session-end audit was thorough:**
-  - Local `squad/*` branches: 0 (Coordinator's worktree-remove-first dance
-    held discipline across all 3 waves)
-  - Remote `squad/*` branches via `gh api .../branches --paginate`: 0
-    (confirmed -- only `develop` and `main` on the remote)
-  - Filesystem `dev-setup-*` orphan dirs at parent: 0
-  - `.squad/decisions/inbox/`: empty
-  - Rogue `issue_body*.md` at repo root: 0 (`gh issue create -F` + `Remove-Item`
-    pattern held)
-  - Rogue `*.tmp`, `*.bak`, `.DS_Store`, `Thumbs.db`: 0
-- **Step 6 -- `git gc --auto`:** exit 0, no output. Heuristics did not
-  trigger a pack -- expected, since the worktree-local strategy keeps
-  most churn off the primary checkout's loose-object pile. 10 PRs of
-  merge activity did not accumulate enough loose objects to cross the
-  auto-gc threshold.
-- **Final repo state:**
-  - develop: `5e0fb53` (clean)
-  - main: `724c62c` (0.9.1, untouched)
-  - Local branches: develop, main
-  - Remote branches (post-prune): origin/develop, origin/main, origin/HEAD
-  - Worktrees: 1 (primary)
-  - Open PRs: 0
-- **Sprint 12 EOS verdict:** CLEAN. 5 stale tracking refs pruned, 0 actual
-  orphans (no branches, no worktrees, no fs dirs, no rogue files). Jiminy's
-  session-end audit handled everything except the local-tracking-ref
-  catchup, which is the canonical Ralph job. Sweep complete.
-- **EOS pattern note:** 3rd consecutive EOS (Sprint 11 wrap -> 0.9.1
-  release -> Sprint 12 wrap) with zero orphan branches and zero worktree
-  stragglers. The Sprint 11-era hypothesis ("the team has internalized
-  cleanup-on-merge OR `gh pr merge --delete-branch` reliability improved")
-  now has a 3rd data point in its favor. One more cycle and the
-  `gh --delete-branch` quirk (issue #300) is effectively obsolete for
-  this repo's workflow.
-- **Multi-wave/multi-PR scaling note (new):** This is the first EOS
-  following a 3-wave / 10-PR sprint. The cleanup load did NOT scale
-  linearly with PR count -- the entire sweep produced 5 stale tracking
-  refs (1 per active wave/release + the retro), not 10. Worktree-local
-  strategy + Scribe's per-wave fold pattern keeps the EOS surface area
-  bounded regardless of sprint size. Worth remembering when sizing
-  future sprints: cleanup cost is per-wave, not per-PR.
-
-### Learnings (Ralph)
-
-- **Local tracking refs always lag a fresh merge.** When `gh pr merge`
-  deletes the remote branch, the local `origin/squad/*` ref persists
-  until the next `git fetch --prune` (or explicit `git remote prune`).
-  Jiminy's session-end audit ran before PR #327 merged, so it counted
-  4 refs; by the time Ralph dispatched, it was 5. Not a bug in Jiminy's
-  count -- a timing artifact. Future EOS dispatches after a fresh
-  merge should expect +1 ref vs. the prior audit.
-- **`git gc --auto` on a worktree-local-strategy repo rarely triggers.**
-  3rd consecutive EOS where `git gc --auto` no-ops. The primary checkout
-  stays lean because feature work happens in dedicated worktrees that
-  share the object DB but don't keep their loose objects "live" the way
-  a single-checkout workflow would. Safe to keep running it as cheap
-  insurance, but don't expect it to do anything on this repo.
-- **`gh api ... --jq` quoting is brittle in PowerShell.** First attempt
-  with embedded backslash-escaped quotes failed at the jq parser. The
-  reliable pattern is: `--jq '.[].name'` (no embedded quotes), then
-  filter the result list in PowerShell with `Where-Object { $_ -like
-  'squad/*' }`. Saves a round-trip when the quote dance fails.
+- **Verdict:** CLEAN. 5 stale tracking refs pruned (3 squad issue branches + 2 scribe fold branches), 0 actual orphans. develop @ `5e0fb53`, main @ `724c62c`. 3rd consecutive clean EOS.
+- **Key learnings:** (1) Local tracking refs lag fresh merges -- expect +1 ref vs prior Jiminy audit after late-merge. (2) `git gc --auto` no-ops on worktree-local repos (3rd consecutive). (3) Cleanup cost scales per-wave not per-PR (10 PRs produced only 5 stale refs). (4) `gh api --jq` quoting in PowerShell brittle -- use `--jq '.[].name'` then pipe to `Where-Object`.
 
 ## Sprint 13 EOS Cleanup (2026-05-17)
 
-- **Trigger:** Post Sprint 13 close. Tag `0.9.3` cut to main
-  (`edc67e2`), develop @ `ea2f5f0` after Jiminy session-end audit.
-  0 open issues, 0 open PRs.
-- **Known remnant (handed off by Jiminy, out of his scope):** live
-  remote branch `origin/squad/319-history-archival` -- its PR #332
-  merged 2026-05-17T09:24:42Z without `--delete-branch`.
-
-### Actions
-
-- `git worktree list` -- only main checkout
-  (`C:\Users\Earl Tankard\Coding\dev-setup`) present. No stray
-  worktrees to remove.
-- `git branch -vv` -- only `develop` (active) and `main` local.
-  No stale `squad/*` or `release/*` locals. Nothing to delete.
-- Remote squad/release sweep -- `git ls-remote --heads origin`
-  returned exactly 1 hit:
-  - `squad/319-history-archival` @ `15e55be` -- PR #332 confirmed
-    MERGED via `gh pr list --state merged --head ... --limit 1`.
-    Deleted via `git push origin --delete`.
-- `git remote prune origin` + `git fetch --all --prune` --
-  idempotent, no further refs reaped (already in sync post-delete).
-- `git gc --auto` -- no-op (4th consecutive EOS; pattern holds).
-  `git count-objects -vH`: 2833 loose / 6.93 MiB, 5 packs /
-  69.22 MiB, 238 prune-packable, 0 garbage.
-
-### Final state
-
-- Remote heads: `develop` (`ea2f5f0`), `main` (`edc67e2`).
-  0 `squad/*` or `release/*` remnants.
-- Local: `develop` (active), `main`. Working tree clean.
-- Worktrees: 1 (main checkout only).
-
-### Learnings (Ralph)
-
-- **Jiminy handoff pattern works.** Jiminy's session-end audit
-  explicitly documented the one ref it couldn't reap
-  (`squad/319-history-archival`) because the merge happened outside
-  his audit window. Ralph picked it up cleanly with a single targeted
-  `--delete` + prune. The previous EOS learning ("local refs lag a
-  fresh merge") generalizes: when a PR merges between Jiminy and Ralph
-  dispatch, Ralph should expect exactly +1 remote ref to reap, not a
-  full sweep. Cheap, predictable handoff.
-- **Sprint 13 cleanup load was the smallest in 4 sprints.** 1 remote
-  branch deleted, 0 local, 0 worktrees, 0 prune output. Consistent
-  with the "cost per wave, not per PR" rule from Sprint 12 EOS: this
-  sprint had fewer concurrent waves still open at close, so the
-  surface area shrank accordingly. No new tooling needed.
+- **Verdict:** CLEAN. 1 stale remote branch deleted (`squad/319-history-archival`, PR #332 merged without `--delete-branch`). 0 local, 0 worktrees. develop @ `ea2f5f0`, main @ `edc67e2` (0.9.3). 4th consecutive `git gc --auto` no-op.
+- **Key learnings:** (1) Jiminy handoff pattern works -- when PR merges between Jiminy audit and Ralph dispatch, expect exactly +1 remote ref. (2) Smallest cleanup in 4 sprints -- fewer concurrent waves = smaller EOS surface area.
 
 ## 2026-05-17 -- Sprint 14 EOS
 

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -56,13 +56,10 @@
 
 ## 2026-05-17 Sprint 14 Wave 1 -- Skill formalization (#340 + #341)
 
-- **Scope:** formalized two Scribe skills at medium confidence per Jiminy Sprint 13 EOS audit. One PR closes both #340 and #341.
-- **Skills shipped:**
-  - `.squad/skills/history-compression/SKILL.md` -- 4-step heuristic (front-matter verbatim, current sprint verbatim, older to dated bullets, preserve skill+incident refs), 13KB compress target with 15360 B hard gate, rebound-problem note. 3 applications cited (PR #319/#332, #333, #336).
-  - `.squad/skills/per-topic-inbox-routing/SKILL.md` -- routing decision tree (append / new / delete-stale), atomic-rm model (inbox gitignored -> physical delete IS the atomic action; NOT `git rm`), dual-model coexistence (per-topic `.squad/decisions/*.md` canonical for inbox drains; `.squad/decisions.md` parallel chronological journal; both coexist). 2 applications cited (PR #333, #336) + forward-fix history from PR #323.
-- **Dogfood:** applied history-compression skill to this very file post-append to stay under 15360 B gate. Sprint 13 verbose entries (W1 sweep + W1 fold + W2 fold + retro) condensed to dated bullets; Sprint 14 W1 (this entry) kept verbatim per spec.
-- **Lesson (skill formalization threshold):** medium confidence at 2-3 applications; high confidence reserved for >=5 applications across distinct contexts. Both skills hit medium this wave.
-- **Atomic-drain forward-fix:** N/A this wave (no inbox drops drained; pure skill formalization).
+- **Scope:** Formalized 2 Scribe skills at medium confidence per Jiminy Sprint 13 EOS audit.
+- **Skills shipped:** `.squad/skills/history-compression/SKILL.md` (4-step heuristic, 13KB target, 15360 B hard gate, 3 applications cited) + `.squad/skills/per-topic-inbox-routing/SKILL.md` (routing decision tree, atomic-rm model, dual-model coexistence, 2 applications cited).
+- **Dogfood:** Applied history-compression skill to this file post-append. Pre-Sprint-14 condensed.
+- **Lesson:** Medium confidence at 2-3 applications; high at >=5 across distinct contexts.
 
 ## 2026-05-17 Sprint 14 -- Release 0.9.4
 


### PR DESCRIPTION
## Sprint 18 Wave 1 Post-Batch Audit (jiminy-6)

### Auto-fixes applied:
- **ralph/history.md**: 15006 -> 9312 B (Option A compress: Sprint 12-13 verbose EOS sections condensed to summary bullets)
- **scribe/history.md**: 14449 -> 13606 B (Option A compress: Sprint 14 W1 section condensed)

Both files now under the 14336 B compress threshold per history-md-pre-size-check SKILL.

### Flagged (no auto-fix per charter):
- Pluto and Donald missing inbox drops (2/3 delivered; Scribe's drain domain)
- Pluto and Donald missing history.md trail entries for PRs #402/#403 (attribution matters; coordinator re-spawn needed)

### All other checks PASS:
- decisions.md: 10094 B (under 51200 gate)
- ASCII purity: 0 non-ASCII bytes across all W1 files
- Stale refs: 0 branches, 1 worktree (clean)
- Pre-commit/whitespace: PASS
- SKILL cross-links: Both wired in routing.md + hygiene template
- jiminy history.md: 14023 B (under threshold)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>