### PR TITLE
feat(scripts): add sprint-end-labels.ps1 PowerShell parity

### DIFF
--- a/tests/test_sprint_end_labels_pwsh.ps1
+++ b/tests/test_sprint_end_labels_pwsh.ps1
@@ -311,7 +311,7 @@ set -e
 DIR=`$(CDPATH= cd -- "`$(dirname -- "`$0")" && pwd)
 exec "$PowerShellPath" -NoProfile -ExecutionPolicy Bypass -File "`$DIR/gh.ps1" "`$@"
 "@
-    Write-AsciiFile -Path $launcherPath -Content $launcher
+    Write-AsciiFile -Path $launcherPath -Content ($launcher.Replace("`r", ''))
 
     $cmdPath = Join-Path $dir 'gh.cmd'
     $cmdContent = "@echo off`r`n`"$PowerShellPath`" -NoProfile -ExecutionPolicy Bypass -File `"%~dp0gh.ps1`" %*`r`n"


### PR DESCRIPTION
Closes #423

## Summary
- add scripts/sprint-end-labels.ps1 with bash-parity flags, idempotent label transitions, and verify-with-retry reads
- add PowerShell parity coverage in tests/test_sprint_end_labels_pwsh.ps1
- keep bash coverage intact and harden tests/test_sprint_end_labels.ps1 for pwsh-on-Linux driver generation

## Validation
- shellcheck scripts/sprint-end-labels.sh
- .test-tmp/pwsh-7.6.2/pwsh -NoProfile -File tests/test_sprint_end_labels_pwsh.ps1
- .test-tmp/pwsh-7.6.2/pwsh -NoProfile -File tests/test_sprint_end_labels.ps1