### PR TITLE
docs: add docs/plans convention doc (#Phase2 WI-1)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -30,7 +30,7 @@ a prior one.
 | Status      | Meaning                                          |
 |-------------|--------------------------------------------------|
 | draft       | In progress; not ready for implementation        |
-| ready       | Grill-passed or otherwise approved; ready impl   |
+| ready       | Approved; ready to implement                     |
 | in-progress | Implementation underway (PR open)                |
 | implemented | Shipped to develop; doc kept for reference       |
 | superseded  | Replaced by another plan doc (note supersedes)   |
@@ -56,9 +56,9 @@ or attached binary assets.
 
 ---
 
-## Grill / Review History
+## Review History
 
-Do NOT commit grill-panel review changelogs to plan docs. The HQ coordinator maintains
+Do NOT commit review-panel changelogs to plan docs. The HQ coordinator maintains
 review history externally. Plan docs contain only the living spec; revision history is
 captured in git log and front-matter `updated` field.
 
@@ -75,7 +75,7 @@ captured in git log and front-matter `updated` field.
 
 ## What Does NOT Belong Here
 
-- Review panel names, cast names, or griller attributions
+- Reviewer names, cast names, or review attributions
 - Version changelog blocks (vN Changes sections)
 - Process notes (merge decisions, admin notes, coordinator instructions)
 - Implementation progress updates (use the GitHub issue for that)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,81 @@
+# docs/plans -- Plan Document Convention
+
+This folder contains per-issue vertical slice plans for primetimetank21/dev-setup. Plans are
+the pre-implementation spec; they capture scope decisions, design decisions, and acceptance
+criteria for a given issue before code is written.
+
+---
+
+## Front-Matter Schema
+
+Every plan doc must begin with a YAML front-matter block:
+
+```yaml
+---
+issue: <GitHub issue number, integer>
+title: "Short human-readable title"
+status: <see Status Vocabulary below>
+created: <ISO date, YYYY-MM-DD>
+updated: <ISO date, YYYY-MM-DD>
+---
+```
+
+No other fields are required. `supersedes: <issue>` is optional when a plan replaces
+a prior one.
+
+---
+
+## Status Vocabulary
+
+| Status      | Meaning                                          |
+|-------------|--------------------------------------------------|
+| draft       | In progress; not ready for implementation        |
+| ready       | Grill-passed or otherwise approved; ready impl   |
+| in-progress | Implementation underway (PR open)                |
+| implemented | Shipped to develop; doc kept for reference       |
+| superseded  | Replaced by another plan doc (note supersedes)   |
+
+---
+
+## File Naming
+
+```
+NNN-slug.md
+```
+
+Where NNN is the GitHub issue number (zero-padded to 3 digits) and slug is a short
+kebab-case descriptor. Example: 468-customizable-install.md
+
+---
+
+## Layout
+
+Flat files in docs/plans/. No per-feature subfolders unless a plan accumulates
+supplementary assets (diagrams, data tables) that cannot live inline. Threshold: >10 plans
+or attached binary assets.
+
+---
+
+## Grill / Review History
+
+Do NOT commit grill-panel review changelogs to plan docs. The HQ coordinator maintains
+review history externally. Plan docs contain only the living spec; revision history is
+captured in git log and front-matter `updated` field.
+
+---
+
+## What Belongs Here
+
+- Problem statement
+- Scope (IN / OUT)
+- Design decisions (with rationale)
+- Algorithm / data structures / pseudocode as needed
+- Test plan / acceptance criteria
+- Out-of-scope items (tracked issues)
+
+## What Does NOT Belong Here
+
+- Review panel names, cast names, or griller attributions
+- Version changelog blocks (vN Changes sections)
+- Process notes (merge decisions, admin notes, coordinator instructions)
+- Implementation progress updates (use the GitHub issue for that)


### PR DESCRIPTION
Implements WI-1 of the approved Phase 2 docs-alignment plan.

This PR adds the canonical convention doc for all future plan documents in docs/plans/.
It defines:

- YAML front-matter schema (issue, title, status, created, updated) with locked status
  vocabulary (draft, ready, in-progress, implemented, superseded)
- File-naming convention (NNN-slug.md)
- Flat-layout rationale
- Grill-history policy (no review changelogs; git log + front-matter `updated` sufficient)
- What belongs / what does NOT belong lists (no cast names, no version changelogs, no
  process notes)

This doc is the reference for WI-2 (front-matter normalization) and WI-3 (grill-changelog
scrub).

**Verification:**
- 1 new file: docs/plans/README.md (81 lines)
- ASCII-clean: 0 non-ASCII bytes
- Additive only; no other changes
- Draft PR status pending review
