### PR TITLE
docs: de-squad PR template (#477)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,15 +18,7 @@
 
 ## Hygiene checklist
 
-<!-- Before submitting, verify all items below. Unchecked items may be flagged by Jiminy (hygiene auditor). -->
-
-- [ ] Updated `.squad/agents/{name}/history.md` with a Learnings entry
-- [ ] Decisions inbox drained (or noted N/A for this PR)
-- [ ] Skill captured for any new pattern (or noted N/A)
 - [ ] ASCII-only in all `.ps1` / `test_windows_setup.ps1` / `.yml` files (no em dashes, curly quotes, smart apostrophes -- they break PS 5.1 CP1252 parsing)
 - [ ] Conventional Commits format on all commits
 - [ ] Co-authored-by: Copilot trailer on all commits
-- [ ] Branch forked from develop (not from another `squad/*` branch -- prevents ancestry bleed)
-- [ ] No rogue files outside the canonical `.squad/` paths (`agents/{name}/charter.md|history.md`, `decisions.md`, `decisions/inbox/*.md`, `orchestration-log/*.md`, `log/*.md`, `skills/{name}/SKILL.md`, `templates/*.md`, `casting/*.json`, `identity/*.md`, `plugins/*.json`, `team.md|routing.md|ceremonies.md|config.json`)
-
-<!-- Tip: Jiminy auto-runs before coordinator returns control. Catching hygiene issues before submit saves a round-trip. -->
+- [ ] Branch forked from develop


### PR DESCRIPTION
## Summary
De-squad the PR template per issue #477. Removes all squad-specific checklist items and Jiminy references, leaving a clean generic contributor template.

## Removed (squad-specific)
- Updated .squad/agents/{name}/history.md with a Learnings entry
- Decisions inbox drained (or noted N/A for this PR)
- Skill captured for any new pattern (or noted N/A)
- squad/* branch ancestry clause
- No rogue files outside .squad/ paths (entire long item)
- HTML comments mentioning Jiminy (hygiene auditor)

## Kept (genuine repo conventions)
- ASCII-only in .ps1 files (PS 5.1 CP1252 trap)
- Conventional Commits format
- Co-authored-by: Copilot trailer
- Branch forked from develop

Closes #477.