### PR TITLE
test(ci): wire orphan tests into validate.yml (#424)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,44 @@ jobs:
           chmod +x tests/test_alias_parity.sh
           bash tests/test_alias_parity.sh
 
+      - name: Run tool version tests
+        run: |
+          chmod +x tests/test_tool_versions.sh
+          bash tests/test_tool_versions.sh
+
+      - name: Run idempotency test
+        run: |
+          chmod +x tests/test_idempotency.sh
+          bash tests/test_idempotency.sh
+
+      - name: Run nvm bootstrap test
+        run: |
+          chmod +x tests/test_nvm_bootstrap.sh
+          bash tests/test_nvm_bootstrap.sh
+
+      - name: Run shared logging test
+        run: |
+          chmod +x tests/test_shared_logging.sh
+          bash tests/test_shared_logging.sh
+
+      - name: Run squad spawn test
+        run: |
+          chmod +x tests/test_squad_spawn.sh
+          bash tests/test_squad_spawn.sh
+
+      - name: Run spawn prompt lint test
+        run: |
+          chmod +x tests/test_spawn_prompt_lint.sh
+          bash tests/test_spawn_prompt_lint.sh
+
+      - name: Configure git hooks for precommit test
+        run: git config core.hooksPath hooks
+
+      - name: Run precommit hygiene test
+        run: |
+          chmod +x tests/test_precommit_hygiene.sh
+          bash tests/test_precommit_hygiene.sh
+
   validate-macos:
     name: Validate macOS Setup
     runs-on: macos-latest
@@ -157,6 +195,15 @@ jobs:
       - name: Run tool version tests
         run: bash tests/test_tool_versions.sh
 
+      - name: Run idempotency test
+        run: bash tests/test_idempotency.sh
+
+      - name: Run squad spawn test
+        run: bash tests/test_squad_spawn.sh
+
+      - name: Run spawn prompt lint test
+        run: bash tests/test_spawn_prompt_lint.sh
+
   lint-shell-scripts:
     name: Lint Shell Scripts
     runs-on: ubuntu-latest
@@ -220,6 +267,18 @@ jobs:
 
       - name: Run git hooks tests
         run: pwsh tests/test_git_hooks.ps1
+
+      - name: Run changelog fold test
+        run: pwsh tests/test_changelog_fold.ps1
+
+      - name: Run squad spawn test
+        run: pwsh tests/test_squad_spawn.ps1
+
+      - name: Run spawn prompt lint test
+        run: pwsh tests/test_spawn_prompt_lint.ps1
+
+      - name: Run sprint end labels test
+        run: pwsh tests/test_sprint_end_labels.ps1
 
   validate-ps51:
     name: Validate PowerShell 5.1 Compatibility

--- a/.squad/agents/chip/history.md
+++ b/.squad/agents/chip/history.md
@@ -106,3 +106,5 @@ Lessons preserved verbatim in Learnings section above (CP1252 encoding, PSVersio
 - Baseline failures (8: Copilot CLI live check + O-1..O-7 alias overrides) are environmental and pre-existed on develop @ 66930c6. Verified by stash + re-run before adding Group FF.
 - No Linux uninstall test file added: `tests/test_linux_setup.sh` does not exist; static-source parity in FF-4/FF-5 catches structural divergence between the two uninstall scripts without needing a separate functional bash harness.
 - Diff: +335 lines in `tests/test_windows_setup.ps1`. Pure ASCII (pre-commit clean). All 10 new tests pass locally; tally rose from 119 -> 129 passing (8 skipped, 8 pre-existing failures unchanged).
+
+**2026-05-18 (Sprint 19):** Issue #424 -- wired 10 orphan tests into validate.yml (Linux: +7, macOS: +3, Windows: +4). Skipped 3 .sh tests on macOS (Linux-specific paths: scripts/linux/lib/, scripts/linux/tools/). All 4 Windows .ps1 tests verified locally. PR #426.

--- a/.squad/decisions/sprint-19.md
+++ b/.squad/decisions/sprint-19.md
@@ -194,3 +194,51 @@ wildcard/escape issues with the marker strings (which contain parens and dots).
 
 Confidence: medium -- 1 observation; pattern may need revision once CI gate
 (Phase 3, out of scope here) is implemented and the full marker set is battle-tested.
+
+---
+
+# Decision: Per-Runner Exclusions for Orphan Tests (Issue #424)
+
+**Date:** 2026-05-18  
+**Author:** Chip  
+**Issue:** #424  
+**PR:** #426  
+
+## Context
+
+Wired 10 orphan tests from `tests/` into `.github/workflows/validate.yml`. Not all tests are suitable for all runners.
+
+## Decisions
+
+### macOS Exclusions
+
+Skipped 3 .sh tests on validate-macos job:
+- `test_nvm_bootstrap.sh` - refs `scripts/linux/tools/nvm.sh`, `scripts/linux/tools/squad-cli.sh`, `scripts/linux/tools/copilot-cli.sh`
+- `test_shared_logging.sh` - refs `scripts/linux/lib/log.sh` (Linux-specific logging library)
+- `test_precommit_hygiene.sh` - refs `hooks/pre-commit` (Linux-specific hook behavior)
+
+### Linux Inclusions
+
+Promoted `test_tool_versions.sh` from macOS-only to Linux (it's platform-agnostic, tests `.tool-versions` parsing via `scripts/lib/read-tool-version.sh`).
+
+### Windows Inclusions
+
+All 4 orphan .ps1 tests were wired and verified locally:
+- `test_changelog_fold.ps1` - 5/5 passed
+- `test_squad_spawn.ps1` - 5/5 passed
+- `test_spawn_prompt_lint.ps1` - 5/5 passed
+- `test_sprint_end_labels.ps1` - 7/7 passed
+
+### Non-Runnable Tests
+
+All `test_*.sh` and `test_*.ps1` files in `tests/` were confirmed as standalone entry-points (not sourced libraries). No files were excluded for being non-runnable.
+
+## Rationale
+
+- Linux-specific path references make macOS runs fail or produce false negatives
+- Platform-agnostic tests (idempotency, spawn tooling, tool version parsing) run on all applicable runners
+- Git hooks config (`git config core.hooksPath hooks`) was added before `test_precommit_hygiene.sh` on Linux (matches existing pattern for Windows git hooks tests)
+
+## Follow-up
+
+None required. All orphan tests are now wired or explicitly excluded with documented reason.


### PR DESCRIPTION
## Summary

Wires all orphan tests from 	ests/ into .github/workflows/validate.yml CI jobs.

## Changes

### validate-linux
- Added 	est_tool_versions.sh (promoted from macOS-only)
- Added 	est_idempotency.sh
- Added 	est_nvm_bootstrap.sh
- Added 	est_shared_logging.sh (Linux-specific: refs scripts/linux/lib/log.sh)
- Added 	est_squad_spawn.sh
- Added 	est_spawn_prompt_lint.sh
- Added 	est_precommit_hygiene.sh (with git hooks config step before test)

### validate-macos
- Added 	est_idempotency.sh
- Added 	est_squad_spawn.sh
- Added 	est_spawn_prompt_lint.sh
- **Skipped**: 	est_nvm_bootstrap.sh, 	est_shared_logging.sh, 	est_precommit_hygiene.sh (Linux-specific paths)

### validate-powershell
- Added 	est_changelog_fold.ps1
- Added 	est_squad_spawn.ps1
- Added 	est_spawn_prompt_lint.ps1
- Added 	est_sprint_end_labels.ps1

## Validation

All newly-wired Windows tests were run locally and pass:
- test_changelog_fold.ps1: 5/5 passed
- test_squad_spawn.ps1: 5/5 passed
- test_spawn_prompt_lint.ps1: 5/5 passed
- test_sprint_end_labels.ps1: 7/7 passed

YAML validated with Python yaml.safe_load and gh workflow view.

## Notes

Skipped tests on macOS (Linux-specific paths):
- test_nvm_bootstrap.sh (refs scripts/linux/tools/*.sh)
- test_shared_logging.sh (refs scripts/linux/lib/log.sh)
- test_precommit_hygiene.sh (refs hooks/pre-commit with Linux-specific behavior)

Closes #424