### PR TITLE
feat(hooks): pre-commit history.md size gate (#416)

### DIFF
--- a/.squad/skills/history-md-pre-size-check/SKILL.md
+++ b/.squad/skills/history-md-pre-size-check/SKILL.md
@@ -24,8 +24,24 @@ Both failure modes have occurred in three consecutive sprints (15, 16, 17). The 
 is a single size read before each append. This skill codifies that pre-check as a
 mandatory step.
 
-**Hard gate:** 15360 bytes (pre-commit hook in `hooks/pre-commit`, Check 4).
+**Hard gate:** 15360 bytes (pre-commit hook in `hooks/pre-commit`, Check 7).
 **Safe threshold:** 14336 bytes (90% of the gate, leaving ~1 KB headroom).
+
+## Layered enforcement
+
+This skill operates at two complementary layers:
+
+1. **Agent discipline (this recipe).** Pre-append size check before any bytes are
+   written to `history.md`. Prevents the problem before git is involved.
+
+2. **Pre-commit hook (`hooks/pre-commit`, Check 7, issue #416).** Hard-rejects any
+   staged `history.md` blob over 15360 B; warns (exit 0) when over 14336 B. Added in
+   Sprint 19 after PR #412 breached the gate through agent-discipline-only enforcement.
+
+Both layers enforce the same thresholds (14336 B warn, 15360 B hard). The hook is the
+safety net when the agent-discipline step is skipped or mis-estimates the entry size.
+Passing the hook does NOT mean the file is healthy -- it means it is under the gate
+right now. Keep running the discipline recipe every sprint to stay clear of the gate.
 
 ## Recipe
 
@@ -155,6 +171,6 @@ this SKILL.
 - PR #390 (commit 6375a49) -- Sprint 17 incident: donald/history.md 15860->10236 B
 - PR #378 (commit df59a9c / 8e2c659) -- Sprint 16 incident: pluto/history.md 15694->8734 B
 - Commit 7fe4eb0 -- Sprint 15 EOS cleanup (pluto + scribe history compress)
-- `hooks/pre-commit` Check 4 -- the 15360 B gate enforcement
+- `hooks/pre-commit` Check 7 -- the 15360 B gate enforcement (added Sprint 19, issue #416)
 
-**Last reviewed:** 2026-05-17 (Sprint 18, issue #398)
+**Last reviewed:** 2026-05-18 (Sprint 19, issue #416 -- pre-commit gate added as Check 7)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,6 +7,7 @@
 #   4. Staged inbox file check (.squad/decisions/inbox/ should be gitignored)
 #   5. Refuse commits directly on develop/main/master
 #   6. Shellcheck on staged .sh files
+#   7. history.md size gate (15360 B hard limit, 14336 B warn threshold)
 set -e
 
 # ---------------------------------------------------------------------------
@@ -177,6 +178,27 @@ case "$current_branch" in
     exit 1
     ;;
 esac
+
+# ---------------------------------------------------------------------------
+# Check 7: history.md size gate (15360 B hard limit, 14336 B warn threshold)
+#
+# Measured against staged blob (git show), not working tree, so the gate
+# fires on the exact bytes that will land in the commit.
+# wc -c | tr -d ' ' strips leading whitespace emitted by BSD wc on macOS.
+# || true after grep prevents set -e failure when no history.md is staged.
+# ---------------------------------------------------------------------------
+for staged_file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^\.squad/agents/[^/]+/history\.md$' || true); do
+  size=$(git show :"$staged_file" | wc -c | tr -d ' ')
+  if [ "$size" -gt 15360 ]; then
+    echo ""
+    echo "ERROR: $staged_file is $size bytes (max 15360 B)."
+    echo "  Compress before commit -- see .squad/skills/history-md-pre-size-check/SKILL.md"
+    echo ""
+    exit 1
+  elif [ "$size" -gt 14336 ]; then
+    echo "WARN: $staged_file is $size bytes (warn at 14336 B, hard limit 15360 B). Consider compressing." >&2
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # Check 6: Shellcheck on staged .sh files (existing behavior)

--- a/tests/test_precommit_hygiene.sh
+++ b/tests/test_precommit_hygiene.sh
@@ -8,6 +8,7 @@
 #   Check 3: Rogue path check under .squad/
 #   Check 4: Staged inbox file check
 #   Check 5: Protected branch refuse (develop/main/master)
+#   Check 7: history.md size gate (Issue #416)
 #   pre-push: Main push guard + advisory PSScriptAnalyzer exit-code
 #
 # Usage:
@@ -353,6 +354,63 @@ if sh "$HOOK" >/dev/null 2>&1; then
   pass "T5e: commit on pluto/* branch is allowed"
 else
   fail "T5e: commit on pluto/* branch is allowed"
+fi
+
+# ===========================================================================
+# Check 7 Tests: history.md size gate
+# ===========================================================================
+echo ""
+echo "=== Check 7: history.md size gate ==="
+
+# Helper: create N bytes of ASCII 'a' using awk (portable; no newlines so
+# autocrlf on Windows Git Bash does not inflate the byte count).
+make_bytes() {
+  awk -v n="$1" 'BEGIN{for(i=0;i<n;i++) printf "a"}'
+}
+
+# Test 7a: FAIL -- history.md staged at 15361 B (above 15360 hard limit)
+T7A_DIR="${TMPDIR_BASE}/t7a"
+setup_test_repo "$T7A_DIR"
+git checkout -q -b goofy/size-gate-reject
+mkdir -p .squad/agents/goofy
+make_bytes 15361 > .squad/agents/goofy/history.md
+git add .squad/agents/goofy/history.md
+if sh "$HOOK" >/dev/null 2>&1; then
+  fail "T7a: history.md 15361 B should be rejected"
+else
+  pass "T7a: history.md 15361 B is rejected (hard limit)"
+fi
+
+# Test 7b: PASS with WARN -- history.md staged at 14500 B (between 14336 and 15360)
+T7B_DIR="${TMPDIR_BASE}/t7b"
+setup_test_repo "$T7B_DIR"
+git checkout -q -b goofy/size-gate-warn
+mkdir -p .squad/agents/goofy
+make_bytes 14500 > .squad/agents/goofy/history.md
+git add .squad/agents/goofy/history.md
+hook_out=$(sh "$HOOK" 2>&1); hook_exit=$?
+if [ $hook_exit -ne 0 ]; then
+  fail "T7b: history.md 14500 B should pass (warn only)"
+elif echo "$hook_out" | grep -q "WARN"; then
+  pass "T7b: history.md 14500 B warns but passes"
+else
+  fail "T7b: history.md 14500 B should emit WARN (not found in output)"
+fi
+
+# Test 7c: PASS silently -- history.md staged at 1000 B (below warn threshold)
+T7C_DIR="${TMPDIR_BASE}/t7c"
+setup_test_repo "$T7C_DIR"
+git checkout -q -b goofy/size-gate-ok
+mkdir -p .squad/agents/goofy
+make_bytes 1000 > .squad/agents/goofy/history.md
+git add .squad/agents/goofy/history.md
+hook_out7c=$(sh "$HOOK" 2>&1); hook_exit7c=$?
+if [ $hook_exit7c -ne 0 ]; then
+  fail "T7c: history.md 1000 B should pass silently"
+elif echo "$hook_out7c" | grep -q "WARN\|ERROR"; then
+  fail "T7c: history.md 1000 B should pass without WARN/ERROR output"
+else
+  pass "T7c: history.md 1000 B passes silently"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
Add Check 7 to hooks/pre-commit: hard-rejects staged history.md blobs over 15360 B; warns over 14336 B. 29/29 tests pass. Closes #416