### PR TITLE
chore(repo): unset local user.* override + add .mailmap (identity collapse)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,29 @@
+# .mailmap -- consolidates committer identities for git shortlog, git log --use-mailmap,
+# and GitHub's contributor graph. Does NOT rewrite history; non-destructive.
+#
+# Format: <Canonical Name> <canonical@email> <other@email>
+# See: https://git-scm.com/docs/gitmailmap
+
+# Copilot: collapse the dual identity. The Copilot CLI user (223556219+...)
+# and the @copilot bot account both represent the same Copilot collaborator.
+Copilot <copilot@github.com> <223556219+Copilot@users.noreply.github.com>
+
+# Earl Tankard, Jr., Ph.D.: consolidate his GitHub noreply form and his
+# personal gmail address into the single canonical noreply identity.
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> <theflashtank21@gmail.com>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> primetimetank21 <theflashtank21@gmail.com>
+
+# Squad agent fake-emails: these are Earl's local automation (no real GitHub
+# accounts). Attribute their commits/co-authorship to Earl.
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Jiminy <jiminy@local>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Jiminy <jiminy@dev-setup>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Ralph <ralph@local>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Ralph <ralph@dev-setup>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Scribe <scribe@local>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Scribe <scribe@dev-setup>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Doc <doc@local>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Doc <doc@dev-setup>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Donald <donald@squad.local>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Mickey <mickey@local>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Mickey <mickey@dev-setup>
+Earl Tankard, Jr., Ph.D. <45021016+primetimetank21@users.noreply.github.com> Pluto <pluto@local>


### PR DESCRIPTION
## Why

The repo currently shows "3 contributors" on GitHub but the real count is 2:
- Earl Tankard (real GitHub user)
- Copilot (one collaborator, but with two split identities in commit metadata)

Root cause investigation (2026-05-18 session):
1. `.git/config` had `user.name=Copilot / user.email=copilot@github.com` set locally,
   overriding Earl's global identity. Every local commit attributed Copilot as **author**.
2. Squash-merged PRs aggregated the agent's commit-author identity AND its
   `Co-authored-by` trailer, producing two distinct Copilot entries:
   - `Copilot <copilot@github.com>` (from local config)
   - `Copilot <223556219+Copilot@users.noreply.github.com>` (from system-mandated trailer)

## What

1. Unset `.git/config user.name` / `user.email` so future local commits use
   Earl's global identity instead of Copilot.
2. Add `.mailmap` collapsing:
   - Two Copilot identities -> one canonical `Copilot <copilot@github.com>`
   - Earl's gmail + GitHub noreply -> single canonical noreply identity
   - Squad agent fake-emails (`*@local`, `*@dev-setup`, `*@squad.local`) -> Earl

## Verification

After this change, `git shortlog -sne` shows the consolidated list (verified locally):
- 583 Earl Tankard
- 9 Copilot

No history rewrite. `.mailmap` is a display-only consolidation respected by
`git shortlog`, `git log --use-mailmap`, and GitHub's contributor graph.

Refs: `.squad/decisions.md` "Commit trailer convention -- Copilot identity collapse" (2026-05-18 Earl directive).