### PR TITLE
docs(squad): add parity-audit SKILL and lib-parity smoke test

### DIFF
--- a/.squad/agents/goofy/history.md
+++ b/.squad/agents/goofy/history.md
@@ -60,6 +60,7 @@ Implemented Windows PowerShell setup, utility alias framework, and architectural
 - Set-Alias -Force insufficient for AllScope aliases -- must Remove-Item first
 - Registry SetEnvironmentVariable for PATH persists across terminal sessions: `[System.Environment]::SetEnvironmentVariable('PATH', ..., 'User')`
 - Em dash fix pattern (PR #198): When PS 5.1 CI fails with TerminatorExpectedAtEndOfString, scan ALL .ps1 files on the branch for non-ASCII (bytes > 0x7F). Replace em dashes and other non-ASCII with ASCII equivalents in both comments and string literals. Use a byte-level scan (not just grep) to catch multi-byte UTF-8 sequences.
+- Cross-platform parity audits apply to top-level `scripts/*.{sh,ps1}` utilities and every file in `tests/`, but not platform installers under `scripts/linux/` or `scripts/windows/`. For function-exporting PowerShell libs, parity smoke tests should dot-source the file and call the function, and skip cleanly when `pwsh` is unavailable.
 
 ---
 

--- a/.squad/skills/parity-audit/SKILL.md
+++ b/.squad/skills/parity-audit/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: "parity-audit"
+description: "Audit top-level shell utilities and script-driven tests for Linux, macOS, and Windows parity requirements."
+domain: "cross-platform, testing"
+confidence: "medium"
+source: "observed"
+---
+
+## Context
+
+Cross-platform drift is a recurring failure mode in this repo. Top-level utility scripts and the tests that exercise them can quietly become bash-only or PowerShell-only unless parity is checked during planning and review.
+
+Use this skill when you add, review, or audit cross-platform utilities and shell-script tests.
+
+## Patterns
+
+### Scope
+
+In scope:
+- Top-level `scripts/*.{sh,ps1}` utility entrypoints
+- Every test file in `tests/`
+
+Out of scope:
+- `scripts/linux/`
+- `scripts/windows/`
+
+Platform-specific installers under `scripts/linux/` and `scripts/windows/` are intentionally platform-bound and do not need parity partners.
+
+### Utility parity rule
+
+Every cross-platform utility must have both a `.sh` and `.ps1` version, or an explicit single-platform justification recorded in a decision file.
+
+Acceptable justification locations:
+- `.squad/decisions.md`
+- `.squad/decisions/*.md`
+
+A missing partner file with no documented justification is a parity gap.
+
+### Test runner rule
+
+Every test that exercises shell scripts must run on Linux, macOS, and Windows runners, or have explicit per-runner exceptions documented inline as a comment in `.github/workflows/validate.yml`.
+
+Silent omissions are not acceptable. If a test is intentionally runner-specific, document why next to the workflow entry.
+
+### Audit recipe
+
+Bash inventory for top-level script pairs:
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+
+find "$repo_root/scripts" -maxdepth 1 -type f \( -name '*.sh' -o -name '*.ps1' \) \
+  | sed "s|$repo_root/||" \
+  | sed -E 's/\.(sh|ps1)$//' \
+  | sort \
+  | uniq -c
+```
+
+Bash parity-gap check for `scripts/` and `tests/`:
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+
+comm -3 \
+  <(find "$repo_root/scripts" -maxdepth 1 -type f -name '*.sh'  | sed "s|$repo_root/||" | sed 's/\.sh$//'  | sort) \
+  <(find "$repo_root/scripts" -maxdepth 1 -type f -name '*.ps1' | sed "s|$repo_root/||" | sed 's/\.ps1$//' | sort)
+
+comm -3 \
+  <(find "$repo_root/tests" -maxdepth 1 -type f -name '*.sh'  | sed "s|$repo_root/||" | sed 's/\.sh$//'  | sort) \
+  <(find "$repo_root/tests" -maxdepth 1 -type f -name '*.ps1' | sed "s|$repo_root/||" | sed 's/\.ps1$//' | sort)
+```
+
+PowerShell inventory for the same audit:
+
+```powershell
+$repoRoot = git rev-parse --show-toplevel
+
+Get-ChildItem (Join-Path $repoRoot 'scripts') -File |
+  Where-Object { $_.Extension -in '.sh', '.ps1' } |
+  Group-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) } |
+  Sort-Object Name |
+  Select-Object Count, Name
+
+Get-ChildItem (Join-Path $repoRoot 'tests') -File |
+  Where-Object { $_.Extension -in '.sh', '.ps1' } |
+  Group-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) } |
+  Sort-Object Name |
+  Select-Object Count, Name
+```
+
+PowerShell gap view:
+
+```powershell
+$repoRoot = git rev-parse --show-toplevel
+
+$scriptSh  = Get-ChildItem (Join-Path $repoRoot 'scripts') -Filter '*.sh'  -File | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) }
+$scriptPs1 = Get-ChildItem (Join-Path $repoRoot 'scripts') -Filter '*.ps1' -File | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) }
+Compare-Object ($scriptSh | Sort-Object) ($scriptPs1 | Sort-Object)
+
+$testSh  = Get-ChildItem (Join-Path $repoRoot 'tests') -Filter '*.sh'  -File | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) }
+$testPs1 = Get-ChildItem (Join-Path $repoRoot 'tests') -Filter '*.ps1' -File | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) }
+Compare-Object ($testSh | Sort-Object) ($testPs1 | Sort-Object)
+```
+
+Workflow audit prompt:
+- Check whether every shell-script test in `tests/` is wired into Linux, macOS, and Windows validation.
+- If a runner is intentionally excluded, require an inline justification comment in `validate.yml`.
+
+### When to invoke
+
+Invoke this skill during:
+- pre-sprint research
+- PR review for any new `scripts/*.{sh,ps1}` addition
+- PR review for any new `tests/*.{sh,ps1}` addition
+
+## Examples
+
+- Adding `scripts/foo.sh` means you also add `scripts/foo.ps1`, or record a decision explaining why the utility is intentionally single-platform.
+- Adding `tests/test_foo.sh` means you check `validate.yml` runner coverage and document any exception inline.
+- Auditing parity starts with inventory first, then documented exceptions, then workflow coverage.
+
+## Anti-Patterns
+
+- Treating `scripts/linux/` and `scripts/windows/` as parity gaps. They are platform-specific by design.
+- Adding a top-level `.sh` or `.ps1` utility and assuming the other platform can catch up later.
+- Adding a shell-script test without checking runner coverage in `validate.yml`.
+- Accepting undocumented runner exclusions or undocumented single-platform utilities.

--- a/tests/test_lib_parity.sh
+++ b/tests/test_lib_parity.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# tests/test_lib_parity.sh -- smoke test for read-tool-version parity across bash and PowerShell
+#
+# Usage: bash tests/test_lib_parity.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${RESET}: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}FAIL${RESET}: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo -e "${YELLOW}SKIP${RESET}: $1"; SKIP=$((SKIP + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SH_READER="${REPO_ROOT}/scripts/lib/read-tool-version.sh"
+PS1_READER="${REPO_ROOT}/scripts/lib/Read-ToolVersion.ps1"
+CAPTURED_STDOUT=''
+CAPTURED_RC=0
+
+capture_sh() {
+    local tool="$1"
+    CAPTURED_STDOUT="$(sh "$SH_READER" "$tool" 2>/dev/null)"
+    CAPTURED_RC=$?
+}
+
+capture_ps() {
+    local tool="$1"
+    CAPTURED_STDOUT="$(PS1_READER="$PS1_READER" TOOL_NAME="$tool" pwsh -NoProfile -Command "& { . \$env:PS1_READER; Get-ToolVersion -Name \$env:TOOL_NAME }" 2>/dev/null)"
+    CAPTURED_RC=$?
+}
+
+assert_matching_version() {
+    local label="$1"
+    local tool="$2"
+    local sh_out=''
+    local sh_rc=0
+    local ps_out=''
+    local ps_rc=0
+
+    capture_sh "$tool"
+    sh_out="$CAPTURED_STDOUT"
+    sh_rc=$CAPTURED_RC
+
+    capture_ps "$tool"
+    ps_out="$CAPTURED_STDOUT"
+    ps_rc=$CAPTURED_RC
+
+    if [ "$sh_rc" -eq 0 ] && [ "$ps_rc" -eq 0 ] && [ "$sh_out" = "$ps_out" ]; then
+        pass "$label: $tool version matches ($sh_out)"
+    else
+        fail "$label: sh rc=$sh_rc out='$sh_out'; ps1 rc=$ps_rc out='$ps_out'"
+    fi
+}
+
+assert_matching_missing_tool() {
+    local label="$1"
+    local tool="$2"
+    local sh_out=''
+    local sh_rc=0
+    local ps_out=''
+    local ps_rc=0
+
+    capture_sh "$tool"
+    sh_out="$CAPTURED_STDOUT"
+    sh_rc=$CAPTURED_RC
+
+    capture_ps "$tool"
+    ps_out="$CAPTURED_STDOUT"
+    ps_rc=$CAPTURED_RC
+
+    if [ "$sh_rc" -ne 0 ] && [ "$ps_rc" -ne 0 ] && [ -z "$sh_out" ] && [ -z "$ps_out" ]; then
+        pass "$label: missing tool returns empty stdout and non-zero on both platforms"
+    else
+        fail "$label: sh rc=$sh_rc out='$sh_out'; ps1 rc=$ps_rc out='$ps_out'"
+    fi
+}
+
+if [ ! -f "$SH_READER" ]; then
+    fail "bash reader not found: $SH_READER"
+fi
+
+if [ ! -f "$PS1_READER" ]; then
+    fail "PowerShell reader not found: $PS1_READER"
+fi
+
+if [ "$FAIL" -eq 0 ] && ! command -v pwsh >/dev/null 2>&1; then
+    skip "T4: pwsh is not available; skipping lib parity smoke test"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 0
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    assert_matching_version "T1" "nodejs"
+    assert_matching_version "T2" "nvm"
+    assert_matching_missing_tool "T3" "nonexistent-tool"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #425

- add `.squad/skills/parity-audit/SKILL.md` with the parity policy, scope, audit recipe, and invocation guidance
- add `tests/test_lib_parity.sh` to compare the bash and PowerShell tool-version readers for `nodejs`, `nvm`, and a missing tool case
- skip gracefully with a clear message when `pwsh` is unavailable
- append the Goofy learning note for future parity work

Validation:
- `bash tests/test_tool_versions.sh`
- `bash tests/test_lib_parity.sh`