### PR TITLE
docs: add YAML front-matter to docs/plans (#Phase2 WI-2)

### DIFF
--- a/docs/plans/441-profile-path.md
+++ b/docs/plans/441-profile-path.md
@@ -1,12 +1,12 @@
-# Fix Plan: #441 -- profile.ps1 writes to wrong path on OneDrive/KFM systems
-
-**Author:** Contributor
-**Date:** 2026-05-27
-**Issue:** https://github.com/primetimetank21/dev-setup/issues/441
-**Branch:** fix/441-profile-path
-**Status:** v5.2
-
 ---
+issue: 441
+title: "Profile path fix on OneDrive/KFM systems"
+status: implemented
+created: 2026-05-27
+updated: 2026-06-13
+---
+
+# Plan: #441 -- Profile path fix on OneDrive/KFM systems
 
 ## v5 Changes (revision 5)
 

--- a/docs/plans/451-pwsh-parity-gaps.md
+++ b/docs/plans/451-pwsh-parity-gaps.md
@@ -1,12 +1,12 @@
-# Plan: #451 Vertical Slice -- PowerShell Parity Gaps
-
-**Date:** 2026-05-28T02:56:01-04:00  
-**Revised:** 2026-05-27T23:47:00-04:00  
-**Author:** Contributor
-**Issue:** #451  
-**Status:** v3
-
 ---
+issue: 451
+title: "PowerShell parity gaps (vertical slice)"
+status: ready
+created: 2026-05-28
+updated: 2026-06-13
+---
+
+# Plan: #451 -- PowerShell parity gaps (vertical slice)
 
 ## Summary
 

--- a/docs/plans/468-customizable-install.md
+++ b/docs/plans/468-customizable-install.md
@@ -1,11 +1,12 @@
-# Plan: #468 Customizable Install (Pick-and-Choose Tools)
-
-**Date:** 2026-05-30
-**Author:** Contributor (v14)
-**Issue:** #468
-**Status:** Ready for review
-
 ---
+issue: 468
+title: "Customizable install (pick-and-choose tools)"
+status: ready
+created: 2026-05-30
+updated: 2026-06-13
+---
+
+# Plan: #468 -- Customizable install (pick-and-choose tools)
 
 ## v14 Changelog (revision 14, 2026-05-30)
 


### PR DESCRIPTION
Implements WI-2 of Phase 2 plan: add YAML front-matter and normalize headers.

**Docs modified:**
- docs/plans/441-profile-path.md (status: implemented)
- docs/plans/451-pwsh-parity-gaps.md (status: ready)
- docs/plans/468-customizable-install.md (status: ready)

**Changes:**
- Prepended YAML front-matter block (issue, title, status, created, updated)
- Normalized H1 headers to `# Plan: #NNN -- <Title>` form
- Removed redundant inline metadata lines (Author, Date, Revised, Issue, Branch, Status)

**Out of scope:** grill/vN changelog sections, body prose, cast-name annotations, Revision History, squad-cli references (deferred to WI-3).

All files ASCII-clean.
