### PR TITLE
feat(scripts): auto-inject hygiene tail helper + lint (#414)

### DIFF
--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -70,6 +70,40 @@ verbatim. The canonical template lives at:
 
   `.squad/templates/spawn-prompt-hygiene.md`
 
+Coordinators MUST use one of the two enforcement paths below (issue #414):
+
+**(a) Auto-inject via squad-spawn (preferred):**
+
+```
+# Windows
+pwsh -File scripts\squad-spawn.ps1 --body <prompt-skeleton.md> \
+    --name <agent> --issue <N> --worktree <path>
+
+# POSIX
+bash scripts/squad-spawn.sh --body <prompt-skeleton.md> \
+    --name <agent> --issue <N> --worktree <path>
+```
+
+Outputs the assembled prompt on stdout. Pipe into the `task` tool prompt
+parameter. Substitutes `{name}`, `{N}`, and `{worktree-path}` automatically.
+Idempotent: will not double-inject if markers are already present.
+
+**(b) Lint-verify before spawning:**
+
+```
+# Windows
+pwsh -File scripts\lint-spawn-prompt.ps1 --file <prompt.md>
+
+# POSIX
+bash scripts/lint-spawn-prompt.sh --file <prompt.md>
+```
+
+Exit 0 = all 6 markers present (safe to spawn).
+Exit 1 = list of missing markers (do not spawn; fix first).
+
+See `.squad/skills/spawn-prompt-lint/SKILL.md` for the 6 marker definitions and
+the full recipe.
+
 Copy-paste the entire block from that file into every spawn prompt. No items may
 be omitted. The block covers:
 

--- a/.squad/skills/spawn-prompt-lint/SKILL.md
+++ b/.squad/skills/spawn-prompt-lint/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: "spawn-prompt-lint"
+description: "Six mandatory markers that every coordinator spawn prompt must contain (hygiene tail). Use lint-spawn-prompt.{ps1,sh} to verify presence; use squad-spawn.{ps1,sh} to auto-inject."
+domain: "repo-meta, coordinator-tooling"
+confidence: "medium"
+source: "earned (issue #414, Sprint 19 -- root-cause of #406/#407 fixup pattern: hygiene tail present in template but not injected into spawn prompts)"
+---
+
+## Context
+
+Sprint 18 shipped `.squad/templates/spawn-prompt-hygiene.md` (PR #401) as the canonical
+6-item hygiene tail. In the same sprint wave, two agents (Pluto PR #402, Donald PR #403)
+breached parts of the hygiene tail because the coordinator forgot to embed the template
+into their spawn prompts. Fixup PRs #406 and #407 were required.
+
+The root cause is coordinator-side opt-in injection: the template exists but is not
+mechanically enforced at spawn time. This skill codifies the 6 mandatory markers that
+constitute the hygiene tail, and points to the helper + linter scripts that make
+injection automatic (issue #414).
+
+## The 6 Mandatory Markers
+
+These strings MUST appear verbatim in every coordinator spawn prompt. They are the
+canonical section headers from `.squad/templates/spawn-prompt-hygiene.md`.
+
+| # | Marker (search string)                        | Covers |
+|---|-----------------------------------------------|--------|
+| 1 | `CWD-pin -- before every file write`          | Working directory guard before any file write |
+| 2 | `base=develop discipline`                     | Every gh pr create must pass --base develop |
+| 3 | `ASCII discipline -- after every file write`  | 0 non-ASCII bytes in every committed file |
+| 4 | `history.md pre-size-check -- before every append` | Size gate check before history append |
+| 5 | `Worktree-remove-FIRST cleanup -- after PR merges` | Safe merge sequence for worktree PRs |
+| 6 | `Hygiene tail completion`                     | history.md append + inbox drop at end |
+
+Ref: `.squad/templates/spawn-prompt-hygiene.md` for the full block to copy-paste.
+
+## Recipe: Auto-Inject via squad-spawn
+
+The preferred path. The helper assembles the final prompt by appending the template.
+
+```
+# Windows
+pwsh -File scripts\squad-spawn.ps1 \
+    --body <prompt-skeleton.md> \
+    --name <agent> \
+    --issue <N> \
+    --worktree <path>
+
+# POSIX
+bash scripts/squad-spawn.sh \
+    --body <prompt-skeleton.md> \
+    --name <agent> \
+    --issue <N> \
+    --worktree <path>
+```
+
+Substitutions performed: `{name}` -> agent, `{N}` -> issue number,
+`{worktree-path}` -> worktree absolute path. Output goes to stdout; pipe
+into the `task` tool prompt parameter.
+
+The scripts are idempotent: if the body already contains all 6 markers,
+the template is not appended again.
+
+## Recipe: Lint-Only Verification
+
+Use when you have already assembled a prompt manually and want to confirm
+all 6 markers are present before spawning.
+
+```
+# Windows
+pwsh -File scripts\lint-spawn-prompt.ps1 --file <prompt.md>
+
+# POSIX
+bash scripts/lint-spawn-prompt.sh --file <prompt.md>
+```
+
+Exit 0 = all 6 markers present (safe to spawn).
+Exit 1 = list of missing markers printed to stderr (do not spawn; fix first).
+
+## Coordinator Mandate
+
+Coordinators MUST do one of the following before every agent spawn:
+
+(a) **Use squad-spawn** to assemble the prompt -- hygiene tail is auto-injected.
+(b) **Run lint-spawn-prompt** on the manually assembled prompt -- all 6 markers
+    confirmed before the `task` tool is invoked.
+
+Both scripts are in `scripts/` and tested in `tests/test_squad_spawn.ps1`,
+`tests/test_spawn_prompt_lint.ps1`, and their `.sh` mirrors.
+
+## Anti-Patterns
+
+- Handwriting the hygiene tail from memory -- field experience shows coordinators
+  abbreviate or skip items under time pressure. Use the template or helper.
+- Embedding only a subset of the 6 markers -- all 6 are mandatory; partial
+  compliance reproduces the Sprint 18 failure mode.
+- Running lint after spawning -- the linter is a pre-spawn gate, not a post-hoc audit.
+  If a running agent lacks items 1-6, you cannot retroactively inject them.
+- Trusting "I copy-pasted last sprint's prompt" -- template content can drift
+  between sprints. Always regenerate via squad-spawn for the current template.
+
+## Related Skills
+
+- `.squad/templates/spawn-prompt-hygiene.md` -- the canonical 6-item block (source of truth)
+- `.squad/skills/gh-pr-base-develop/SKILL.md` -- marker 2 detail
+- `.copilot/skills/ascii-docs-about-non-ascii/SKILL.md` -- marker 3 detail
+- `.squad/skills/history-md-pre-size-check/SKILL.md` -- marker 4 detail
+- `.squad/skills/worktree-remove-first/SKILL.md` -- marker 5 detail
+- `.squad/skills/pre-spawn-checklist/SKILL.md` -- broader coordinator spawn hygiene
+- `.squad/routing.md` -- Mandatory Hygiene Tail section (references this SKILL)
+
+## References
+
+- Issue #414 -- formalization request (Sprint 19)
+- PR #401 -- spawn-prompt-hygiene.md template creation (Sprint 18)
+- PRs #406, #407 -- the fixup pattern this skill eliminates
+- Sprint 18 retro (`.squad/retros/2026-05-18-sprint-18-retro.md`) -- root cause analysis
+
+**Last reviewed:** 2026-05-18 (Sprint 19, issue #414)

--- a/scripts/lint-spawn-prompt.ps1
+++ b/scripts/lint-spawn-prompt.ps1
@@ -1,0 +1,74 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Checks a coordinator spawn prompt for all 6 mandatory hygiene tail markers.
+.DESCRIPTION
+    Reads a candidate spawn-prompt from --file <path> or stdin. Scans for the
+    6 mandatory hygiene tail markers. Exit 0 if all 6 are present. Exit 1 with
+    a list of missing markers if any are absent. Side-effect-free and idempotent.
+.EXAMPLE
+    pwsh -File scripts\lint-spawn-prompt.ps1 --file prompt.md
+    cat prompt.md | pwsh -File scripts\lint-spawn-prompt.ps1
+.PARAMETER file
+    Path to the spawn-prompt file to lint. If omitted, reads from stdin.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$filePath = $null
+
+$i = 0
+while ($i -lt $args.Count) {
+    switch ($args[$i]) {
+        '--file' { $i++; $filePath = $args[$i] }
+        default {
+            Write-Host "ERROR: Unknown argument: $($args[$i])" -ForegroundColor Red
+            exit 1
+        }
+    }
+    $i++
+}
+
+# Read input
+if ($filePath) {
+    if (-not (Test-Path -LiteralPath $filePath)) {
+        Write-Host "ERROR: File not found: $filePath" -ForegroundColor Red
+        exit 1
+    }
+    $promptText = [System.IO.File]::ReadAllText($filePath)
+} elseif ([System.Console]::IsInputRedirected) {
+    $promptText = [System.Console]::In.ReadToEnd()
+} else {
+    Write-Host "ERROR: No input provided. Use --file <path> or pipe prompt via stdin." -ForegroundColor Red
+    exit 1
+}
+
+# The 6 mandatory hygiene tail markers (in order from spawn-prompt-hygiene.md)
+$markers = @(
+    @{ Name = 'CWD-pin';                   Text = 'CWD-pin -- before every file write' },
+    @{ Name = 'base=develop discipline';   Text = 'base=develop discipline' },
+    @{ Name = 'ASCII discipline';          Text = 'ASCII discipline -- after every file write' },
+    @{ Name = 'history.md pre-size-check'; Text = 'history.md pre-size-check -- before every append' },
+    @{ Name = 'Worktree-remove-FIRST';     Text = 'Worktree-remove-FIRST cleanup -- after PR merges' },
+    @{ Name = 'Hygiene tail completion';   Text = 'Hygiene tail completion' }
+)
+
+$missing = @()
+foreach ($m in $markers) {
+    if ($promptText.IndexOf($m.Text) -lt 0) {
+        $missing += $m.Name
+    }
+}
+
+if ($missing.Count -eq 0) {
+    Write-Host "OK: All 6 hygiene tail markers present." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "FAIL: Missing $($missing.Count) of 6 hygiene tail markers:" -ForegroundColor Red
+    foreach ($name in $missing) {
+        Write-Host "  - $name" -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "Run scripts\squad-spawn.ps1 to assemble prompts with the hygiene tail auto-injected." -ForegroundColor Yellow
+    exit 1
+}

--- a/scripts/lint-spawn-prompt.sh
+++ b/scripts/lint-spawn-prompt.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/lint-spawn-prompt.sh
+# Checks a coordinator spawn prompt for all 6 mandatory hygiene tail markers.
+#
+# Usage:
+#   bash scripts/lint-spawn-prompt.sh [--file <path>]
+#   cat prompt.md | bash scripts/lint-spawn-prompt.sh
+#
+# Options:
+#   --file <path>  Spawn-prompt file to lint (default: stdin)
+#
+# Exit 0 if all 6 markers are present.
+# Exit 1 with a list of missing markers if any are absent.
+# Side-effect-free and idempotent.
+
+set -euo pipefail
+
+file_path=''
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --file) file_path="$2"; shift 2 ;;
+        *)
+            echo "ERROR: Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Read input
+if [ -n "$file_path" ]; then
+    if [ ! -f "$file_path" ]; then
+        echo "ERROR: File not found: $file_path" >&2
+        exit 1
+    fi
+    prompt_text="$(cat "$file_path")"
+else
+    prompt_text="$(cat)"
+fi
+
+# The 6 mandatory hygiene tail markers (in order from spawn-prompt-hygiene.md)
+markers=(
+    'CWD-pin -- before every file write'
+    'base=develop discipline'
+    'ASCII discipline -- after every file write'
+    'history.md pre-size-check -- before every append'
+    'Worktree-remove-FIRST cleanup -- after PR merges'
+    'Hygiene tail completion'
+)
+
+missing=()
+for marker in "${markers[@]}"; do
+    if ! printf '%s' "$prompt_text" | grep -qF "$marker"; then
+        missing+=("$marker")
+    fi
+done
+
+if [ ${#missing[@]} -eq 0 ]; then
+    echo "OK: All 6 hygiene tail markers present."
+    exit 0
+else
+    echo "FAIL: Missing ${#missing[@]} of 6 hygiene tail markers:" >&2
+    for m in "${missing[@]}"; do
+        echo "  - $m" >&2
+    done
+    echo "" >&2
+    echo "Run scripts/squad-spawn.sh to assemble prompts with the hygiene tail auto-injected." >&2
+    exit 1
+fi

--- a/scripts/squad-spawn.ps1
+++ b/scripts/squad-spawn.ps1
@@ -1,0 +1,106 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Assembles a coordinator spawn prompt by appending the hygiene tail template.
+.DESCRIPTION
+    Reads a spawn-prompt body from --body <path> or stdin, appends the verbatim
+    contents of .squad/templates/spawn-prompt-hygiene.md (with {name}, {N}, and
+    {worktree-path} substituted), and writes the assembled prompt to stdout.
+    Idempotent: if the body already contains all 6 hygiene tail markers the
+    template is not appended again.
+    Exit 0 on success, exit 1 on error.
+.EXAMPLE
+    pwsh -File scripts\squad-spawn.ps1 --body prompt.md --name donald --issue 123 --worktree C:\Coding\dev-setup-123
+    echo "body text" | pwsh -File scripts\squad-spawn.ps1 --name donald --issue 123 --worktree C:\Coding\dev-setup-123
+.PARAMETER body
+    Path to a file containing the spawn-prompt body. If omitted, body is read from stdin.
+.PARAMETER template
+    Path to the hygiene tail template. Defaults to .squad\templates\spawn-prompt-hygiene.md
+    relative to the repo root (parent of the scripts\ directory).
+.PARAMETER name
+    Agent name. Replaces {name} in the template.
+.PARAMETER issue
+    Issue number. Replaces {N} in the template.
+.PARAMETER worktree
+    Worktree path. Replaces {worktree-path} in the template.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$bodyPath     = $null
+$templatePath = $null
+$agentName    = ''
+$issueNum     = ''
+$worktreePath = ''
+
+$i = 0
+while ($i -lt $args.Count) {
+    switch ($args[$i]) {
+        '--body'     { $i++; $bodyPath     = $args[$i] }
+        '--template' { $i++; $templatePath = $args[$i] }
+        '--name'     { $i++; $agentName    = $args[$i] }
+        '--issue'    { $i++; $issueNum     = $args[$i] }
+        '--worktree' { $i++; $worktreePath = $args[$i] }
+        default {
+            Write-Host "ERROR: Unknown argument: $($args[$i])" -ForegroundColor Red
+            exit 1
+        }
+    }
+    $i++
+}
+
+# Resolve template path (default: .squad\templates\spawn-prompt-hygiene.md at repo root)
+if (-not $templatePath) {
+    $repoRoot     = Split-Path $PSScriptRoot -Parent
+    $templatePath = Join-Path $repoRoot '.squad\templates\spawn-prompt-hygiene.md'
+}
+
+if (-not (Test-Path -LiteralPath $templatePath)) {
+    Write-Host "ERROR: Template not found: $templatePath" -ForegroundColor Red
+    exit 1
+}
+
+# Read body
+if ($bodyPath) {
+    if (-not (Test-Path -LiteralPath $bodyPath)) {
+        Write-Host "ERROR: Body file not found: $bodyPath" -ForegroundColor Red
+        exit 1
+    }
+    $bodyText = [System.IO.File]::ReadAllText($bodyPath)
+} elseif ([System.Console]::IsInputRedirected) {
+    $bodyText = [System.Console]::In.ReadToEnd()
+} else {
+    Write-Host "ERROR: No body provided. Use --body <path> or pipe body text via stdin." -ForegroundColor Red
+    exit 1
+}
+
+if ([string]::IsNullOrWhiteSpace($bodyText)) {
+    Write-Host "ERROR: Body is empty. Provide --body <path> or pipe body text via stdin." -ForegroundColor Red
+    exit 1
+}
+
+# Read template and perform substitutions
+$templateText = [System.IO.File]::ReadAllText($templatePath)
+if ($agentName)    { $templateText = $templateText.Replace('{name}', $agentName) }
+if ($issueNum)     { $templateText = $templateText.Replace('{N}', $issueNum) }
+if ($worktreePath) { $templateText = $templateText.Replace('{worktree-path}', $worktreePath) }
+
+# Idempotency: skip re-append if all 6 hygiene tail markers are already present
+$markers = @(
+    'CWD-pin',
+    'base=develop discipline',
+    'ASCII discipline',
+    'history.md pre-size-check',
+    'Worktree-remove-FIRST',
+    'Hygiene tail completion'
+)
+$allPresent = $true
+foreach ($m in $markers) {
+    if ($bodyText.IndexOf($m) -lt 0) { $allPresent = $false; break }
+}
+
+if ($allPresent) {
+    [System.Console]::Write($bodyText)
+} else {
+    [System.Console]::Write($bodyText + "`n`n---`n`n" + $templateText)
+}

--- a/scripts/squad-spawn.sh
+++ b/scripts/squad-spawn.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# scripts/squad-spawn.sh
+# Assembles a coordinator spawn prompt by appending the hygiene tail template.
+#
+# Usage:
+#   bash scripts/squad-spawn.sh [--body <path>] [--template <path>] \
+#       --name <agent> --issue <N> --worktree <path>
+#   cat body.md | bash scripts/squad-spawn.sh --name donald --issue 123 \
+#       --worktree /path/to/dev-setup-123
+#
+# Options:
+#   --body <path>      Spawn-prompt body file (default: stdin)
+#   --template <path>  Hygiene tail template
+#                      (default: .squad/templates/spawn-prompt-hygiene.md)
+#   --name <agent>     Agent name -- replaces {name} in template
+#   --issue <N>        Issue number -- replaces {N} in template
+#   --worktree <path>  Worktree path -- replaces {worktree-path} in template
+#
+# Output: assembled prompt on stdout.
+# Exit 0 on success, exit 1 on error.
+# Idempotent: if the body already contains all 6 hygiene tail markers the
+# template is not appended again.
+
+set -euo pipefail
+
+body_path=''
+template_path=''
+agent_name=''
+issue_num=''
+worktree_path=''
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --body)     body_path="$2";     shift 2 ;;
+        --template) template_path="$2"; shift 2 ;;
+        --name)     agent_name="$2";    shift 2 ;;
+        --issue)    issue_num="$2";     shift 2 ;;
+        --worktree) worktree_path="$2"; shift 2 ;;
+        *)
+            echo "ERROR: Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve template path (default: .squad/templates/spawn-prompt-hygiene.md at repo root)
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(dirname "$script_dir")"
+if [ -z "$template_path" ]; then
+    template_path="${repo_root}/.squad/templates/spawn-prompt-hygiene.md"
+fi
+
+if [ ! -f "$template_path" ]; then
+    echo "ERROR: Template not found: $template_path" >&2
+    exit 1
+fi
+
+# Read body
+if [ -n "$body_path" ]; then
+    if [ ! -f "$body_path" ]; then
+        echo "ERROR: Body file not found: $body_path" >&2
+        exit 1
+    fi
+    body_text="$(cat "$body_path")"
+else
+    body_text="$(cat)"
+fi
+
+if [ -z "$(printf '%s' "$body_text" | tr -d '[:space:]')" ]; then
+    echo "ERROR: Body is empty. Provide --body <path> or pipe body text via stdin." >&2
+    exit 1
+fi
+
+# Read template and perform substitutions
+template_text="$(cat "$template_path")"
+if [ -n "$agent_name" ];    then template_text="${template_text//\{name\}/$agent_name}";         fi
+if [ -n "$issue_num" ];     then template_text="${template_text//\{N\}/$issue_num}";             fi
+if [ -n "$worktree_path" ]; then template_text="${template_text//\{worktree-path\}/$worktree_path}"; fi
+
+# Idempotency: skip re-append if all 6 hygiene tail markers are already present
+markers=(
+    'CWD-pin'
+    'base=develop discipline'
+    'ASCII discipline'
+    'history.md pre-size-check'
+    'Worktree-remove-FIRST'
+    'Hygiene tail completion'
+)
+all_present=true
+for marker in "${markers[@]}"; do
+    if ! printf '%s' "$body_text" | grep -qF "$marker"; then
+        all_present=false
+        break
+    fi
+done
+
+if [ "$all_present" = true ]; then
+    printf '%s' "$body_text"
+else
+    printf '%s\n\n---\n\n%s' "$body_text" "$template_text"
+fi

--- a/tests/test_spawn_prompt_lint.ps1
+++ b/tests/test_spawn_prompt_lint.ps1
@@ -1,0 +1,155 @@
+#!/usr/bin/env pwsh
+# tests/test_spawn_prompt_lint.ps1
+# Tests for scripts/lint-spawn-prompt.ps1 (Issue #414)
+#
+# Covers:
+#   A. All 6 markers present -- exits 0 with OK message
+#   B. One marker missing -- exits 1 and names the missing marker
+#   C. All markers missing -- exits 1 and lists all 6
+#   D. File not found -- exits 1 with error message
+#   E. Unknown argument -- exits 1
+#
+# Usage:
+#   pwsh -File tests\test_spawn_prompt_lint.ps1
+
+$ErrorActionPreference = 'Stop'
+$TestsPassed  = 0
+$TestsFailed  = 0
+
+$RepoRoot   = Split-Path $PSScriptRoot -Parent
+$ScriptPath = Join-Path $RepoRoot 'scripts\lint-spawn-prompt.ps1'
+
+# Temp directory for test fixtures (cleaned up on exit)
+$TmpDir = Join-Path $RepoRoot "tests\.tmp_lint_prompt_$PID"
+New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+function Remove-TmpDir {
+    if (Test-Path -LiteralPath $TmpDir) {
+        Remove-Item -LiteralPath $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+$null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action { Remove-TmpDir } -ErrorAction SilentlyContinue
+
+# Full hygiene tail block for reuse in tests
+$FullTail = @"
+### Hygiene Tail -- MANDATORY (do not omit any item)
+
+**1. CWD-pin -- before every file write**
+Run and PASS before touching any file.
+
+**2. base=develop discipline**
+Every gh pr create MUST pass --base develop explicitly.
+
+**3. ASCII discipline -- after every file write**
+0 non-ASCII bytes in every committed file.
+
+**4. history.md pre-size-check -- before every append**
+Check size before appending.
+
+**5. Worktree-remove-FIRST cleanup -- after PR merges**
+From the MAIN checkout, harvest then remove worktree.
+
+**6. Hygiene tail completion**
+Append history.md entry when done.
+"@
+
+function Test-Scenario {
+    param([string]$Name, [scriptblock]$Test)
+    Write-Host ""
+    Write-Host "=== TEST: $Name ===" -ForegroundColor Cyan
+    try {
+        & $Test
+        Write-Host "PASS: $Name" -ForegroundColor Green
+        $script:TestsPassed++
+    } catch {
+        Write-Host "FAIL: $Name" -ForegroundColor Red
+        Write-Host "  Error: $_" -ForegroundColor Red
+        $script:TestsFailed++
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test A: All 6 present -- exits 0
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'all 6 markers present exits 0 with OK message' {
+    $promptFile = Join-Path $TmpDir 'all6.md'
+    [System.IO.File]::WriteAllText($promptFile, "Spawn donald for issue 99.`n`n$FullTail", [System.Text.Encoding]::ASCII)
+
+    $output = pwsh -File $ScriptPath --file $promptFile 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "Expected exit 0, got $LASTEXITCODE; output: $output" }
+    if ($output -notmatch 'OK') { throw "Expected OK in output; got: $output" }
+}
+
+# ---------------------------------------------------------------------------
+# Test B: One marker missing -- exits 1 and names it
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'one marker missing exits 1 and names the missing item' {
+    # Remove the Worktree-remove-FIRST marker
+    $body = $FullTail -replace 'Worktree-remove-FIRST cleanup -- after PR merges', 'REMOVED_MARKER'
+    $promptFile = Join-Path $TmpDir 'missing_one.md'
+    [System.IO.File]::WriteAllText($promptFile, "Body.`n`n$body", [System.Text.Encoding]::ASCII)
+
+    $output = pwsh -File $ScriptPath --file $promptFile 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+    if ($output -notmatch 'Worktree-remove-FIRST') { throw "Expected missing marker name in output; got: $output" }
+    if ($output -notmatch 'FAIL') { throw "Expected FAIL label in output; got: $output" }
+}
+
+# ---------------------------------------------------------------------------
+# Test C: All markers missing -- exits 1 and lists all 6
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'all markers missing exits 1 and lists all 6' {
+    $promptFile = Join-Path $TmpDir 'none.md'
+    [System.IO.File]::WriteAllText($promptFile, "Spawn chip for issue 7. No hygiene tail here.", [System.Text.Encoding]::ASCII)
+
+    $output = pwsh -File $ScriptPath --file $promptFile 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+    foreach ($m in @('CWD-pin','base=develop discipline','ASCII discipline',
+                      'history.md pre-size-check','Worktree-remove-FIRST','Hygiene tail completion')) {
+        if ($output.IndexOf($m) -lt 0) { throw "Expected missing marker '$m' in output; got: $output" }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test D: File not found -- exits 1
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'file not found exits 1 with error message' {
+    $noFile = Join-Path $TmpDir 'no-such-prompt.md'
+
+    $output = pwsh -File $ScriptPath --file $noFile 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+    if ($output -notmatch 'not found') { throw "Expected 'not found' in error output; got: $output" }
+}
+
+# ---------------------------------------------------------------------------
+# Test E: Unknown argument -- exits 1
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'unknown argument exits 1' {
+    $output = pwsh -File $ScriptPath --bogus-flag 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup and summary
+# ---------------------------------------------------------------------------
+
+Remove-TmpDir
+
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor White
+Write-Host "Passed: $TestsPassed" -ForegroundColor Green
+Write-Host "Failed: $TestsFailed" -ForegroundColor $(if ($TestsFailed -gt 0) { 'Red' } else { 'White' })
+Write-Host "==========================================" -ForegroundColor White
+
+if ($TestsFailed -gt 0) {
+    Write-Host "TESTS FAILED" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "All tests PASSED" -ForegroundColor Green
+exit 0

--- a/tests/test_spawn_prompt_lint.sh
+++ b/tests/test_spawn_prompt_lint.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# tests/test_spawn_prompt_lint.sh
+# Tests for scripts/lint-spawn-prompt.sh (Issue #414)
+#
+# Covers:
+#   A. All 6 markers present -- exits 0 with OK message
+#   B. One marker missing -- exits 1 and names the missing marker
+#   C. All markers missing -- exits 1 and lists all 6
+#   D. File not found -- exits 1 with error message
+#   E. Unknown argument -- exits 1
+#
+# Usage:
+#   bash tests/test_spawn_prompt_lint.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LINT_SCRIPT="${REPO_ROOT}/scripts/lint-spawn-prompt.sh"
+
+passed=0
+failed=0
+
+pass() { printf '\033[0;32m[PASS]\033[0m %s\n' "$1"; passed=$((passed + 1)); }
+fail() { printf '\033[0;31m[FAIL]\033[0m %s\n' "$1"; failed=$((failed + 1)); }
+
+TMPDIR_BASE="${REPO_ROOT}/tests/.tmp_lint_prompt_$$"
+mkdir -p "$TMPDIR_BASE"
+# shellcheck disable=SC2329
+cleanup() { rm -rf "$TMPDIR_BASE"; }
+trap cleanup EXIT
+
+# Reusable full hygiene tail block (ASCII only)
+FULL_TAIL='
+### Hygiene Tail -- MANDATORY (do not omit any item)
+
+**1. CWD-pin -- before every file write**
+Run and PASS before touching any file.
+
+**2. base=develop discipline**
+Every gh pr create MUST pass --base develop explicitly.
+
+**3. ASCII discipline -- after every file write**
+0 non-ASCII bytes in every committed file.
+
+**4. history.md pre-size-check -- before every append**
+Check size before appending.
+
+**5. Worktree-remove-FIRST cleanup -- after PR merges**
+From the MAIN checkout, harvest then remove worktree.
+
+**6. Hygiene tail completion**
+Append history.md entry when done.
+'
+
+# ---------------------------------------------------------------------------
+# Test A: All 6 present -- exits 0
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test A: all 6 present ==="
+
+printf '%s\n%s' "Spawn chip for issue 77." "$FULL_TAIL" > "${TMPDIR_BASE}/all6.md"
+output="$(bash "$LINT_SCRIPT" --file "${TMPDIR_BASE}/all6.md" 2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 0 ]; then
+    fail "A: expected exit 0, got $code; output: $output"
+elif ! printf '%s' "$output" | grep -qF 'OK'; then
+    fail "A: expected OK in output; got: $output"
+else
+    pass "A: all 6 markers present exits 0 with OK message"
+fi
+
+# ---------------------------------------------------------------------------
+# Test B: One marker missing -- exits 1 and names it
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test B: one marker missing ==="
+
+# Replace the Worktree-remove-FIRST marker with a dummy string
+body_b="$(printf '%s' "$FULL_TAIL" | sed 's/Worktree-remove-FIRST cleanup -- after PR merges/REMOVED_MARKER/')"
+printf '%s\n%s' "Body." "$body_b" > "${TMPDIR_BASE}/missing_one.md"
+output="$(bash "$LINT_SCRIPT" --file "${TMPDIR_BASE}/missing_one.md" 2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "B: expected exit 1, got $code"
+elif ! printf '%s' "$output" | grep -qF 'Worktree-remove-FIRST'; then
+    fail "B: expected missing marker name in output; got: $output"
+else
+    pass "B: one marker missing exits 1 and names the missing item"
+fi
+
+# ---------------------------------------------------------------------------
+# Test C: All markers missing -- exits 1 and lists all 6
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test C: all markers missing ==="
+
+echo "Spawn pluto for dotfiles. No hygiene tail here." > "${TMPDIR_BASE}/none.md"
+output="$(bash "$LINT_SCRIPT" --file "${TMPDIR_BASE}/none.md" 2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "C: expected exit 1, got $code"
+else
+    all_listed=true
+    for m in \
+        'CWD-pin' \
+        'base=develop discipline' \
+        'ASCII discipline' \
+        'history.md pre-size-check' \
+        'Worktree-remove-FIRST' \
+        'Hygiene tail completion'; do
+        if ! printf '%s' "$output" | grep -qF "$m"; then
+            fail "C: expected missing marker '$m' in output; got: $output"
+            all_listed=false
+            break
+        fi
+    done
+    if [ "$all_listed" = true ]; then
+        pass "C: all markers missing exits 1 and lists all 6"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test D: File not found -- exits 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test D: file not found ==="
+
+output="$(bash "$LINT_SCRIPT" --file "${TMPDIR_BASE}/no-such-prompt.md" 2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "D: expected exit 1, got $code"
+elif ! printf '%s' "$output" | grep -qiF 'not found'; then
+    fail "D: expected 'not found' in error output; got: $output"
+else
+    pass "D: file not found exits 1 with error message"
+fi
+
+# ---------------------------------------------------------------------------
+# Test E: Unknown argument -- exits 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test E: unknown argument ==="
+
+output="$(bash "$LINT_SCRIPT" --bogus-flag 2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "E: expected exit 1, got $code; output: $output"
+else
+    pass "E: unknown argument exits 1"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=========================================="
+printf 'Passed: %d\n' "$passed"
+printf 'Failed: %d\n' "$failed"
+echo "=========================================="
+
+if [ "$failed" -gt 0 ]; then
+    echo "TESTS FAILED"
+    exit 1
+fi
+
+echo "All tests PASSED"
+exit 0

--- a/tests/test_squad_spawn.ps1
+++ b/tests/test_squad_spawn.ps1
@@ -1,0 +1,180 @@
+#!/usr/bin/env pwsh
+# tests/test_squad_spawn.ps1
+# Tests for scripts/squad-spawn.ps1 (Issue #414)
+#
+# Covers:
+#   A. Substitution: {name}, {N}, {worktree-path} replaced in output
+#   B. Missing template exits 1
+#   C. Idempotent: body already containing all 6 markers is not double-injected
+#   D. Empty body exits 1
+#   E. Missing body file exits 1
+#
+# Usage:
+#   pwsh -File tests\test_squad_spawn.ps1
+
+$ErrorActionPreference = 'Stop'
+$TestsPassed  = 0
+$TestsFailed  = 0
+
+$RepoRoot   = Split-Path $PSScriptRoot -Parent
+$ScriptPath = Join-Path $RepoRoot 'scripts\squad-spawn.ps1'
+
+# Temp directory for test fixtures (cleaned up on exit)
+$TmpDir = Join-Path $RepoRoot "tests\.tmp_squad_spawn_$PID"
+New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+function Remove-TmpDir {
+    if (Test-Path -LiteralPath $TmpDir) {
+        Remove-Item -LiteralPath $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+# Register cleanup
+$null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action { Remove-TmpDir } -ErrorAction SilentlyContinue
+
+function Test-Scenario {
+    param([string]$Name, [scriptblock]$Test)
+    Write-Host ""
+    Write-Host "=== TEST: $Name ===" -ForegroundColor Cyan
+    try {
+        & $Test
+        Write-Host "PASS: $Name" -ForegroundColor Green
+        $script:TestsPassed++
+    } catch {
+        Write-Host "FAIL: $Name" -ForegroundColor Red
+        Write-Host "  Error: $_" -ForegroundColor Red
+        $script:TestsFailed++
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test A: Substitutions are applied correctly
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'substitution replaces name, issue, and worktree-path in output' {
+    $bodyFile = Join-Path $TmpDir 'body_a.md'
+    [System.IO.File]::WriteAllText($bodyFile, "Spawn Donald to work on issue 123.", [System.Text.Encoding]::ASCII)
+
+    $output = pwsh -File $ScriptPath --body $bodyFile --name donald --issue 123 --worktree 'C:\Coding\dev-setup-123' 2>&1 | Out-String
+
+    if ($LASTEXITCODE -ne 0) { throw "Expected exit 0, got $LASTEXITCODE" }
+    if ($output -match '\{name\}')         { throw "{name} placeholder not substituted" }
+    if ($output -match '\{N\}')            { throw "{N} placeholder not substituted" }
+    if ($output -match '\{worktree-path\}') { throw "{worktree-path} placeholder not substituted" }
+    if ($output -notmatch 'donald')        { throw "agent name 'donald' not found in output" }
+    if ($output -notmatch '123')           { throw "issue number '123' not found in output" }
+    if ($output -notmatch [regex]::Escape('C:\Coding\dev-setup-123')) {
+        throw "worktree path not found in output"
+    }
+    # Output must contain all 6 hygiene tail markers
+    foreach ($m in @('CWD-pin','base=develop discipline','ASCII discipline',
+                      'history.md pre-size-check','Worktree-remove-FIRST','Hygiene tail completion')) {
+        if ($output.IndexOf($m) -lt 0) { throw "Marker '$m' not found in output" }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test B: Missing template exits 1 with error message
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'missing template exits 1 with error message' {
+    $bodyFile = Join-Path $TmpDir 'body_b.md'
+    [System.IO.File]::WriteAllText($bodyFile, "Some spawn body.", [System.Text.Encoding]::ASCII)
+
+    $fakeTpl = Join-Path $TmpDir 'nonexistent-template.md'
+
+    $output = pwsh -File $ScriptPath --body $bodyFile --template $fakeTpl 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+    if ($output -notmatch 'Template not found') { throw "Error message missing; got: $output" }
+}
+
+# ---------------------------------------------------------------------------
+# Test C: Idempotent -- body already contains all 6 markers is not re-injected
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'idempotent: all-6-marker body is not double-injected' {
+    $fullBody = @"
+Spawn goofy for issue 42.
+
+### Hygiene Tail -- MANDATORY (do not omit any item)
+
+**1. CWD-pin -- before every file write**
+Run and PASS before touching any file.
+
+**2. base=develop discipline**
+Every gh pr create MUST pass --base develop explicitly.
+
+**3. ASCII discipline -- after every file write**
+0 non-ASCII bytes in every committed file.
+
+**4. history.md pre-size-check -- before every append**
+Check size before appending.
+
+**5. Worktree-remove-FIRST cleanup -- after PR merges**
+From the MAIN checkout, harvest then remove worktree.
+
+**6. Hygiene tail completion**
+Append history.md entry when done.
+"@
+    $bodyFile = Join-Path $TmpDir 'body_c.md'
+    [System.IO.File]::WriteAllText($bodyFile, $fullBody, [System.Text.Encoding]::ASCII)
+
+    $output = pwsh -File $ScriptPath --body $bodyFile --name goofy --issue 42 --worktree 'C:\Coding\dev-setup-42' 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "Expected exit 0, got $LASTEXITCODE" }
+
+    # Count occurrences of the first marker -- must appear exactly once
+    $markerText = 'CWD-pin -- before every file write'
+    $count = 0
+    $idx = 0
+    while ($true) {
+        $idx = $output.IndexOf($markerText, $idx)
+        if ($idx -lt 0) { break }
+        $count++
+        $idx++
+    }
+    if ($count -ne 1) { throw "Marker appeared $count times (expected 1); hygiene tail was double-injected" }
+}
+
+# ---------------------------------------------------------------------------
+# Test D: Empty body exits 1
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'empty body file exits 1' {
+    $bodyFile = Join-Path $TmpDir 'body_d.md'
+    [System.IO.File]::WriteAllText($bodyFile, '   ', [System.Text.Encoding]::ASCII)
+
+    $output = pwsh -File $ScriptPath --body $bodyFile 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+    if ($output -notmatch 'empty') { throw "Expected 'empty' in error output; got: $output" }
+}
+
+# ---------------------------------------------------------------------------
+# Test E: Missing body file exits 1
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'missing body file exits 1' {
+    $noFile = Join-Path $TmpDir 'no-such-body.md'
+
+    $output = pwsh -File $ScriptPath --body $noFile 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 1) { throw "Expected exit 1, got $LASTEXITCODE" }
+    if ($output -notmatch 'not found') { throw "Expected 'not found' in error output; got: $output" }
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup and summary
+# ---------------------------------------------------------------------------
+
+Remove-TmpDir
+
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor White
+Write-Host "Passed: $TestsPassed" -ForegroundColor Green
+Write-Host "Failed: $TestsFailed" -ForegroundColor $(if ($TestsFailed -gt 0) { 'Red' } else { 'White' })
+Write-Host "==========================================" -ForegroundColor White
+
+if ($TestsFailed -gt 0) {
+    Write-Host "TESTS FAILED" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "All tests PASSED" -ForegroundColor Green
+exit 0

--- a/tests/test_squad_spawn.sh
+++ b/tests/test_squad_spawn.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# tests/test_squad_spawn.sh
+# Tests for scripts/squad-spawn.sh (Issue #414)
+#
+# Covers:
+#   A. Substitution: {name}, {N}, {worktree-path} replaced in output
+#   B. Missing template exits 1
+#   C. Idempotent: body already containing all 6 markers is not double-injected
+#   D. Empty body exits 1
+#   E. Missing body file exits 1
+#
+# Usage:
+#   bash tests/test_squad_spawn.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPAWN_SCRIPT="${REPO_ROOT}/scripts/squad-spawn.sh"
+
+passed=0
+failed=0
+
+pass() { printf '\033[0;32m[PASS]\033[0m %s\n' "$1"; passed=$((passed + 1)); }
+fail() { printf '\033[0;31m[FAIL]\033[0m %s\n' "$1"; failed=$((failed + 1)); }
+
+TMPDIR_BASE="${REPO_ROOT}/tests/.tmp_squad_spawn_$$"
+mkdir -p "$TMPDIR_BASE"
+# shellcheck disable=SC2329
+cleanup() { rm -rf "$TMPDIR_BASE"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Test A: Substitutions are applied correctly
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test A: substitution ==="
+
+echo "Spawn donald to work on issue 123." > "${TMPDIR_BASE}/body_a.md"
+output="$(bash "$SPAWN_SCRIPT" \
+    --body "${TMPDIR_BASE}/body_a.md" \
+    --name donald \
+    --issue 123 \
+    --worktree /coding/dev-setup-123 \
+    2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 0 ]; then
+    fail "A: expected exit 0, got $code"
+elif printf '%s' "$output" | grep -qF '{name}'; then
+    fail "A: {name} placeholder not substituted"
+elif printf '%s' "$output" | grep -qF '{N}'; then
+    fail "A: {N} placeholder not substituted"
+elif printf '%s' "$output" | grep -qF '{worktree-path}'; then
+    fail "A: {worktree-path} placeholder not substituted"
+elif ! printf '%s' "$output" | grep -qF 'donald'; then
+    fail "A: agent name 'donald' not found in output"
+elif ! printf '%s' "$output" | grep -qF '123'; then
+    fail "A: issue number '123' not found in output"
+elif ! printf '%s' "$output" | grep -qF '/coding/dev-setup-123'; then
+    fail "A: worktree path not found in output"
+else
+    all_ok=true
+    for m in \
+        'CWD-pin' \
+        'base=develop discipline' \
+        'ASCII discipline' \
+        'history.md pre-size-check' \
+        'Worktree-remove-FIRST' \
+        'Hygiene tail completion'; do
+        if ! printf '%s' "$output" | grep -qF "$m"; then
+            fail "A: marker '$m' missing from output"
+            all_ok=false
+            break
+        fi
+    done
+    if [ "$all_ok" = true ]; then
+        pass "A: substitution replaces name, issue, and worktree-path in output"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test B: Missing template exits 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test B: missing template ==="
+
+echo "Some body." > "${TMPDIR_BASE}/body_b.md"
+output="$(bash "$SPAWN_SCRIPT" \
+    --body "${TMPDIR_BASE}/body_b.md" \
+    --template "${TMPDIR_BASE}/nonexistent-template.md" \
+    2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "B: expected exit 1, got $code"
+elif ! printf '%s' "$output" | grep -qiF 'Template not found'; then
+    fail "B: error message missing; got: $output"
+else
+    pass "B: missing template exits 1 with error message"
+fi
+
+# ---------------------------------------------------------------------------
+# Test C: Idempotent -- body already containing all 6 markers
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test C: idempotent ==="
+
+cat > "${TMPDIR_BASE}/body_c.md" << 'IDEMPOTENT_BODY'
+Spawn goofy for issue 42.
+
+### Hygiene Tail -- MANDATORY (do not omit any item)
+
+**1. CWD-pin -- before every file write**
+Run and PASS before touching any file.
+
+**2. base=develop discipline**
+Every gh pr create MUST pass --base develop explicitly.
+
+**3. ASCII discipline -- after every file write**
+0 non-ASCII bytes in every committed file.
+
+**4. history.md pre-size-check -- before every append**
+Check size before appending.
+
+**5. Worktree-remove-FIRST cleanup -- after PR merges**
+From the MAIN checkout, harvest then remove worktree.
+
+**6. Hygiene tail completion**
+Append history.md entry when done.
+IDEMPOTENT_BODY
+
+output="$(bash "$SPAWN_SCRIPT" \
+    --body "${TMPDIR_BASE}/body_c.md" \
+    --name goofy \
+    --issue 42 \
+    --worktree /coding/dev-setup-42 \
+    2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 0 ]; then
+    fail "C: expected exit 0, got $code"
+else
+    # Count occurrences of the first marker -- must be exactly 1
+    count="$(printf '%s' "$output" | grep -cF 'CWD-pin -- before every file write' || true)"
+    if [ "$count" -ne 1 ]; then
+        fail "C: marker appeared $count times (expected 1); hygiene tail was double-injected"
+    else
+        pass "C: idempotent -- all-6-marker body is not double-injected"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test D: Empty body exits 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test D: empty body ==="
+
+printf '   ' > "${TMPDIR_BASE}/body_d.md"
+output="$(bash "$SPAWN_SCRIPT" \
+    --body "${TMPDIR_BASE}/body_d.md" \
+    2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "D: expected exit 1, got $code"
+elif ! printf '%s' "$output" | grep -qiF 'empty'; then
+    fail "D: expected 'empty' in error output; got: $output"
+else
+    pass "D: empty body exits 1"
+fi
+
+# ---------------------------------------------------------------------------
+# Test E: Missing body file exits 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Test E: missing body file ==="
+
+output="$(bash "$SPAWN_SCRIPT" \
+    --body "${TMPDIR_BASE}/no-such-body.md" \
+    2>&1)" && code=0 || code=$?
+
+if [ "$code" -ne 1 ]; then
+    fail "E: expected exit 1, got $code"
+elif ! printf '%s' "$output" | grep -qiF 'not found'; then
+    fail "E: expected 'not found' in error output; got: $output"
+else
+    pass "E: missing body file exits 1"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=========================================="
+printf 'Passed: %d\n' "$passed"
+printf 'Failed: %d\n' "$failed"
+echo "=========================================="
+
+if [ "$failed" -gt 0 ]; then
+    echo "TESTS FAILED"
+    exit 1
+fi
+
+echo "All tests PASSED"
+exit 0


### PR DESCRIPTION
## Summary

Root-cause fix for the Sprint 18 fixup pattern (PRs #406/#407): coordinator
forgot to embed .squad/templates/spawn-prompt-hygiene.md into spawn prompts,
causing agents to breach the hygiene tail. This PR makes injection automatic
and verifiable.

## Deliverables

### Phase 1 -- Coordinator-side helper (auto-inject)
- `scripts/squad-spawn.ps1` (Windows) and `scripts/squad-spawn.sh` (POSIX)
  - `--body <path>` or stdin for spawn-prompt body
  - `--template <path>` (optional, defaults to .squad/templates/spawn-prompt-hygiene.md)
  - `--name`, `--issue`, `--worktree` for placeholder substitution
  - Idempotent: skips re-inject if all 6 markers already present
  - Exits 1 on missing template or empty body

### Phase 2 -- Lint backstop (verify before spawning)
- `scripts/lint-spawn-prompt.ps1` (Windows) and `scripts/lint-spawn-prompt.sh` (POSIX)
  - `--file <path>` or stdin
  - Checks for all 6 mandatory markers
  - Exit 0 = all present; Exit 1 = list of missing markers
  - Side-effect-free and idempotent

### SKILL + routing
- `.squad/skills/spawn-prompt-lint/SKILL.md`: documents 6 markers, inject recipe,
  lint recipe (confidence: medium)
- `.squad/routing.md`: Mandatory Hygiene Tail section updated to require coordinators
  to use squad-spawn OR lint-spawn-prompt before every spawn

### Tests (20 total, 5 per file, 4 files)
- `tests/test_squad_spawn.ps1` and `.sh`: substitution, missing template, idempotent,
  empty body, missing body file
- `tests/test_spawn_prompt_lint.ps1` and `.sh`: all-6-pass, one-missing-fail,
  all-missing-fail, file-not-found, unknown-arg

## Acceptance Criteria

- [x] Both helper scripts work cross-platform (verified: 10/10 tests pass on Windows + bash)
- [x] Both linter scripts work cross-platform (verified: 10/10 tests pass on Windows + bash)
- [x] SKILL.md exists and documents the 6 markers
- [x] routing.md updated with helper/linter directive
- [x] All new tests pass locally (20/20)
- [x] Existing pre-commit hook passes (bash hooks/pre-commit exit 0)

Closes #414