### PR TITLE
docs(plans): strip stale squad-cli content from #468 plan (WI-0)

### DIFF
--- a/docs/plans/468-customizable-install.md
+++ b/docs/plans/468-customizable-install.md
@@ -3,7 +3,7 @@ issue: 468
 title: "Customizable install (pick-and-choose tools)"
 status: ready
 created: 2026-05-30
-updated: 2026-06-13
+updated: 2026-06-19
 ---
 
 # Plan: #468 -- Customizable install (pick-and-choose tools)
@@ -123,8 +123,6 @@ Manifest and prompt are explicitly out of scope -- they can layer on top later.
 
 ### Default Order (Linux)
 
-> **NOTE:** squad-cli entries below are stale pending #468 implementation.
-
 ```bash
 DEFAULT_TOOLS=(
   "prereqs"
@@ -134,7 +132,6 @@ DEFAULT_TOOLS=(
   "gh"
   "auth"
   "copilot-cli"
-  "squad-cli"
   "dotfiles"
   "git-hook"
 )
@@ -153,7 +150,6 @@ $DefaultTools = @(
   'vim'
   'psmux'
   'copilot'
-  'squad-cli'
   'dotfiles'
   'profile'
   'git-hook'
@@ -210,7 +206,6 @@ $ToolRegistry = [ordered]@{
     'vim'       = { Install-Vim }
     'psmux'     = { Install-Psmux }
     'copilot'   = { Install-CopilotCli }
-    'squad-cli' = { Install-SquadCli }
     'dotfiles'  = { Install-Dotfiles }
     'profile'   = { Write-PowerShellProfile }
     'git-hook'  = { Install-GitHook }
@@ -492,12 +487,11 @@ nvm
 gh
 auth
 copilot-cli
-squad-cli
 dotfiles
 git-hook
 ```
 
-Linux maps to `install_prerequisites` first, then the seven `run_tool` calls, then the dotfiles block, then git-hook config in `main`.
+Linux maps to `install_prerequisites` first, then the six `run_tool` calls, then the dotfiles block, then git-hook config in `main`.
 
 **Current Windows order** (from `scripts/windows/setup.ps1` `Main` execution):
 ```
@@ -510,7 +504,6 @@ auth
 vim
 psmux
 copilot
-squad-cli
 dotfiles
 profile
 git-hook
@@ -643,23 +636,17 @@ param(
 ### Graceful Degradation
 
 Tools are NOT fully independent. Known chains:
-- `copilot-cli` / `squad-cli` npm-absent behavior **differs by tool and platform** (Verified):
+- `copilot-cli` npm-absent behavior (Verified):
+  - Linux: `log_warn` + `exit 0` -- warning, silent skip; run continues
+  - Windows: `Write-Warn` + `return` -- warning, non-hard-stop; run continues
 
-  | Tool | Linux | Windows |
-  |------|-------|---------|
-  | `copilot-cli` | `log_warn` + `exit 0` -- warning, silent skip; run continues | `Write-Warn` + `return` -- warning, non-hard-stop; run continues |
-  | `squad-cli` | `log_warn` + `exit 0` -- warning, silent skip; run continues | `Write-Err` + `exit 1` -- hard stop with PATH/nvm diagnostics |
-
-  Sources: `scripts/linux/tools/copilot-cli.sh:46-49`, `scripts/linux/tools/squad-cli.sh:41-43`,
-  `scripts/windows/tools/copilot.ps1:47-50`, `scripts/windows/tools/squad-cli.ps1:37-43`.
+  Sources: `scripts/linux/tools/copilot-cli.sh:46-49`, `scripts/windows/tools/copilot.ps1:47-50`.
 
 - `auth` silently skips if `gh` not installed
 
 **npm-absent examples (fresh machine without Node):**
 - `--only=copilot-cli` Linux: `exit 0`, tool non-functional until Node available.
 - `-Only 'copilot'` Windows: `return` (non-hard-stop), tool non-functional until Node available.
-- `--only=squad-cli` Linux: `exit 0`, tool non-functional until Node available.
-- `-Only 'squad-cli'` Windows: `exit 1` (hard stop) -- actionable error guides PATH refresh / nvm troubleshooting.
 
 Documented behavior. Future DAG (out of scope) could warn.
 


### PR DESCRIPTION
# WI-0: Strip stale squad-cli content from #468 plan

**Issue:** #468 (Customizable install)

## What

Resolved D4 decision: stripped all 11 squad-cli references from the #468 customizable-install plan document. This work item is the first (WI-0) in the FLAGS-FIRST implementation series.

## Why

The dev-setup repository fully de-squadded squad-cli in PR #475 (2026-06-11). The #468 plan document, created before that de-squad, still contained squad-cli as a live tool in multiple places. These stale references would dangerously seed squad-cli into the default-run tool registry with NO installer, violating the plan's own coherence invariants.

This doc-only PR strips the moot content before WI-1 (the framework implementation) ships, ensuring the plan reflects the current post-#475 reality.

## Changes

Removed 11 squad-cli references:
- R5 NOTE banner (line 126)
- squad-cli entries in Linux DEFAULT_TOOLS array (line 137)
- squad-cli entries in Windows $DefaultTools array (line 156)
- squad-cli entry in Windows $ToolRegistry (line 213)
- squad-cli entries in current order listings (lines 495, 513)
- squad-cli rows in graceful-degradation comparison table (lines 646-654, 661-662)

Also:
- Updated prose count: "seven run_tool calls" -> "six run_tool calls" (Linux, to reflect post-removal state)
- Updated front-matter `updated` field to 2026-06-19

## Backward-Compat Impact

None. This is a pure documentation cleanup. No functional code, no tool behavior changes. The file is now coherent with the post-#475 toolset.

## Testing

- Verified ASCII purity (dev-setup pre-commit ASCII gate enforces no em-dash/smart-quotes)
- Verified all squad-cli references removed: `git grep -i squad-cli` returns empty
- Verified file coherence: order arrays, registry, and prose all consistent

## Deployment

Doc-only. No build, no deployment steps. This PR can merge anytime after review.

---

**Next:** WI-1 (Flags-first framework) will build the core engine for `--list`, `--only=`, `--skip=`, `--help` and the backward-compat gate. Part of FLAGS-FIRST #468 implementation phase.
