### PR TITLE
fix(tools): source nvm in npm-dependent scripts

### DIFF
--- a/.squad/agents/donald/history.md
+++ b/.squad/agents/donald/history.md
@@ -57,6 +57,7 @@ Implemented Linux/macOS tool installer scripts and cross-platform CLI tooling:
 - `timeout 10 <cmd>` is the correct guard for any version-probe that might hit a network-dependent binary in Codespace; treat non-zero exit / timeout as unknown version, not an error
 - In Codespaces, always check `gh copilot --version` (via timeout) before falling through to `npm install -g` -- the gh extension already provides copilot capability, and the npm postinstall can deadlock without a TTY
 - `CI=true` + `--no-fund --no-audit` is the minimum npm non-interactive guard; mirrors the `is_non_interactive()` pattern already in `auth.sh`
+- Any npm-dependent tool script that runs under `setup.sh` must source `~/.nvm/nvm.sh` in its own process and `nvm use default` before `command -v npm`; sibling `bash "${tool_script}"` subprocesses do not inherit nvm PATH changes from `nvm.sh`
 
 ---
 > Compressed 2026-05-18 (Jiminy S17 audit): pre-Sprint-12 entries archived to history-archive.md.

--- a/.squad/decisions/inbox/donald-nvm-path-subshell-fix.md
+++ b/.squad/decisions/inbox/donald-nvm-path-subshell-fix.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-26  
 **Author:** Donald (Copilot)  
-**PR:** pending  
+**PR:** #436  
 **Branch:** squad/fix-npm-path-nvm-subshell
 
 ## Decision

--- a/.squad/decisions/inbox/donald-nvm-path-subshell-fix.md
+++ b/.squad/decisions/inbox/donald-nvm-path-subshell-fix.md
@@ -1,0 +1,37 @@
+# Decision: source nvm inside npm-dependent tool scripts
+
+**Date:** 2026-05-26  
+**Author:** Donald (Copilot)  
+**PR:** pending  
+**Branch:** squad/fix-npm-path-nvm-subshell
+
+## Decision
+
+Added the standard non-interactive nvm bootstrap block to both `scripts/linux/tools/copilot-cli.sh` and `scripts/linux/tools/squad-cli.sh` immediately after `log.sh` is sourced:
+
+```bash
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh" --no-use
+  nvm use default 2>/dev/null || true
+fi
+```
+
+Also changed `scripts/linux/tools/squad-cli.sh` so a missing `npm` is treated as a skip-with-warning, not a hard failure:
+
+- logs `WARN`
+- exits `0`
+- tells the operator which pinned `npm install -g` command to run manually later
+
+## Rationale
+
+`setup.sh` launches each tool via `bash "${tool_script}"`, so every installer runs in its own subshell. That means the PATH mutation performed by `nvm.sh` dies with the `nvm.sh` process and is not visible to later siblings like `copilot-cli.sh` or `squad-cli.sh` unless they source `nvm.sh` again themselves.
+
+The graceful `squad-cli.sh` fallback keeps setup idempotent and consistent with `copilot-cli.sh`: if Node is still unavailable, setup should warn and continue rather than fail the whole run.
+
+## Validation
+
+- `shellcheck scripts/linux/tools/copilot-cli.sh scripts/linux/tools/squad-cli.sh tests/test_nvm_bootstrap.sh`
+- `bash tests/test_nvm_bootstrap.sh`
+- `bash tests/test_tool_versions.sh`
+- Functional subshell verification with a fake `nvm.sh` confirmed both installers find `npm` only after sourcing nvm, and `squad-cli.sh` warns/returns success when npm remains unavailable.

--- a/scripts/linux/tools/copilot-cli.sh
+++ b/scripts/linux/tools/copilot-cli.sh
@@ -13,6 +13,14 @@ set -euo pipefail
 # shellcheck disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/log.sh"
 
+# Source nvm if available, to get node/npm on PATH in this subshell.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck source=/dev/null
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh" --no-use
+  nvm use default 2>/dev/null || true
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COPILOT_CLI_VERSION="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" copilot-cli)"
 

