### PR TITLE
fix(copilot-cli): prevent hang in Codespace environments

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -54,6 +54,9 @@ Implemented Linux/macOS tool installer scripts and cross-platform CLI tooling:
 - `script(1)` PTY is right tool for isatty-gated CLIs but not when parent pipe may close early (e.g., container lifecycle hooks)
 - Directory existence check for Copilot binary: `~/.local/share/gh/copilot` (not exit code probe)
 - sed -i 's/\r//' chosen over dos2unix for POSIX portability
+- `timeout 10 <cmd>` is the correct guard for any version-probe that might hit a network-dependent binary in Codespace; treat non-zero exit / timeout as unknown version, not an error
+- In Codespaces, always check `gh copilot --version` (via timeout) before falling through to `npm install -g` -- the gh extension already provides copilot capability, and the npm postinstall can deadlock without a TTY
+- `CI=true` + `--no-fund --no-audit` is the minimum npm non-interactive guard; mirrors the `is_non_interactive()` pattern already in `auth.sh`
 
 ---
 > Compressed 2026-05-18 (Jiminy S17 audit): pre-Sprint-12 entries archived to history-archive.md.

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -18,10 +18,10 @@ COPILOT_CLI_VERSION="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" copilot
 
 log_info "Pinned copilot-cli version: ${COPILOT_CLI_VERSION}"
 
-# Detect installed version; command may emit warnings to stderr before the semver
+# Detect installed version; use timeout to prevent a network-dependent binary from hanging
 INSTALLED_VERSION=""
 if command -v copilot &>/dev/null; then
-  INSTALLED_VERSION="$(copilot --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  INSTALLED_VERSION="$(timeout 10 copilot --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
 fi
 
 if [ "${INSTALLED_VERSION}" = "${COPILOT_CLI_VERSION}" ]; then
@@ -40,5 +40,19 @@ if ! command -v npm &>/dev/null; then
   exit 0
 fi
 
-npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
+# In a Codespace, gh copilot extension already provides copilot capability -- skip npm install
+if [[ "${CODESPACES:-}" == "true" ]] && timeout 10 gh copilot --version &>/dev/null 2>&1; then
+  log_ok "Codespace detected with gh copilot extension -- skipping npm install"
+  exit 0
+fi
+
+# Suppress interactive postinstall prompts in non-interactive / CI environments
+is_non_interactive() {
+  [[ "${CI:-}" == "true" ]] || [[ "${CODESPACES:-}" == "true" ]] || ! [[ -t 0 && -t 1 ]]
+}
+if is_non_interactive; then
+  export CI=true
+fi
+
+npm install -g --no-fund --no-audit "@github/copilot@${COPILOT_CLI_VERSION}"
 log_ok "GitHub Copilot CLI installed at ${COPILOT_CLI_VERSION}"


### PR DESCRIPTION
Fixes setup.sh stalling during copilot-cli install in GitHub Codespaces.

## Root cause
- `copilot --version` can hang if the binary requires network/auth
- `npm install -g` postinstall scripts can block without CI=true in non-interactive environments

## Fix
- Add `timeout 10` to version detection
- Detect Codespace / non-interactive env; set CI=true + --no-fund --no-audit for npm
- Skip npm install entirely when running in a Codespace that already has `gh copilot`

Requested by Earl.