### PR TITLE
docs: document gosquad alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gosquad` alias - launches GitHub Copilot CLI with the Squad agent (`copilot --agent squad --yolo`), available on bash/zsh and Windows PowerShell.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ After running setup, you get shortcuts for common git, dev, and utility commands
 
 **GitHub CLI:** `ghpr`, `ghprl`, `ghprv`, `ghis`, `ghiv`
 
-**Dev tools:** `uvr`, `uvs`, `ni`, `nr`, `nrd`, `nrt`, `py`, `c`
+**Dev tools:** `uvr`, `uvs`, `ni`, `nr`, `nrd`, `nrt`, `py`, `c`, `gosquad`
 
 **Utility:** `myip`, `pb`, `h`, `ep`
 

--- a/config/dotfiles/README.md
+++ b/config/dotfiles/README.md
@@ -81,6 +81,12 @@ remain in `$HOME/.gitconfig` -- just edit the file manually.
 | `git undo` | `git reset --soft HEAD~1` |
 | `git unstage` | `git restore --staged` |
 
+**Shell Aliases:**
+
+| Alias | Expands to |
+|-------|-----------|
+| `gosquad` | `copilot --agent squad --yolo` |
+
 ---
 
 ### `.editorconfig`


### PR DESCRIPTION
Documents the gosquad alias added in PR #472 (commit f908f96).

The alias runs 'copilot --agent squad --yolo' and is available on both bash/zsh and Windows PowerShell.

Updated:
- README.md: added gosquad to Dev tools list
- config/dotfiles/README.md: added Shell Aliases section with gosquad entry
- CHANGELOG.md: added entry to [Unreleased] Added section