--- a/scripts/linux/tools/squad-cli.sh
+++ b/scripts/linux/tools/squad-cli.sh
@@ -10,6 +10,14 @@ set -euo pipefail
 # shellcheck disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/log.sh"
 
+# Source nvm if available, to get node/npm on PATH in this subshell.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck source=/dev/null
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh" --no-use
+  nvm use default 2>/dev/null || true
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQUAD_CLI_VERSION="$(sh "${SCRIPT_DIR}/../../lib/read-tool-version.sh" squad-cli)"
 
@@ -31,11 +39,8 @@ else
 fi
 
 if ! command -v npm &>/dev/null; then
-  log_error "npm not found after nvm install. Possible causes:"
-  log_error "  1. PATH refresh failed -- close this terminal and open a new one, then re-run setup"
-  log_error "  2. nvm install failed silently -- check 'nvm list' and try 'nvm install <version>' manually"
-  log_error "  3. Node is installed elsewhere but not on PATH"
-  exit 1
+  log_warn "npm not found -- cannot install squad-cli; run 'npm install -g @bradygaster/squad-cli@${SQUAD_CLI_VERSION}' once Node is available"
+  exit 0
 fi
 
 npm install -g "@bradygaster/squad-cli@${SQUAD_CLI_VERSION}"

--- a/tests/test_nvm_bootstrap.sh
+++ b/tests/test_nvm_bootstrap.sh
@@ -4,7 +4,8 @@
 # Checks:
 #   1. nvm.sh sources nvm correctly (uses \. not just source)
 #   2. nvm.sh reads pinned Node version from .tool-versions
-#   3. squad-cli.sh emits ERROR (not WARN) when npm is missing
+#   3. npm-dependent installers source nvm in their own subshells
+#   4. squad-cli.sh degrades gracefully when npm is missing
 
 set -euo pipefail
 
@@ -42,57 +43,72 @@ else
   fail "nvm.sh still uses --lts or does not use PINNED_NODE variable"
 fi
 
-# --- squad-cli.sh tests ---
+# --- npm-dependent installer bootstrap tests ---
 
 SQUAD_SCRIPT="${REPO_ROOT}/scripts/linux/tools/squad-cli.sh"
+COPILOT_SCRIPT="${REPO_ROOT}/scripts/linux/tools/copilot-cli.sh"
 
-# T4: squad-cli.sh uses ERROR not WARN for npm missing
-if grep -q '\[ERROR\].*npm not found' "$SQUAD_SCRIPT" && ! grep -q '\[WARN\].*npm not found' "$SQUAD_SCRIPT"; then
-  pass "squad-cli.sh emits ERROR (not WARN) when npm missing"
+# T4: copilot-cli.sh sources nvm in-script before npm checks
+# shellcheck disable=SC2016
+if grep -q '\. "\$NVM_DIR/nvm.sh" --no-use' "$COPILOT_SCRIPT" && grep -q 'nvm use default 2>/dev/null || true' "$COPILOT_SCRIPT"; then
+  pass "copilot-cli.sh sources nvm and activates default alias in-script"
 else
-  fail "squad-cli.sh still uses WARN or missing ERROR for npm-not-found"
+  fail "copilot-cli.sh does not source nvm/default alias before npm checks"
 fi
 
-# T5: squad-cli.sh exits non-zero when npm missing
-if grep -q 'exit 1' "$SQUAD_SCRIPT"; then
-  pass "squad-cli.sh exits non-zero when npm missing"
+# T5: squad-cli.sh sources nvm in-script before npm checks
+# shellcheck disable=SC2016
+if grep -q '\. "\$NVM_DIR/nvm.sh" --no-use' "$SQUAD_SCRIPT" && grep -q 'nvm use default 2>/dev/null || true' "$SQUAD_SCRIPT"; then
+  pass "squad-cli.sh sources nvm and activates default alias in-script"
 else
