### PR TITLE
fix(tests): make test_changelog_fold.ps1 tag-resolution self-contained (#430)

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -111,6 +111,7 @@ Issue #371: decisions.md hard gate policy review. decisions.md was 65,737 bytes,
 
 Cut release/0.9.7 from develop@792646e. Folded [Unreleased] to [0.9.7] - 2026-05-17 (3 Added, 3 Changed, 1 Fixed) covering #371 #381 #382 #383 #384 (Sprint 17: Hygiene gate restoration + label automation + skill formalization). PR #393: release/0.9.7 -> develop (squash). PR #394: develop -> main (regular merge, fe83af3). Tag 0.9.7 bare at f596202. GitHub release: https://github.com/primetimetank21/dev-setup/releases/tag/0.9.7.
 
-## Sprint 19 -- #414
+## Sprint 19 -- #414, #430
 
 2026-05-18: Squad-spawn helper + lint-spawn-prompt backstop (PR #420). Added scripts/squad-spawn.{ps1,sh} (auto-inject hygiene tail, idempotent, {name}/{N}/{worktree-path} substitution) and scripts/lint-spawn-prompt.{ps1,sh} (6-marker scan, exit 0/1). .squad/skills/spawn-prompt-lint/SKILL.md added (medium confidence). routing.md updated with helper/linter enforcement paths. 20 tests (4 files x 5 cases). Root-cause fix for Sprint 18 #406/#407 fixup pattern.
+2026-05-18: test_changelog_fold.ps1 CI fix (PR #431, #430). New-TestEnv now creates git sandbox with tag 0.9.7 for tag-resolution self-containment. Rejected fetch-tags in validate.yml -- hermetic test sandboxes preferred.

--- a/tests/test_changelog_fold.ps1
+++ b/tests/test_changelog_fold.ps1
@@ -15,7 +15,8 @@
 # Mocking strategy:
 #   Tests A-C create a stub gh script in a temp dir added to PATH.
 #   Test D relies on the idempotency check which runs BEFORE any gh calls.
-#   The repo must have tag 0.9.7 resolvable (used as --last-tag).
+#   New-TestEnv creates a git sandbox with tag 0.9.7 so tag resolution is
+#   self-contained for CI (no dependency on host repo tags).
 #
 # Usage:
 #   pwsh -File tests\test_changelog_fold.ps1
@@ -203,6 +204,23 @@ function New-TestEnv {
     # chmod +x so bash can execute it via PATH lookup
     $posixStub = ConvertTo-PosixPath $stubPath
     & $bashPath -c "chmod +x '$posixStub'"
+
+    # Initialize git repo with 0.9.7 tag for tag-resolution tests (Issue #430).
+    # changelog-fold.ps1 / changelog-fold.sh resolve --last-tag via git commands,
+    # so the test sandbox must have the tag present to be self-contained for CI.
+    Push-Location $dir
+    try {
+        & git init -q 2>&1 | Out-Null
+        & git config user.name "Test User" 2>&1 | Out-Null
+        & git config user.email "test@example.com" 2>&1 | Out-Null
+        "initial" | Out-File -FilePath "README.md" -Encoding ASCII -NoNewline
+        & git add README.md 2>&1 | Out-Null
+        & git commit -q -m "initial commit" 2>&1 | Out-Null
+        & git tag 0.9.7 HEAD 2>&1 | Out-Null
+    }
+    finally {
+        Pop-Location
+    }
 
     return $dir
 }


### PR DESCRIPTION
## Root Cause

Sprint 19 Wave 2 PR #426 wired 	ests/test_changelog_fold.ps1 into CI. All 3 test scenarios failed on Windows runner with:

\\\
[changelog-fold] resolving tag SHA for: 0.9.7 ...
[changelog-fold] ERROR: could not resolve tag: 0.9.7
\\\

**New-TestEnv** created a temp directory with stub \gh\ script but did **NOT** initialize git or create tag \