### PR TITLE
fix(tests): test_changelog_fold sandbox cwd regression

### DIFF
--- a/.squad/agents/mickey/history.md
+++ b/.squad/agents/mickey/history.md
@@ -115,3 +115,12 @@ Cut release/0.9.7 from develop@792646e. Folded [Unreleased] to [0.9.7] - 2026-05
 
 2026-05-18: Squad-spawn helper + lint-spawn-prompt backstop (PR #420). Added scripts/squad-spawn.{ps1,sh} (auto-inject hygiene tail, idempotent, {name}/{N}/{worktree-path} substitution) and scripts/lint-spawn-prompt.{ps1,sh} (6-marker scan, exit 0/1). .squad/skills/spawn-prompt-lint/SKILL.md added (medium confidence). routing.md updated with helper/linter enforcement paths. 20 tests (4 files x 5 cases). Root-cause fix for Sprint 18 #406/#407 fixup pattern.
 2026-05-18: test_changelog_fold.ps1 CI fix (PR #431, #430). New-TestEnv now creates git sandbox with tag 0.9.7 for tag-resolution self-containment. Rejected fetch-tags in validate.yml -- hermetic test sandboxes preferred.
+
+
+## 2026-05-18 03:09 (PR #433-fix, Issue #433)
+- **Outcome**: Fixed test_changelog_fold sandbox CWD regression
+- **Lesson**: Sandbox tests must run from a neutral CWD to reproduce CI's
+  stateless environment. Don't rely on host worktree's git state.
+  The cd '\' && prefix ensures bash inherits the sandbox's
+  git repo rather than whatever CWD the test runner happens to be in.
+- **Files**: tests/test_changelog_fold.ps1

--- a/.squad/skills/sandbox-cwd-isolation/SKILL.md
+++ b/.squad/skills/sandbox-cwd-isolation/SKILL.md
@@ -1,0 +1,72 @@
+# SKILL: sandbox-cwd-isolation
+
+**Confidence**: High  
+**First observed**: Issue #430 (PR #431)  
+**Confirmed again**: Issue #433  
+
+## Rule
+
+Always run test scripts from a **neutral CWD** (a directory that is NOT a git
+repo and does NOT have the tags/history your test sandbox creates) before
+pushing. Never consider a test fix complete based on a run inside the worktree.
+
+## When to invoke
+
+Invoke this check any time a test:
+- Shells out to `git` (e.g., `git rev-parse`, `git log`, `git tag`)
+- Creates a temporary git sandbox (`git init` + `git tag`)
+- Uses `bash -c` to invoke a script that internally calls `git`
+
+If any of the above apply, the "neutral CWD" smoke test is **mandatory** before
+pushing.
+
+## Recipe
+
+```powershell
+# 1. Create a fresh directory that is NOT inside any git repo
+$tmpCwd = "C:\Temp\test-isolated-$(Get-Random)"
+New-Item -ItemType Directory -Path $tmpCwd | Out-Null
+
+# 2. cd into it (so the test process CWD has no git history/tags)
+Set-Location $tmpCwd
+
+# 3. Run the test suite with an absolute path to the script
+pwsh -File "C:\path\to\worktree\tests\test_changelog_fold.ps1"
+
+# 4. MUST report: 5 passed, 0 failed
+# If any fail, the fix is incomplete -- iterate before pushing.
+
+# 5. Clean up
+Set-Location $WORKTREE_PATH
+Remove-Item $tmpCwd -Recurse -Force
+```
+
+## Why this matters
+
+When running tests from inside the worktree:
+- Git commands pick up the *host* repo's tags, history, and refs.
+- A sandbox `git init + git tag` may appear to work because the host repo
+  already has that tag in scope.
+- On CI (shallow clone, no host tags), the same test fails.
+
+The neutral-CWD run exactly replicates CI's stateless environment and will
+catch this class of state-leak bug before it reaches CI.
+
+## Anti-pattern to avoid
+
+```powershell
+# BAD: running test from inside the worktree
+Set-Location $WORKTREE_PATH
+pwsh -File tests\test_changelog_fold.ps1  # PASSES locally, FAILS on CI
+```
+
+```powershell
+# GOOD: running test from neutral CWD
+Set-Location C:\Temp\test-isolated-12345
+pwsh -File $WORKTREE_PATH\tests\test_changelog_fold.ps1  # catches CI bugs
+```
+
+## Related issues
+
+- #430: First occurrence -- `changelog-fold` tag resolution in CI
+- #433: Second occurrence -- same test, same error, different root cause layer

--- a/tests/test_changelog_fold.ps1
+++ b/tests/test_changelog_fold.ps1
@@ -246,6 +246,7 @@ Test-Scenario 'A: dry-run output present; CHANGELOG not modified' {
     $posixChangelog = ConvertTo-PosixPath $tmpChangelog
     try {
         $out = & $bashPath -c "
+cd '$posixEnvDir' &&
 export PATH='$posixEnvDir':`$PATH
 '$posixScript' \
     --release-version 0.9.99 \
@@ -293,6 +294,7 @@ Test-Scenario 'B: apply mode folds CHANGELOG.md correctly' {
     $posixChangelog = ConvertTo-PosixPath $tmpChangelog
     try {
         $out = & $bashPath -c "
+cd '$posixEnvDir' &&
 export PATH='$posixEnvDir':`$PATH
 '$posixScript' \
     --release-version 0.9.99 \
@@ -358,6 +360,7 @@ Test-Scenario 'C: missing entries reported to stderr' {
         $tmpErr     = Join-Path $env_dir 'stderr.txt'
         $posixErr   = ConvertTo-PosixPath $tmpErr
         & $bashPath -c "
+cd '$posixEnvDir' &&
 export PATH='$posixEnvDir':`$PATH
 '$posixScript' \
     --release-version 0.9.99 \
@@ -395,6 +398,7 @@ Test-Scenario 'D: idempotency gate exits 1 for already-folded version' {
     $posixChangelog = ConvertTo-PosixPath $tmpChangelog
     try {
         $out = & $bashPath -c "
+cd '$posixEnvDir' &&
 export PATH='$posixEnvDir':`$PATH
 '$posixScript' \
     --release-version 0.9.99 \


### PR DESCRIPTION
## Why PR #431 was insufficient

PR #431 (#430) added `git init + git tag 0.9.7 HEAD` in `New-TestEnv` to make the test sandbox self-contained. That was correct in principle, but the four bash invocations (Tests A-D) never `cd`'d into the sandbox directory first. So `changelog-fold.sh`'s `git rev-parse 0.9.7^{commit}` ran in whatever the PowerShell process CWD happened to be, NOT in the sandbox with the tag.

Locally the fix "worked" because the host worktree is a full clone and already has the `0.9.7` tag visible to any git command. On CI's shallow checkout there are no tags in scope -> same error as before.

## Root cause

`
bash -c "'' --last-tag 0.9.7 ..."
         ^--- runs git in CALLER's CWD, not sandbox
`

## Fix

Prepend `cd '\' &&` to every bash `-c` string:

`
bash -c "cd '\' && export PATH=... && '\' ..."
          ^--- git now resolves against the sandbox repo with 0.9.7 tag
`

## Neutral-CWD verification (the missed step from #431)

Ran from `C:\Temp\test-isolated-<N>` (NOT a git repo):

`
Results: 5 passed, 0 failed, 0 skipped
`

This exactly replicates CI's stateless environment and is the step that was skipped before #431 was pushed.

## Files changed

- `tests/test_changelog_fold.ps1` -- prepend `cd` in Tests A, B, C, D
- `.squad/agents/mickey/history.md` -- history entry
- `.squad/skills/sandbox-cwd-isolation/SKILL.md` -- new skill (2nd occurrence)

Closes #433