### PR TITLE
feat(scripts): codify CHANGELOG fold recipe as script (#415)

### DIFF
--- a/.copilot/skills/changelog-fold-completeness/SKILL.md
+++ b/.copilot/skills/changelog-fold-completeness/SKILL.md
@@ -201,4 +201,30 @@ individual agent appends and therefore lives at the team level.
 - `CHANGELOG.md` -- Keep a Changelog format reference
 - `https://keepachangelog.com/en/1.1.0/` -- canonical format spec
 
-**Last reviewed:** 2026-05-17 (Sprint 18, issue #399)
+## Codified Script
+
+This SKILL has been codified as executable scripts (Issue #415):
+
+- `scripts/changelog-fold.sh` -- POSIX bash implementation
+- `scripts/changelog-fold.ps1` -- PowerShell mirror
+
+**Usage (bash):**
+```
+bash scripts/changelog-fold.sh \
+  --release-version X.Y.Z \
+  --last-tag X.Y.W \
+  --release-date YYYY-MM-DD \
+  [--changelog-path path/to/CHANGELOG.md] \
+  [--dry-run | --apply]
+```
+
+Default mode is `--dry-run`. Pass `--apply` to write changes in-place.
+
+The scripts:
+- Resolve the last-tag commit date from git
+- Query `gh pr list` and `gh issue list` for items since that date
+- Deduplicate, categorize by label or title prefix
+- Check for items missing from `[Unreleased]` and warn to stderr
+- Build a correctly formatted section and either print (dry-run) or splice it in
+
+**Last reviewed:** 2026-05-18 (Sprint 19, Issue #415)

--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -80,6 +80,12 @@ Full details in `.squad/agents/donald/history-archive.md`. Key work: Issues #68-
 - Cross-link: CONTRIBUTING.md's new section sits between Parallel Agent Work and Group Letter Assignment, so the testing sections cluster.
 - Out of scope (per ticket): refactoring tests, adding new tests, changing `set -*` flags in existing files, PowerShell test harness.
 
+### Sprint 19 -- PR #415: Codify changelog-fold-completeness as script
+
+- **What:** Implemented `scripts/changelog-fold.sh` (POSIX bash) and `scripts/changelog-fold.ps1` (PowerShell) to automate the CHANGELOG fold recipe from `.copilot/skills/changelog-fold-completeness/SKILL.md`. Added `tests/test_changelog_fold.ps1` (5 tests, all pass). Updated SKILL.md to reference the new scripts.
+- **CLI:** `--release-version` (required), `--last-tag`, `--release-date`, `--changelog-path`, `--dry-run` (default), `--apply`. Idempotency gate exits 1 if version already present.
+- **Key fixes:** (1) `[[ -n ]] &&` compound in `$()` with `set -e` aborts subshell -- replaced with unconditional `printf`. (2) PowerShell here-strings write CRLF, breaking bash stub shebangs in tests -- fixed via `[System.IO.File]::WriteAllText` with `($lines -join "\`n")`. (3) Scoop jq shim hits arg-length limit on large JSON -- pre-combined arrays via stdin instead of `--argjson`. Live dry-run against 0.9.8..HEAD: 104 PRs + 51 issues processed cleanly.
+
 ### Sprint 17 -- PR #389 (closes #382): Sprint-end label automation with verification
 
 - **What:** Hybrid (C) delivery -- standalone bash script `scripts/sprint-end-labels.sh` and matching workflow `.github/workflows/sprint-end-labels.yml`. For every issue/PR carrying a given sprint label, removes `release:backlog` (if present) and adds `release:shipped-X.Y.Z` (if missing). Never touches type/area/squad/priority labels.

--- a/scripts/changelog-fold.ps1
+++ b/scripts/changelog-fold.ps1
@@ -1,0 +1,366 @@
+# scripts/changelog-fold.ps1 -- CHANGELOG fold automation (Issue #415)
+#
+# Owner: Donald
+# Closes: #415 (Windows mirror of scripts/changelog-fold.sh)
+#
+# Enumerates all PRs merged and issues closed since the last release tag,
+# categorizes them by label/title-prefix, compares with [Unreleased], and
+# either prints the proposed [X.Y.Z] section (-DryRun, default) or folds
+# CHANGELOG.md in-place (-Apply).
+#
+# Usage (PowerShell naming convention -- same logic as changelog-fold.sh):
+#   scripts/changelog-fold.ps1 -ReleaseVersion X.Y.Z [options]
+#
+# Required:
+#   -ReleaseVersion X.Y.Z
+#
+# Optional:
+#   -LastTag TAG              (default: git describe --tags --abbrev=0 origin/main)
+#   -ReleaseDate YYYY-MM-DD   (default: today)
+#   -ChangelogPath PATH       (default: .\CHANGELOG.md)
+#   -DryRun                   (default -- print proposed section to stdout)
+#   -Apply                    (in-place fold; mutually exclusive with -DryRun)
+#
+# Examples:
+#   # Dry-run (default):
+#   scripts/changelog-fold.ps1 -ReleaseVersion 0.9.9 -LastTag 0.9.8
+#
+#   # Apply (in-place):
+#   scripts/changelog-fold.ps1 -ReleaseVersion 0.9.9 -LastTag 0.9.8 -Apply
+
+[CmdletBinding(DefaultParameterSetName = 'DryRun')]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseVersion,
+
+    [string]$LastTag = '',
+
+    [string]$ReleaseDate = '',
+
+    [string]$ChangelogPath = '.\CHANGELOG.md',
+
+    [Parameter(ParameterSetName = 'DryRun')]
+    [switch]$DryRun,
+
+    [Parameter(ParameterSetName = 'Apply')]
+    [switch]$Apply
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Mode = if ($Apply) { 'apply' } else { 'dry-run' }
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+function Write-Log   { param([string]$Msg) Write-Host "[changelog-fold] $Msg" }
+function Write-Warn  { param([string]$Msg) Write-Host "[changelog-fold] WARN: $Msg" -ForegroundColor Yellow }
+function Write-Err   { param([string]$Msg) Write-Host "[changelog-fold] ERROR: $Msg" -ForegroundColor Red }
+
+# ---------------------------------------------------------------------------
+# Tool checks
+# ---------------------------------------------------------------------------
+
+foreach ($tool in @('gh', 'jq')) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        Write-Err "$tool not found on PATH"
+        exit 127
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+if ($ReleaseVersion -notmatch '^\d+\.\d+\.\d+$') {
+    Write-Err "-ReleaseVersion must be X.Y.Z (e.g. 0.9.9), got: $ReleaseVersion"
+    exit 2
+}
+
+if ($ReleaseDate -ne '' -and $ReleaseDate -notmatch '^\d{4}-\d{2}-\d{2}$') {
+    Write-Err "-ReleaseDate must be YYYY-MM-DD, got: $ReleaseDate"
+    exit 2
+}
+
+if (-not (Test-Path -LiteralPath $ChangelogPath)) {
+    Write-Err "CHANGELOG not found at: $ChangelogPath"
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Resolve defaults
+# ---------------------------------------------------------------------------
+
+if ($LastTag -eq '') {
+    Write-Log "resolving last tag via git describe ..."
+    $LastTag = (git describe --tags --abbrev=0 origin/main 2>$null) `
+             ?? (git describe --tags --abbrev=0 2>$null)
+    if (-not $LastTag) {
+        Write-Err "could not resolve last tag; use -LastTag TAG"
+        exit 1
+    }
+    Write-Log "last tag: $LastTag"
+}
+
+if ($ReleaseDate -eq '') {
+    $ReleaseDate = (Get-Date -Format 'yyyy-MM-dd')
+}
+
+# ---------------------------------------------------------------------------
+# Idempotency gate: reject if version already folded
+# ---------------------------------------------------------------------------
+
+$changelogContent = Get-Content -LiteralPath $ChangelogPath -Raw
+if ($changelogContent -match "(?m)^## \[$([regex]::Escape($ReleaseVersion))\]") {
+    Write-Err "version [$ReleaseVersion] is already present in $ChangelogPath -- already folded (idempotency gate)"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Resolve last tag SHA and date
+# ---------------------------------------------------------------------------
+
+Write-Log "resolving tag SHA for: $LastTag ..."
+$lastTagSha = (git rev-parse "$LastTag^{commit}" 2>$null) `
+            ?? (git rev-parse $LastTag 2>$null)
+if (-not $lastTagSha) {
+    Write-Err "could not resolve SHA for tag: $LastTag"
+    exit 1
+}
+$lastTagDate = ((git log -1 --format='%ci' $lastTagSha) -split ' ')[0]
+Write-Log "last tag SHA : $lastTagSha"
+Write-Log "last tag date: $lastTagDate"
+
+# ---------------------------------------------------------------------------
+# Enumerate merged PRs
+# ---------------------------------------------------------------------------
+
+Write-Log "enumerating PRs merged since $lastTagDate ..."
+$prsJson = (gh pr list `
+    --state merged `
+    --search "merged:>=$lastTagDate" `
+    --json number,title,labels,mergedAt `
+    --limit 200) -replace '\r', ''
+$prCount = ($prsJson | jq 'length')
+Write-Log "found $prCount merged PR(s)"
+
+# ---------------------------------------------------------------------------
+# Enumerate closed issues (excluding PR numbers)
+# ---------------------------------------------------------------------------
+
+Write-Log "enumerating issues closed since $lastTagDate ..."
+$issuesJson = (gh issue list `
+    --state closed `
+    --search "closed:>=$lastTagDate" `
+    --json number,title,labels,closedAt `
+    --limit 200) -replace '\r', ''
+
+$prNumbersArr = $prsJson | jq '[.[].number]'
+$issuesFiltered = $issuesJson | jq `
+    --argjson prnums $prNumbersArr `
+    '[.[] | select(.number as $n | ($prnums | index($n)) == null)]'
+$issueCount = ($issuesFiltered | jq 'length')
+Write-Log "found $issueCount closed issue(s) (after PR dedup)"
+
+# ---------------------------------------------------------------------------
+# Categorize
+# ---------------------------------------------------------------------------
+
+function Get-Category {
+    param([string]$Number, [string]$Title, [string]$LabelsCsv)
+
+    $csv = ",$LabelsCsv,"
+    if ($csv -match ',type:feature,') { return 'Added' }
+    if ($csv -match ',type:bug,')     { return 'Fixed' }
+    if ($csv -match ',type:chore,')   { return 'Changed' }
+    if ($csv -match ',type:docs,')    { return 'Changed' }
+
+    if ($Title -match '^feat[:(]')                                      { return 'Added' }
+    if ($Title -match '^fix[:(]')                                       { return 'Fixed' }
+    if ($Title -match '^(chore|docs|refactor|perf|style)[:(]')         { return 'Changed' }
+
+    Write-Warn "#${Number} '${Title}': no label/prefix match -- categorized as Changed"
+    return 'Changed'
+}
+
+# ---------------------------------------------------------------------------
+# Build categorized entry lines
+# ---------------------------------------------------------------------------
+
+$addedLines   = [System.Collections.Generic.List[string]]::new()
+$changedLines = [System.Collections.Generic.List[string]]::new()
+$fixedLines   = [System.Collections.Generic.List[string]]::new()
+$removedLines = [System.Collections.Generic.List[string]]::new()
+
+$allItems = (jq -rn `
+    --argjson prs $prsJson `
+    --argjson issues $issuesFiltered `
+    '($prs + $issues | sort_by(.number)) | .[] | [(.number|tostring), .title, ([.labels // [] | .[].name] | join(","))] | @tsv') `
+    -replace '\r', ''
+
+foreach ($line in ($allItems -split "`n")) {
+    if ($line -eq '') { continue }
+    $parts      = $line -split "`t", 3
+    $num        = $parts[0]
+    $title      = if ($parts.Count -gt 1) { $parts[1] } else { '' }
+    $labelsCsv  = if ($parts.Count -gt 2) { $parts[2] } else { '' }
+    $cat        = Get-Category -Number $num -Title $title -LabelsCsv $labelsCsv
+    $entry      = "- $title (#$num)"
+    switch ($cat) {
+        'Added'   { $addedLines.Add($entry) }
+        'Changed' { $changedLines.Add($entry) }
+        'Fixed'   { $fixedLines.Add($entry) }
+        'Removed' { $removedLines.Add($entry) }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Check for missing entries in [Unreleased]
+# ---------------------------------------------------------------------------
+
+$changelogLines   = Get-Content -LiteralPath $ChangelogPath
+$inUnreleased     = $false
+$unreleasedLines  = [System.Collections.Generic.List[string]]::new()
+foreach ($cl in $changelogLines) {
+    if ($cl -match '^## \[Unreleased\]') { $inUnreleased = $true; continue }
+    if ($inUnreleased -and $cl -match '^## \[')  { break }
+    if ($inUnreleased) { $unreleasedLines.Add($cl) }
+}
+$unreleasedText = $unreleasedLines -join "`n"
+
+$missingNums = [System.Collections.Generic.List[string]]::new()
+$allNums = (jq -rn `
+    --argjson prs $prsJson `
+    --argjson issues $issuesFiltered `
+    '($prs + $issues | sort_by(.number)) | .[].number') -replace '\r', ''
+foreach ($n in ($allNums -split "`n")) {
+    if ($n -eq '') { continue }
+    if ($unreleasedText -notmatch "\(#$n\)") {
+        $missingNums.Add("#$n")
+    }
+}
+if ($missingNums.Count -gt 0) {
+    Write-Warn "Missing from [Unreleased]: $($missingNums -join ', ')"
+}
+
+# ---------------------------------------------------------------------------
+# Build new [X.Y.Z] section
+# ---------------------------------------------------------------------------
+
+function Build-Section {
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine("## [$ReleaseVersion] - $ReleaseDate")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('### Added')
+    foreach ($e in $addedLines)   { [void]$sb.AppendLine($e) }
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('### Changed')
+    foreach ($e in $changedLines) { [void]$sb.AppendLine($e) }
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('### Fixed')
+    foreach ($e in $fixedLines)   { [void]$sb.AppendLine($e) }
+    [void]$sb.AppendLine()
+    [void]$sb.Append('### Removed')
+    foreach ($e in $removedLines) {
+        [void]$sb.AppendLine()
+        [void]$sb.Append($e)
+    }
+    return $sb.ToString()
+}
+
+$newSection = Build-Section
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Log "mode        : $Mode"
+Write-Log "version     : $ReleaseVersion"
+Write-Log "date        : $ReleaseDate"
+Write-Log "last tag    : $LastTag ($lastTagDate)"
+Write-Log "entries     : Added=$($addedLines.Count) Changed=$($changedLines.Count) Fixed=$($fixedLines.Count) Removed=$($removedLines.Count)"
+
+# ---------------------------------------------------------------------------
+# Dry-run: print proposed section and exit
+# ---------------------------------------------------------------------------
+
+if ($Mode -eq 'dry-run') {
+    Write-Host ""
+    Write-Host "=== Proposed [$ReleaseVersion] section (dry-run) ==="
+    Write-Host $newSection
+    Write-Host "=== End proposed section ==="
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Apply: fold CHANGELOG.md in-place
+# ---------------------------------------------------------------------------
+
+$unreleasedIdx = -1
+for ($i = 0; $i -lt $changelogLines.Count; $i++) {
+    if ($changelogLines[$i] -match '^## \[Unreleased\]') {
+        $unreleasedIdx = $i
+        break
+    }
+}
+if ($unreleasedIdx -lt 0) {
+    Write-Err "## [Unreleased] not found in $ChangelogPath"
+    exit 1
+}
+
+$nextVersionIdx = -1
+for ($i = $unreleasedIdx + 1; $i -lt $changelogLines.Count; $i++) {
+    if ($changelogLines[$i] -match '^## \[') {
+        $nextVersionIdx = $i
+        break
+    }
+}
+if ($nextVersionIdx -lt 0) {
+    Write-Err "no versioned section found after [Unreleased] in $ChangelogPath"
+    exit 1
+}
+
+$freshUnreleased = @(
+    '## [Unreleased]',
+    '',
+    '### Added',
+    '',
+    '### Changed',
+    '',
+    '### Fixed',
+    '',
+    '### Removed'
+)
+
+$newLines = [System.Collections.Generic.List[string]]::new()
+
+# Lines before ## [Unreleased]
+for ($i = 0; $i -lt $unreleasedIdx; $i++) {
+    $newLines.Add($changelogLines[$i])
+}
+
+# Fresh empty [Unreleased] block
+foreach ($l in $freshUnreleased) { $newLines.Add($l) }
+$newLines.Add('')
+
+# New [X.Y.Z] section
+foreach ($l in ($newSection -split "`r?`n")) { $newLines.Add($l) }
+$newLines.Add('')
+
+# Rest of file from previous version header
+for ($i = $nextVersionIdx; $i -lt $changelogLines.Count; $i++) {
+    $newLines.Add($changelogLines[$i])
+}
+
+# Write with LF line endings (Unix-style -- same as the source file)
+$output = ($newLines -join "`n")
+[System.IO.File]::WriteAllText(
+    (Resolve-Path $ChangelogPath).Path,
+    $output,
+    [System.Text.Encoding]::ASCII
+)
+
+Write-Log "CHANGELOG.md updated: [Unreleased] folded to [$ReleaseVersion]"
+Write-Log "fresh [Unreleased] block restored above [$ReleaseVersion]"

--- a/scripts/changelog-fold.sh
+++ b/scripts/changelog-fold.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# scripts/changelog-fold.sh -- CHANGELOG fold automation (Issue #415)
+#
+# Usage:
+#   bash scripts/changelog-fold.sh \
+#     --release-version X.Y.Z \
+#     --last-tag X.Y.W \
+#     [--release-date YYYY-MM-DD]   (default: today)
+#     [--changelog-path PATH]       (default: ./CHANGELOG.md)
+#     [--dry-run]                   (default)
+#     [--apply]
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '[changelog-fold] %s\n'        "$*" >&2; }
+warn() { printf '[changelog-fold] WARN: %s\n'  "$*" >&2; }
+die()  { printf '[changelog-fold] ERROR: %s\n' "$*" >&2; exit 1; }
+usage_die() { printf '[changelog-fold] ERROR: %s\n' "$*" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+RELEASE_VERSION=""
+LAST_TAG=""
+RELEASE_DATE=""
+CHANGELOG_PATH="./CHANGELOG.md"
+MODE="dry-run"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-version) RELEASE_VERSION="$2"; shift 2 ;;
+    --last-tag)        LAST_TAG="$2";        shift 2 ;;
+    --release-date)    RELEASE_DATE="$2";    shift 2 ;;
+    --changelog-path)  CHANGELOG_PATH="$2";  shift 2 ;;
+    --dry-run)         MODE="dry-run";       shift   ;;
+    --apply)           MODE="apply";         shift   ;;
+    *) usage_die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$RELEASE_VERSION" ]] || usage_die "--release-version is required"
+[[ -f "$CHANGELOG_PATH"  ]] || die "CHANGELOG not found: $CHANGELOG_PATH"
+
+# Default release date to today
+if [[ -z "$RELEASE_DATE" ]]; then
+  RELEASE_DATE=$(date +%Y-%m-%d)
+fi
+
+# ---------------------------------------------------------------------------
+# Idempotency gate
+# ---------------------------------------------------------------------------
+
+if grep -q "\[${RELEASE_VERSION}\]" "$CHANGELOG_PATH"; then
+  die "version [${RELEASE_VERSION}] is already present in ${CHANGELOG_PATH} -- already folded (idempotency gate)"
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve last-tag commit date
+# ---------------------------------------------------------------------------
+
+LAST_TAG_DATE=""
+
+if [[ -n "$LAST_TAG" ]]; then
+  log "resolving tag SHA for: $LAST_TAG ..."
+  LAST_TAG_SHA=$(git log -1 --format="%H" "$LAST_TAG" 2>/dev/null || true)
+  if [[ -z "$LAST_TAG_SHA" ]]; then
+    die "could not resolve tag: $LAST_TAG"
+  fi
+  log "last tag SHA : $LAST_TAG_SHA"
+  LAST_TAG_DATE=$(git log -1 --format="%as" "$LAST_TAG")
+  log "last tag date: $LAST_TAG_DATE"
+else
+  LAST_TAG_DATE=$(date -d "90 days ago" +%Y-%m-%d 2>/dev/null \
+    || date -v -90d +%Y-%m-%d 2>/dev/null \
+    || date +%Y-%m-%d)
+  log "no --last-tag supplied; using $LAST_TAG_DATE as cutoff"
+fi
+
+# ---------------------------------------------------------------------------
+# Enumerate merged PRs since last tag date
+# ---------------------------------------------------------------------------
+
+log "enumerating PRs merged since $LAST_TAG_DATE ..."
+prs_json=$(gh pr list \
+  --state merged \
+  --search "merged:>=${LAST_TAG_DATE}" \
+  --json number,title,labels,mergedAt \
+  --limit 200 | tr -d '\r')
+pr_count=$(printf '%s' "$prs_json" | jq 'length')
+log "found $pr_count merged PR(s)"
+
+# ---------------------------------------------------------------------------
+# Enumerate closed issues since last tag date (excluding PR numbers)
+# ---------------------------------------------------------------------------
+
+log "enumerating issues closed since $LAST_TAG_DATE ..."
+issues_json=$(gh issue list \
+  --state closed \
+  --search "closed:>=${LAST_TAG_DATE}" \
+  --json number,title,labels,closedAt \
+  --limit 200 | tr -d '\r')
+
+# Filter: exclude items whose numbers appear in the PR list.
+pr_numbers_arr=$(printf '%s' "$prs_json" | jq '[.[].number]')
+issues_filtered=$(printf '%s' "$issues_json" | jq \
+  --argjson prnums "$pr_numbers_arr" \
+  '[.[] | select(.number as $n | ($prnums | index($n)) == null)]')
+issue_count=$(printf '%s' "$issues_filtered" | jq 'length')
+log "found $issue_count closed issue(s) (after PR dedup)"
+
+# Combine and sort once; use stdin piping to avoid --argjson arg-length limits
+combined_json=$(printf '%s\n%s' "$prs_json" "$issues_filtered" | jq -s 'add | sort_by(.number)')
+
+# ---------------------------------------------------------------------------
+# Categorize: label-first, then title-prefix, then Changed with WARN
+# ---------------------------------------------------------------------------
+
+categorize() {
+  local number="$1" title="$2" labels_csv="$3"
+
+  # Label takes priority
+  case ",$labels_csv," in
+    *",type:feature,"*) echo "Added";   return ;;
+    *",type:bug,"*)     echo "Fixed";   return ;;
+    *",type:chore,"*)   echo "Changed"; return ;;
+    *",type:docs,"*)    echo "Changed"; return ;;
+  esac
+
+  # Fall back to title prefix (conventional commits)
+  case "$title" in
+    feat:*|"feat("*)                                    echo "Added";   return ;;
+    fix:*|"fix("*)                                      echo "Fixed";   return ;;
+    chore:*|"chore("*|docs:*|"docs("*|\
+    refactor:*|"refactor("*|perf:*|"perf("*)           echo "Changed"; return ;;
+  esac
+
+  warn "#${number} '${title}': no label/prefix match -- categorized as Changed"
+  echo "Changed"
+}
+
+# ---------------------------------------------------------------------------
+# Build categorized entry lines
+# ---------------------------------------------------------------------------
+
+added_lines=""
+changed_lines=""
+fixed_lines=""
+removed_lines=""
+
+while IFS=$'\t' read -r number title labels_csv; do
+  category=$(categorize "$number" "$title" "$labels_csv")
+  entry="- ${title} (#${number})"
+  case "$category" in
+    Added)   added_lines="${added_lines}${entry}"$'\n' ;;
+    Changed) changed_lines="${changed_lines}${entry}"$'\n' ;;
+    Fixed)   fixed_lines="${fixed_lines}${entry}"$'\n' ;;
+    Removed) removed_lines="${removed_lines}${entry}"$'\n' ;;
+  esac
+done < <(printf '%s' "$combined_json" | jq -r \
+  '.[] | [(.number|tostring), .title, ([.labels // [] | .[].name] | join(","))] | @tsv' \
+  | tr -d '\r')
+
+# ---------------------------------------------------------------------------
+# Check for missing entries in [Unreleased] -- warn to stderr
+# ---------------------------------------------------------------------------
+
+unreleased_content=$(awk '
+  /^## \[Unreleased\]/ { found=1; next }
+  found && /^## \[/    { exit }
+  found                { print }
+' "$CHANGELOG_PATH")
+
+missing_list=""
+while IFS=$'\t' read -r number _title; do
+  if ! printf '%s' "$unreleased_content" | grep -q "(#${number})"; then
+    if [[ -n "$missing_list" ]]; then missing_list="${missing_list}, "; fi
+    missing_list="${missing_list}#${number}"
+  fi
+done < <(printf '%s' "$combined_json" | jq -r \
+  '.[] | [(.number|tostring), .title] | @tsv' \
+  | tr -d '\r')
+
+if [[ -n "$missing_list" ]]; then
+  warn "Missing from [Unreleased]: $missing_list"
+fi
+
+# ---------------------------------------------------------------------------
+# Build the new [X.Y.Z] section
+# ---------------------------------------------------------------------------
+
+build_section() {
+  printf '## [%s] - %s\n\n' "$RELEASE_VERSION" "$RELEASE_DATE"
+  printf '### Added\n'
+  printf '%s' "$added_lines"
+  printf '\n'
+  printf '### Changed\n'
+  printf '%s' "$changed_lines"
+  printf '\n'
+  printf '### Fixed\n'
+  printf '%s' "$fixed_lines"
+  printf '\n'
+  printf '### Removed\n'
+  printf '%s' "$removed_lines"
+}
+
+NEW_SECTION=$(build_section)
+
+# ---------------------------------------------------------------------------
+# Summary / dry-run output
+# ---------------------------------------------------------------------------
+
+added_count=$(printf '%s' "$added_lines"   | grep -c '^-' || true)
+changed_count=$(printf '%s' "$changed_lines" | grep -c '^-' || true)
+fixed_count=$(printf '%s' "$fixed_lines"   | grep -c '^-' || true)
+removed_count=$(printf '%s' "$removed_lines" | grep -c '^-' || true)
+
+log "mode        : $MODE"
+log "version     : $RELEASE_VERSION"
+log "date        : $RELEASE_DATE"
+log "last tag    : ${LAST_TAG:-<none>} (${LAST_TAG_DATE:-<unknown>})"
+log "entries     : Added=${added_count} Changed=${changed_count} Fixed=${fixed_count} Removed=${removed_count}"
+
+if [[ "$MODE" == "dry-run" ]]; then
+  printf '\n=== Proposed [%s] section (dry-run) ===\n' "$RELEASE_VERSION"
+  printf '%s\n' "$NEW_SECTION"
+  printf '=== End proposed section ===\n'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Apply mode: splice new section into CHANGELOG.md
+# ---------------------------------------------------------------------------
+
+# Find the line number of ## [Unreleased]
+unreleased_line=$(grep -n '^## \[Unreleased\]' "$CHANGELOG_PATH" | head -1 | cut -d: -f1)
+if [[ -z "$unreleased_line" ]]; then
+  die "could not find '## [Unreleased]' in $CHANGELOG_PATH"
+fi
+
+# Find the next version line after [Unreleased]
+next_version_line=$(awk -v start="$unreleased_line" '
+  NR > start && /^## \[/ { print NR; exit }
+' "$CHANGELOG_PATH")
+
+if [[ -z "$next_version_line" ]]; then
+  die "could not find any existing version section after [Unreleased] in $CHANGELOG_PATH"
+fi
+
+# Build fresh [Unreleased] block
+fresh_unreleased="## [Unreleased]"$'\n'$'\n'
+
+# Assemble the new file
+{
+  head -n $(( unreleased_line - 1 )) "$CHANGELOG_PATH"
+  printf '%s\n' "$fresh_unreleased"
+  printf '%s\n\n' "$NEW_SECTION"
+  tail -n +"${next_version_line}" "$CHANGELOG_PATH"
+} > "${CHANGELOG_PATH}.tmp"
+
+mv "${CHANGELOG_PATH}.tmp" "$CHANGELOG_PATH"
+
+log "applied [${RELEASE_VERSION}] section to ${CHANGELOG_PATH}"

--- a/tests/test_changelog_fold.ps1
+++ b/tests/test_changelog_fold.ps1
@@ -1,0 +1,441 @@
+#!/usr/bin/env pwsh
+# tests/test_changelog_fold.ps1
+# Tests for scripts/changelog-fold.sh (Issue #415)
+#
+# Coverage:
+#   A. Dry-run output is printed to stdout; CHANGELOG.md is not modified.
+#   B. Apply mode correctly folds [Unreleased] into [X.Y.Z] and restores
+#      a fresh [Unreleased] block.
+#   C. Missing-entries detection: entries present in the gh query but absent
+#      from [Unreleased] are reported to stderr.
+#   D. Idempotency gate: a second --apply for the same version exits 1 with
+#      a clear "already folded" error message.
+#   E. Argument validation: missing --release-version exits 2.
+#
+# Mocking strategy:
+#   Tests A-C create a stub gh script in a temp dir added to PATH.
+#   Test D relies on the idempotency check which runs BEFORE any gh calls.
+#   The repo must have tag 0.9.7 resolvable (used as --last-tag).
+#
+# Usage:
+#   pwsh -File tests\test_changelog_fold.ps1
+
+$ErrorActionPreference = 'Stop'
+$TestsPassed  = 0
+$TestsFailed  = 0
+$TestsSkipped = 0
+
+$RepoRoot   = Split-Path $PSScriptRoot -Parent
+$ScriptPath = Join-Path $RepoRoot 'scripts\changelog-fold.sh'
+
+function Test-Scenario {
+    param(
+        [string]$Name,
+        [scriptblock]$Test
+    )
+    Write-Host ""
+    Write-Host "=== TEST: $Name ===" -ForegroundColor Cyan
+    try {
+        & $Test
+        Write-Host "PASS: $Name" -ForegroundColor Green
+        $script:TestsPassed++
+    }
+    catch {
+        Write-Host "FAIL: $Name" -ForegroundColor Red
+        Write-Host "  Error: $_" -ForegroundColor Red
+        $script:TestsFailed++
+    }
+}
+
+function Write-Skip {
+    param([string]$Name, [string]$Reason)
+    Write-Host ""
+    Write-Host "=== TEST: $Name ===" -ForegroundColor Cyan
+    Write-Host "SKIP: $Name" -ForegroundColor Yellow
+    Write-Host "  Reason: $Reason" -ForegroundColor Yellow
+    $script:TestsSkipped++
+}
+
+# ---------------------------------------------------------------------------
+# Bash discovery (skips WSL stub at System32\bash.exe per Sprint-17 lesson)
+# ---------------------------------------------------------------------------
+
+$bashPath = $null
+$candidates = @(
+    'C:\Program Files\Git\bin\bash.exe',
+    'C:\Program Files\Git\usr\bin\bash.exe',
+    '/usr/bin/bash',
+    '/bin/bash'
+)
+foreach ($c in $candidates) {
+    if (Test-Path -LiteralPath $c -ErrorAction SilentlyContinue) {
+        $bashPath = $c
+        break
+    }
+}
+if (-not $bashPath) {
+    try {
+        $cmd = Get-Command bash -ErrorAction Stop
+        if ($cmd.Source -notmatch '[\\/]System32[\\/]bash\.exe$') {
+            $bashPath = $cmd.Source
+        }
+    } catch { }
+}
+
+if (-not $bashPath) {
+    Write-Skip 'all tests' 'bash not available on this machine'
+    exit 0
+}
+
+Write-Host "Using bash at: $bashPath" -ForegroundColor DarkGray
+
+# ---------------------------------------------------------------------------
+# Minimal CHANGELOG fixture used by tests A, B, C
+# ---------------------------------------------------------------------------
+
+$FixtureChangelog = @'
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.9.7] - 2026-05-17
+
+### Added
+- Sprint-end label automation (#382)
+
+### Changed
+
+### Fixed
+
+### Removed
+'@
+
+# ---------------------------------------------------------------------------
+# Minimal CHANGELOG for idempotency test D (version already present)
+# ---------------------------------------------------------------------------
+
+$IdempotentChangelog = @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.9.99] - 2026-05-18
+
+### Added
+- already there (#1)
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.9.7] - 2026-05-17
+
+### Added
+- Sprint-end label automation (#382)
+
+### Changed
+
+### Fixed
+
+### Removed
+'@
+
+# ---------------------------------------------------------------------------
+# Helper: convert a Windows path to a POSIX path for Git Bash
+# ---------------------------------------------------------------------------
+
+function ConvertTo-PosixPath {
+    param([string]$WinPath)
+    $p = $WinPath.Replace('\', '/')
+    if ($p -match '^([A-Za-z]):(.*)') {
+        return '/' + $Matches[1].ToLower() + $Matches[2]
+    }
+    return $p
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a temp test dir and stub gh in it (LF-only, no CRLF)
+# ---------------------------------------------------------------------------
+
+function New-TestEnv {
+    param(
+        [string]$TestId,
+        [string]$GhPrJson    = '[]',
+        [string]$GhIssueJson = '[]'
+    )
+    $dir      = Join-Path $RepoRoot ".test-tmp\cf-$TestId-$([Guid]::NewGuid().ToString('N').Substring(0,8))"
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    $stubPath = Join-Path $dir 'gh'
+
+    # Build stub with LF-only line endings (CRLF breaks the bash shebang).
+    # JSON is wrapped in bash single-quotes so internal double-quotes are literal.
+    $lines = @(
+        '#!/usr/bin/env bash',
+        'case "$1 $2" in',
+        ("  `"pr list`")    printf '%s\n' " + "'" + $GhPrJson    + "' ;;"),
+        ("  `"issue list`") printf '%s\n' " + "'" + $GhIssueJson + "' ;;"),
+        "  *)            exit 0 ;;",
+        "esac"
+    )
+    $content = ($lines -join "`n") + "`n"
+    [System.IO.File]::WriteAllText($stubPath, $content, [System.Text.Encoding]::ASCII)
+
+    # chmod +x so bash can execute it via PATH lookup
+    $posixStub = ConvertTo-PosixPath $stubPath
+    & $bashPath -c "chmod +x '$posixStub'"
+
+    return $dir
+}
+
+function Remove-TestEnv {
+    param([string]$Dir)
+    if (Test-Path -LiteralPath $Dir) {
+        Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test A: dry-run prints proposed section to stdout; CHANGELOG unchanged
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'A: dry-run output present; CHANGELOG not modified' {
+    $env_dir = New-TestEnv -TestId 'A'
+    $tmpChangelog = Join-Path $env_dir 'CHANGELOG.md'
+    Set-Content -Path $tmpChangelog -Value $FixtureChangelog -Encoding ASCII
+
+    $posixEnvDir    = ConvertTo-PosixPath $env_dir
+    $posixScript    = ConvertTo-PosixPath $ScriptPath
+    $posixChangelog = ConvertTo-PosixPath $tmpChangelog
+    try {
+        $out = & $bashPath -c "
+export PATH='$posixEnvDir':`$PATH
+'$posixScript' \
+    --release-version 0.9.99 \
+    --last-tag 0.9.7 \
+    --release-date 2026-05-18 \
+    --changelog-path '$posixChangelog' \
+    --dry-run
+" 2>&1
+        $code = $LASTEXITCODE
+
+        if ($code -ne 0) {
+            throw "expected exit 0 from --dry-run, got $code; output: $($out -join ' ')"
+        }
+        $outStr = $out -join "`n"
+        if ($outStr -notmatch 'Proposed') {
+            throw "expected 'Proposed' in stdout; got: $outStr"
+        }
+        if ($outStr -notmatch '\[0\.9\.99\]') {
+            throw "expected version header in stdout; got: $outStr"
+        }
+        # CHANGELOG must be unchanged (no [0.9.99] in it)
+        $afterContent = Get-Content -LiteralPath $tmpChangelog -Raw
+        if ($afterContent -match '\[0\.9\.99\]') {
+            throw "--dry-run must not modify CHANGELOG.md"
+        }
+    }
+    finally {
+        Remove-TestEnv -Dir $env_dir
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test B: apply mode folds [Unreleased] into [X.Y.Z]; fresh [Unreleased] restored
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'B: apply mode folds CHANGELOG.md correctly' {
+    $prJson    = '[{"number":901,"title":"feat: add thing","labels":[{"name":"type:feature"}],"mergedAt":"2026-05-01T00:00:00Z"}]'
+    $issueJson = '[{"number":902,"title":"fix: fix bug","labels":[{"name":"type:bug"}],"closedAt":"2026-05-01T00:00:00Z"}]'
+    $env_dir   = New-TestEnv -TestId 'B' -GhPrJson $prJson -GhIssueJson $issueJson
+    $tmpChangelog = Join-Path $env_dir 'CHANGELOG.md'
+    Set-Content -Path $tmpChangelog -Value $FixtureChangelog -Encoding ASCII
+
+    $posixEnvDir    = ConvertTo-PosixPath $env_dir
+    $posixScript    = ConvertTo-PosixPath $ScriptPath
+    $posixChangelog = ConvertTo-PosixPath $tmpChangelog
+    try {
+        $out = & $bashPath -c "
+export PATH='$posixEnvDir':`$PATH
+'$posixScript' \
+    --release-version 0.9.99 \
+    --last-tag 0.9.7 \
+    --release-date 2026-05-18 \
+    --changelog-path '$posixChangelog' \
+    --apply
+" 2>&1
+        $code = $LASTEXITCODE
+
+        if ($code -ne 0) {
+            throw "expected exit 0 from --apply, got $code; output: $($out -join ' ')"
+        }
+
+        $result = Get-Content -LiteralPath $tmpChangelog -Raw
+
+        # New version header present
+        if ($result -notmatch '\[0\.9\.99\] - 2026-05-18') {
+            throw "new version header not found in CHANGELOG.md"
+        }
+        # Fresh [Unreleased] present
+        if ($result -notmatch '(?m)^## \[Unreleased\]') {
+            throw "fresh [Unreleased] block not found in CHANGELOG.md"
+        }
+        # [Unreleased] appears BEFORE [0.9.99]
+        $unrelIdx = $result.IndexOf('## [Unreleased]')
+        $verIdx   = $result.IndexOf('## [0.9.99]')
+        if ($unrelIdx -ge $verIdx) {
+            throw "[Unreleased] must appear before [0.9.99]"
+        }
+        # Categorized entries present
+        if ($result -notmatch 'feat: add thing \(#901\)') {
+            throw "Added entry #901 not found"
+        }
+        if ($result -notmatch 'fix: fix bug \(#902\)') {
+            throw "Fixed entry #902 not found"
+        }
+        # Previous version still present
+        if ($result -notmatch '\[0\.9\.7\]') {
+            throw "prior version [0.9.7] not preserved"
+        }
+    }
+    finally {
+        Remove-TestEnv -Dir $env_dir
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test C: missing-entries detection reports to stderr
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'C: missing entries reported to stderr' {
+    # PR #999 is not referenced in [Unreleased] of the fixture
+    $prJson  = '[{"number":999,"title":"feat: unreported feature","labels":[{"name":"type:feature"}],"mergedAt":"2026-05-01T00:00:00Z"}]'
+    $env_dir = New-TestEnv -TestId 'C' -GhPrJson $prJson
+    $tmpChangelog = Join-Path $env_dir 'CHANGELOG.md'
+    Set-Content -Path $tmpChangelog -Value $FixtureChangelog -Encoding ASCII
+
+    $posixEnvDir    = ConvertTo-PosixPath $env_dir
+    $posixScript    = ConvertTo-PosixPath $ScriptPath
+    $posixChangelog = ConvertTo-PosixPath $tmpChangelog
+    try {
+        $tmpErr     = Join-Path $env_dir 'stderr.txt'
+        $posixErr   = ConvertTo-PosixPath $tmpErr
+        & $bashPath -c "
+export PATH='$posixEnvDir':`$PATH
+'$posixScript' \
+    --release-version 0.9.99 \
+    --last-tag 0.9.7 \
+    --release-date 2026-05-18 \
+    --changelog-path '$posixChangelog' \
+    --dry-run \
+    2>'$posixErr'
+" | Out-Null
+        $errContent = if (Test-Path $tmpErr) { Get-Content -LiteralPath $tmpErr -Raw } else { '' }
+
+        if ($errContent -notmatch 'Missing from \[Unreleased\]') {
+            throw "expected 'Missing from [Unreleased]' in stderr; got: $errContent"
+        }
+        if ($errContent -notmatch '#999') {
+            throw "expected '#999' in missing-entries warning; got: $errContent"
+        }
+    }
+    finally {
+        Remove-TestEnv -Dir $env_dir
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test D: idempotency -- second --apply exits 1 with "already folded"
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'D: idempotency gate exits 1 for already-folded version' {
+    $env_dir = New-TestEnv -TestId 'D'
+    $tmpChangelog = Join-Path $env_dir 'CHANGELOG.md'
+    Set-Content -Path $tmpChangelog -Value $IdempotentChangelog -Encoding ASCII
+
+    $posixEnvDir    = ConvertTo-PosixPath $env_dir
+    $posixScript    = ConvertTo-PosixPath $ScriptPath
+    $posixChangelog = ConvertTo-PosixPath $tmpChangelog
+    try {
+        $out = & $bashPath -c "
+export PATH='$posixEnvDir':`$PATH
+'$posixScript' \
+    --release-version 0.9.99 \
+    --last-tag 0.9.7 \
+    --release-date 2026-05-18 \
+    --changelog-path '$posixChangelog' \
+    --apply
+" 2>&1
+        $code = $LASTEXITCODE
+
+        if ($code -ne 1) {
+            throw "expected exit 1 from idempotency gate, got $code; output: $($out -join ' ')"
+        }
+        $outStr = $out -join "`n"
+        if ($outStr -notmatch 'already folded') {
+            throw "expected 'already folded' in error output; got: $outStr"
+        }
+    }
+    finally {
+        Remove-TestEnv -Dir $env_dir
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test E: missing --release-version exits 2
+# ---------------------------------------------------------------------------
+
+Test-Scenario 'E: missing --release-version exits 2' {
+    $posixScript = ConvertTo-PosixPath $ScriptPath
+    $out  = & $bashPath -c "'$posixScript' --last-tag 0.9.7 --dry-run" 2>&1
+    $code = $LASTEXITCODE
+    if ($code -ne 2) {
+        throw "expected exit 2 for missing --release-version, got $code; output: $($out -join ' ')"
+    }
+    $outStr = $out -join "`n"
+    if ($outStr -notmatch 'release-version') {
+        throw "expected '--release-version' in error output; got: $outStr"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup: remove .test-tmp directory if empty
+# ---------------------------------------------------------------------------
+
+$testTmpDir = Join-Path $RepoRoot '.test-tmp'
+if (Test-Path -LiteralPath $testTmpDir) {
+    $remaining = Get-ChildItem -LiteralPath $testTmpDir -ErrorAction SilentlyContinue
+    if (-not $remaining) {
+        Remove-Item -LiteralPath $testTmpDir -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "Results: $TestsPassed passed, $TestsFailed failed, $TestsSkipped skipped" `
+    -ForegroundColor $(if ($TestsFailed -gt 0) { 'Red' } else { 'Green' })
+
+if ($TestsFailed -gt 0) { exit 1 }
+exit 0


### PR DESCRIPTION
## Summary

Closes #415.

Codifies the `changelog-fold-completeness` SKILL recipe as two executable scripts:
- `scripts/changelog-fold.sh` -- POSIX bash implementation
- `scripts/changelog-fold.ps1` -- PowerShell mirror

## Usage

\\\ash
bash scripts/changelog-fold.sh \
  --release-version X.Y.Z \
  --last-tag X.Y.W \
  [--release-date YYYY-MM-DD] \
  [--changelog-path PATH] \
  [--dry-run | --apply]
\\\

Default mode is `--dry-run`. Pass `--apply` to write in-place.

## Logic

1. Idempotency gate: exits 1 if version already present
2. Resolves last-tag commit date via `git log`
3. Queries `gh pr list` + `gh issue list` since that date; deduplicates
4. Categorizes by `type:*` label > conventional-commit prefix > Changed+WARN
5. Reports items missing from `[Unreleased]` to stderr
6. Builds a formatted `## [X.Y.Z]` section; dry-runs print it, apply splices it in

## Tests

`tests/test_changelog_fold.ps1` -- 5 tests, all pass:
- A: dry-run does not modify CHANGELOG
- B: apply mode produces correct structure and entries
- C: missing entries reported to stderr
- D: idempotency gate exits 1 for already-folded version
- E: missing `--release-version` exits 2

## Live Validation

Ran `--dry-run` against the 0.9.8 tag (`--last-tag 0.9.8`, targeting 0.9.9):
- Resolved 104 merged PRs + 51 closed issues (after PR dedup) since 2026-05-17
- Categorized: Added=3, Changed=147, Fixed=5, Removed=0
- Warnings for 10 items with no label/prefix match (release commits, design issues)
- Missing-from-[Unreleased] warnings expected: the query covers all history since 0.9.7

Note: the 0.9.8 release itself triggers the idempotency gate correctly (exits 1).

## Key Implementation Notes

- **jq via stdin**: Pre-combines PR+issue arrays via `jq -s 'add'` to avoid Scoop jq shim argument-length limits on large datasets
- **LF-only tests**: Test stubs written with `[System.IO.File]::WriteAllText` + `(\ -join \"\
\")` to avoid CRLF bash shebang failures on Windows
- **build_section safety**: Uses unconditional `printf '%s' \` (not `[[ -n \ ]] && printf`) to avoid set -e abort inside `\`