-  fail "squad-cli.sh does not exit non-zero"
+  fail "squad-cli.sh does not source nvm/default alias before npm checks"
+fi
+
+# T6: squad-cli.sh warns (not errors) when npm missing
+if grep -q 'log_warn "npm not found -- cannot install squad-cli' "$SQUAD_SCRIPT" && ! grep -q 'log_error ".*npm not found' "$SQUAD_SCRIPT"; then
+  pass "squad-cli.sh warns when npm missing"
+else
+  fail "squad-cli.sh does not warn cleanly when npm is missing"
+fi
+
+# T7: squad-cli.sh exits zero when npm missing
+if grep -q 'exit 0' "$SQUAD_SCRIPT" && ! grep -q 'exit 1' "$SQUAD_SCRIPT"; then
+  pass "squad-cli.sh exits zero when npm missing"
+else
+  fail "squad-cli.sh does not exit zero when npm is missing"
 fi
 
 # --- version-pin enforcement tests ---
 
-# T6: squad-cli.sh reads pinned version from .tool-versions
+# T8: squad-cli.sh reads pinned version from .tool-versions
 if grep -q 'read-tool-version.sh.*squad-cli' "$SQUAD_SCRIPT"; then
   pass "squad-cli.sh reads squad-cli version from .tool-versions"
 else
   fail "squad-cli.sh does not read squad-cli version from .tool-versions"
 fi
 
-# T7: squad-cli.sh installs pinned version via npm (not bare latest)
+# T9: squad-cli.sh installs pinned version via npm (not bare latest)
 if grep -q 'npm install.*SQUAD_CLI_VERSION' "$SQUAD_SCRIPT"; then
   pass "squad-cli.sh installs pinned version via npm"
 else
   fail "squad-cli.sh does not pass pinned version to npm install"
 fi
 
-COPILOT_SCRIPT="${REPO_ROOT}/scripts/linux/tools/copilot-cli.sh"
-
-# T8: copilot-cli.sh reads pinned version from .tool-versions
+# T10: copilot-cli.sh reads pinned version from .tool-versions
 if grep -q 'read-tool-version.sh.*copilot-cli' "$COPILOT_SCRIPT"; then
   pass "copilot-cli.sh reads copilot-cli version from .tool-versions"
 else
   fail "copilot-cli.sh does not read copilot-cli version from .tool-versions"
 fi
 
-# T9: copilot-cli.sh performs version-aware check (not bare binary-exists guard)
+# T11: copilot-cli.sh performs version-aware check (not bare binary-exists guard)
 if grep -q 'INSTALLED_VERSION' "$COPILOT_SCRIPT" && grep -q 'COPILOT_CLI_VERSION' "$COPILOT_SCRIPT"; then
   pass "copilot-cli.sh performs version-aware idempotency check"
 else
   fail "copilot-cli.sh still uses bare binary-exists guard (no version comparison)"
 fi
 
-# T10: squad-cli.sh installs from the correct npm package (#255)
+# T12: squad-cli.sh installs from the correct npm package (#255)
 # Root cause investigation: 'session persistence may fail' warning was reported
 # in e2e runs. Confirmed it originates in @github/copilot-sdk (a transitive dep
 # of @bradygaster/squad-cli). Verified absent in 0.9.4. This test ensures the
@@ -103,7 +119,7 @@ else
   fail "squad-cli.sh does not install @bradygaster/squad-cli"
 fi
 
-# T11: squad-cli.sh already-installed check captures stderr with 2>&1 (#255)
+# T13: squad-cli.sh already-installed check captures stderr with 2>&1 (#255)
 # When squad --version is run, any 'session persistence may fail' warning
 # emitted to stderr must appear in the installer log so it is visible in CI.
 # The already-installed branch uses: squad --version 2>&1


### PR DESCRIPTION
## Summary
- source nvm inside copilot-cli.sh and squad-cli.sh so npm is available in each setup.sh subshell
- make squad-cli.sh warn and exit 0 when npm is still unavailable, matching copilot-cli.sh
- update bootstrap coverage and record the decision/history note

## Validation
- shellcheck scripts/linux/tools/copilot-cli.sh scripts/linux/tools/squad-cli.sh tests/test_nvm_bootstrap.sh
- bash tests/test_nvm_bootstrap.sh
- bash tests/test_tool_versions.sh
- functional fake-nvm verification for subshell PATH propagation and npm-missing fallback