### PR TITLE
docs(routing): pre-spawn worktree creation expectation

### DIFF
--- a/.squad/agents/pluto/history.md
+++ b/.squad/agents/pluto/history.md
@@ -124,3 +124,9 @@ Formalized two skills surfaced by Sprint 17 audit:
 Both SKILLs use YAML frontmatter (name/description/domain/confidence/source), Context, Recipe with PowerShell + bash snippets, Why-this-order rationale, real PR/SHA examples, Anti-Patterns, Related Skills, References. Meta-validation: this very append was pre-checked against the size-check skill being formalized.
 
 **Lesson:** when formalizing a hygiene skill, eat your own dog food -- verify the very edit committing the skill follows the rule the skill teaches.
+## Sprint 19 -- Issue #417: routing.md pre-spawn worktree clarification
+
+**PR:** #418
+**Status:** Complete.
+
+Added 2-3 line clarification to routing.md "Pre-Spawn Worktree Creation" section: coordinators must pre-create N isolated worktrees BEFORE dispatching N parallel agents. Cross-references worktree-isolation SKILL (no duplication). Surfaces pattern already implicit in worktree-isolation/SKILL.md and issue-lifecycle.md.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -63,6 +63,16 @@ Must equal "develop". If not, close the PR and recreate with --base develop.
 See also `.squad/skills/pre-spawn-checklist/SKILL.md` for the full background
 checklist.
 
+## Pre-Spawn Worktree Creation (Multi-Agent Runs)
+
+When dispatching N agents in parallel (2+ concurrent agents), the coordinator MUST
+pre-create N isolated worktrees before spawning any agents. This prevents
+branch-checkout races when agents share a single working tree. For each agent:
+```
+git worktree add ../dev-setup-{issue-N} -b squad/{N}-{slug} develop
+```
+Pass each agent its `WORKTREE_PATH`. Ref: `.squad/skills/worktree-isolation/SKILL.md`.
+
 ## Mandatory Hygiene Tail
 
 Every coordinator spawn prompt MUST include the **Mandatory Hygiene Tail** block


### PR DESCRIPTION
Closes #417

Add clarification to routing.md that coordinators must pre-create isolated worktrees BEFORE dispatching parallel agents. This surfaces the pattern already documented in worktree-isolation SKILL and issue-lifecycle template.